### PR TITLE
feat(compiler): ✨ add indentation-aware lexer for Dao

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build
         run: cmake --build build/debug
 
+      - name: Run tests
+        run: ctest --test-dir build/debug --output-on-failure
+
       - name: Verify daoc runs
         run: ./build/debug/compiler/driver/daoc examples/hello.dao
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+enable_testing()
+
+add_subdirectory(compiler/frontend)
 add_subdirectory(compiler/driver)

--- a/compiler/driver/CMakeLists.txt
+++ b/compiler/driver/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_executable(daoc main.cpp)
+target_link_libraries(daoc PRIVATE dao_frontend)

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -1,29 +1,80 @@
+#include "frontend/lexer/lexer.h"
+
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
+
+namespace {
+
+auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  if (!file) {
+    std::cerr << "error: could not open: " << path << "\n";
+    std::exit(EXIT_FAILURE);
+  }
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+void cmd_lex(const std::filesystem::path& path) {
+  auto contents = read_file(path);
+  dao::SourceBuffer source(path.filename().string(), std::move(contents));
+  auto result = dao::lex(source);
+
+  for (const auto& tok : result.tokens) {
+    auto loc = source.line_col(tok.span.offset);
+    std::cout << loc.line << ":" << loc.col << " " << dao::token_kind_name(tok.kind);
+    if (!tok.text.empty() && tok.kind != dao::TokenKind::Newline &&
+        tok.kind != dao::TokenKind::Eof) {
+      std::cout << " \"" << tok.text << "\"";
+    }
+    std::cout << "\n";
+  }
+
+  if (!result.diagnostics.empty()) {
+    for (const auto& diag : result.diagnostics) {
+      auto loc = source.line_col(diag.span.offset);
+      std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+                << ": error: " << diag.message << "\n";
+    }
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+} // namespace
 
 auto main(int argc, char* argv[]) -> int {
   if (argc < 2) {
-    std::cerr << "usage: daoc <file>\n";
+    std::cerr << "usage: daoc <command> <file>\n";
+    std::cerr << "commands: lex\n";
     return EXIT_FAILURE;
   }
 
-  std::filesystem::path path{argv[1]};
+  std::string_view arg1(argv[1]);
 
+  // daoc lex <file>
+  if (arg1 == "lex") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc lex <file>\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path path(argv[2]);
+    if (!std::filesystem::exists(path)) {
+      std::cerr << "error: file not found: " << path << "\n";
+      return EXIT_FAILURE;
+    }
+    cmd_lex(path);
+    return EXIT_SUCCESS;
+  }
+
+  // daoc <file> — read and exit (Task 0 compat)
+  std::filesystem::path path(arg1);
   if (!std::filesystem::exists(path)) {
     std::cerr << "error: file not found: " << path << "\n";
     return EXIT_FAILURE;
   }
-
-  std::ifstream file{path};
-  if (!file) {
-    std::cerr << "error: could not open: " << path << "\n";
-    return EXIT_FAILURE;
-  }
-
-  std::string contents{std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
-
+  auto contents = read_file(path);
   return EXIT_SUCCESS;
 }

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -18,6 +18,8 @@ auto read_file(const std::filesystem::path& path) -> std::string {
   return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
 }
 
+// Debug-only token dump. Output format is not stable and must not be
+// relied upon by tests, tooling, or documentation.
 void cmd_lex(const std::filesystem::path& path) {
   auto contents = read_file(path);
   dao::SourceBuffer source(path.filename().string(), std::move(contents));

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -28,7 +28,11 @@ void cmd_lex(const std::filesystem::path& path) {
     std::cout << loc.line << ":" << loc.col << " " << dao::token_kind_name(tok.kind);
     if (!tok.text.empty() && tok.kind != dao::TokenKind::Newline &&
         tok.kind != dao::TokenKind::Eof) {
-      std::cout << " \"" << tok.text << "\"";
+      if (tok.kind == dao::TokenKind::StringLiteral) {
+        std::cout << " " << tok.text;
+      } else {
+        std::cout << " \"" << tok.text << "\"";
+      }
     }
     std::cout << "\n";
   }

--- a/compiler/frontend/CMakeLists.txt
+++ b/compiler/frontend/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(dao_frontend STATIC
+  lexer/lexer.cpp
+)
+
+target_include_directories(dao_frontend PUBLIC
+  ${CMAKE_SOURCE_DIR}/compiler
+)
+
+# Tests
+find_package(ut REQUIRED)
+
+add_executable(lexer_test
+  lexer/lexer_test.cpp
+)
+
+target_link_libraries(lexer_test PRIVATE dao_frontend Boost::ut)
+
+target_compile_definitions(lexer_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
+include(CTest)
+add_test(NAME lexer_test COMMAND lexer_test)

--- a/compiler/frontend/diagnostics/diagnostic.h
+++ b/compiler/frontend/diagnostics/diagnostic.h
@@ -1,0 +1,30 @@
+#ifndef DAO_FRONTEND_DIAGNOSTICS_DIAGNOSTIC_H
+#define DAO_FRONTEND_DIAGNOSTICS_DIAGNOSTIC_H
+
+#include "frontend/diagnostics/source.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace dao {
+
+enum class Severity : std::uint8_t { Error, Warning, Note };
+
+struct Diagnostic {
+  Severity severity;
+  Span span;
+  std::string message;
+
+  static auto error(Span span, std::string message) -> Diagnostic {
+    return {.severity = Severity::Error, .span = span, .message = std::move(message)};
+  }
+
+  static auto warning(Span span, std::string message) -> Diagnostic {
+    return {.severity = Severity::Warning, .span = span, .message = std::move(message)};
+  }
+};
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_DIAGNOSTICS_DIAGNOSTIC_H

--- a/compiler/frontend/diagnostics/source.h
+++ b/compiler/frontend/diagnostics/source.h
@@ -63,7 +63,7 @@ private:
   void build_line_index() {
     line_offsets_.push_back(0);
     for (uint32_t i = 0; i < contents_.size(); ++i) {
-      if (contents_[i] == '\n' && i + 1 < contents_.size()) {
+      if (contents_[i] == '\n') {
         line_offsets_.push_back(i + 1);
       }
     }

--- a/compiler/frontend/diagnostics/source.h
+++ b/compiler/frontend/diagnostics/source.h
@@ -1,0 +1,75 @@
+#ifndef DAO_FRONTEND_DIAGNOSTICS_SOURCE_H
+#define DAO_FRONTEND_DIAGNOSTICS_SOURCE_H
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace dao {
+
+struct Span {
+  uint32_t offset = 0;
+  uint32_t length = 0;
+};
+
+struct LineCol {
+  uint32_t line = 1;
+  uint32_t col = 1;
+};
+
+class SourceBuffer {
+public:
+  SourceBuffer(std::string filename, std::string contents)
+      : filename_(std::move(filename)), contents_(std::move(contents)) {
+    build_line_index();
+  }
+
+  [[nodiscard]] auto filename() const -> std::string_view {
+    return filename_;
+  }
+  [[nodiscard]] auto contents() const -> std::string_view {
+    return contents_;
+  }
+  [[nodiscard]] auto size() const -> uint32_t {
+    return static_cast<uint32_t>(contents_.size());
+  }
+
+  [[nodiscard]] auto text(Span span) const -> std::string_view {
+    return std::string_view(contents_).substr(span.offset, span.length);
+  }
+
+  [[nodiscard]] auto line_col(uint32_t offset) const -> LineCol {
+    // Binary search for the line containing this offset.
+    uint32_t low = 0;
+    auto high = static_cast<uint32_t>(line_offsets_.size());
+    while (low + 1 < high) {
+      uint32_t mid = low + ((high - low) / 2);
+      if (line_offsets_[mid] <= offset) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+    return {.line = low + 1, .col = offset - line_offsets_[low] + 1};
+  }
+
+private:
+  std::string filename_;
+  std::string contents_;
+  std::vector<uint32_t> line_offsets_;
+
+  void build_line_index() {
+    line_offsets_.push_back(0);
+    for (uint32_t i = 0; i < contents_.size(); ++i) {
+      if (contents_[i] == '\n' && i + 1 < contents_.size()) {
+        line_offsets_.push_back(i + 1);
+      }
+    }
+  }
+};
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_DIAGNOSTICS_SOURCE_H

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -1,0 +1,543 @@
+#include "frontend/lexer/lexer.h"
+
+#include <cctype>
+
+namespace dao {
+
+auto token_kind_name(TokenKind kind) -> const char* {
+  switch (kind) {
+  case TokenKind::KwImport:
+    return "KwImport";
+  case TokenKind::KwFn:
+    return "KwFn";
+  case TokenKind::KwStruct:
+    return "KwStruct";
+  case TokenKind::KwType:
+    return "KwType";
+  case TokenKind::KwLet:
+    return "KwLet";
+  case TokenKind::KwIf:
+    return "KwIf";
+  case TokenKind::KwElse:
+    return "KwElse";
+  case TokenKind::KwWhile:
+    return "KwWhile";
+  case TokenKind::KwFor:
+    return "KwFor";
+  case TokenKind::KwIn:
+    return "KwIn";
+  case TokenKind::KwReturn:
+    return "KwReturn";
+  case TokenKind::KwMode:
+    return "KwMode";
+  case TokenKind::KwResource:
+    return "KwResource";
+  case TokenKind::KwTrue:
+    return "KwTrue";
+  case TokenKind::KwFalse:
+    return "KwFalse";
+  case TokenKind::KwAnd:
+    return "KwAnd";
+  case TokenKind::KwOr:
+    return "KwOr";
+  case TokenKind::Colon:
+    return "Colon";
+  case TokenKind::Arrow:
+    return "Arrow";
+  case TokenKind::FatArrow:
+    return "FatArrow";
+  case TokenKind::Eq:
+    return "Eq";
+  case TokenKind::EqEq:
+    return "EqEq";
+  case TokenKind::BangEq:
+    return "BangEq";
+  case TokenKind::Lt:
+    return "Lt";
+  case TokenKind::LtEq:
+    return "LtEq";
+  case TokenKind::Gt:
+    return "Gt";
+  case TokenKind::GtEq:
+    return "GtEq";
+  case TokenKind::Plus:
+    return "Plus";
+  case TokenKind::Minus:
+    return "Minus";
+  case TokenKind::Star:
+    return "Star";
+  case TokenKind::Slash:
+    return "Slash";
+  case TokenKind::Percent:
+    return "Percent";
+  case TokenKind::Amp:
+    return "Amp";
+  case TokenKind::Bang:
+    return "Bang";
+  case TokenKind::Dot:
+    return "Dot";
+  case TokenKind::Comma:
+    return "Comma";
+  case TokenKind::Pipe:
+    return "Pipe";
+  case TokenKind::PipeGt:
+    return "PipeGt";
+  case TokenKind::LParen:
+    return "LParen";
+  case TokenKind::RParen:
+    return "RParen";
+  case TokenKind::LBracket:
+    return "LBracket";
+  case TokenKind::RBracket:
+    return "RBracket";
+  case TokenKind::IntLiteral:
+    return "IntLiteral";
+  case TokenKind::FloatLiteral:
+    return "FloatLiteral";
+  case TokenKind::StringLiteral:
+    return "StringLiteral";
+  case TokenKind::Identifier:
+    return "Identifier";
+  case TokenKind::Newline:
+    return "Newline";
+  case TokenKind::Indent:
+    return "Indent";
+  case TokenKind::Dedent:
+    return "Dedent";
+  case TokenKind::Eof:
+    return "Eof";
+  case TokenKind::Error:
+    return "Error";
+  }
+  return "Unknown";
+}
+
+namespace {
+
+class LexerImpl {
+public:
+  explicit LexerImpl(const SourceBuffer& source) : source_(source), src_(source.contents()) {
+  }
+
+  auto run() -> LexResult {
+    while (pos_ < src_.size()) {
+      if (at_line_start_) {
+        handle_line_start();
+        continue;
+      }
+
+      skip_horizontal_whitespace();
+
+      if (pos_ >= src_.size()) {
+        break;
+      }
+
+      char cur = src_[pos_];
+
+      if (cur == '\n') {
+        handle_newline();
+        continue;
+      }
+
+      if (cur == '\r') {
+        ++pos_;
+        if (pos_ < src_.size() && src_[pos_] == '\n') {
+          ++pos_;
+        }
+        handle_newline_emit();
+        continue;
+      }
+
+      lex_token();
+    }
+
+    // Emit remaining DEDENTs.
+    while (indent_stack_.size() > 1) {
+      emit(TokenKind::Dedent, pos_, 0);
+      indent_stack_.pop_back();
+    }
+
+    emit(TokenKind::Eof, pos_, 0);
+
+    return {.tokens = std::move(tokens_), .diagnostics = std::move(diagnostics_)};
+  }
+
+private:
+  const SourceBuffer& source_;
+  std::string_view src_;
+  uint32_t pos_ = 0;
+  std::vector<uint32_t> indent_stack_ = {0};
+  uint32_t paren_depth_ = 0;
+  bool at_line_start_ = true;
+  std::vector<Token> tokens_;
+  std::vector<Diagnostic> diagnostics_;
+
+  void emit(TokenKind kind, uint32_t offset, uint32_t length) {
+    tokens_.push_back({.kind = kind,
+                       .span = {.offset = offset, .length = length},
+                       .text = src_.substr(offset, length)});
+  }
+
+  void emit_error(uint32_t offset, uint32_t length, std::string message) {
+    emit(TokenKind::Error, offset, length);
+    diagnostics_.push_back(
+        Diagnostic::error({.offset = offset, .length = length}, std::move(message)));
+  }
+
+  [[nodiscard]] auto peek() const -> char {
+    if (pos_ < src_.size()) {
+      return src_[pos_];
+    }
+    return '\0';
+  }
+
+  [[nodiscard]] auto peek_at(uint32_t offset) const -> char {
+    if (offset < src_.size()) {
+      return src_[offset];
+    }
+    return '\0';
+  }
+
+  auto advance() -> char {
+    char cur = src_[pos_];
+    ++pos_;
+    return cur;
+  }
+
+  void skip_horizontal_whitespace() {
+    while (pos_ < src_.size() && src_[pos_] == ' ') {
+      ++pos_;
+    }
+  }
+
+  void handle_newline() {
+    ++pos_;
+    handle_newline_emit();
+  }
+
+  void handle_newline_emit() {
+    if (paren_depth_ == 0) {
+      emit(TokenKind::Newline, pos_ - 1, 1);
+    }
+    at_line_start_ = true;
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void handle_line_start() {
+    // Count leading spaces. Tabs are illegal.
+    uint32_t line_begin = pos_;
+    uint32_t spaces = 0;
+    while (pos_ < src_.size()) {
+      if (src_[pos_] == ' ') {
+        ++spaces;
+        ++pos_;
+      } else if (src_[pos_] == '\t') {
+        emit_error(pos_, 1, "tabs are not allowed in Dao source");
+        ++pos_;
+        ++spaces; // treat tab as one space for recovery
+      } else {
+        break;
+      }
+    }
+
+    // Blank line — skip without affecting indentation.
+    if (pos_ >= src_.size() || src_[pos_] == '\n' || src_[pos_] == '\r') {
+      at_line_start_ = false;
+      if (pos_ < src_.size()) {
+        // Consume the newline but don't emit NEWLINE for blank lines
+        // (previous line's NEWLINE already emitted).
+        if (src_[pos_] == '\r') {
+          ++pos_;
+          if (pos_ < src_.size() && src_[pos_] == '\n') {
+            ++pos_;
+          }
+        } else {
+          ++pos_;
+        }
+        at_line_start_ = true;
+      }
+      return;
+    }
+
+    at_line_start_ = false;
+
+    // Inside parentheses/brackets, indentation is ignored.
+    if (paren_depth_ > 0) {
+      return;
+    }
+
+    uint32_t current_indent = indent_stack_.back();
+
+    if (spaces > current_indent) {
+      indent_stack_.push_back(spaces);
+      emit(TokenKind::Indent, line_begin, spaces);
+    } else if (spaces < current_indent) {
+      while (indent_stack_.size() > 1 && indent_stack_.back() > spaces) {
+        indent_stack_.pop_back();
+        emit(TokenKind::Dedent, line_begin, 0);
+      }
+      if (indent_stack_.back() != spaces) {
+        emit_error(line_begin, spaces, "inconsistent indentation");
+      }
+    }
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void lex_token() {
+    uint32_t start = pos_;
+    char cur = advance();
+
+    switch (cur) {
+    case ':':
+      emit(TokenKind::Colon, start, 1);
+      return;
+    case '+':
+      emit(TokenKind::Plus, start, 1);
+      return;
+    case '%':
+      emit(TokenKind::Percent, start, 1);
+      return;
+    case '&':
+      emit(TokenKind::Amp, start, 1);
+      return;
+    case '.':
+      emit(TokenKind::Dot, start, 1);
+      return;
+    case ',':
+      emit(TokenKind::Comma, start, 1);
+      return;
+
+    case '(':
+      emit(TokenKind::LParen, start, 1);
+      ++paren_depth_;
+      return;
+    case ')':
+      emit(TokenKind::RParen, start, 1);
+      if (paren_depth_ > 0) {
+        --paren_depth_;
+      }
+      return;
+    case '[':
+      emit(TokenKind::LBracket, start, 1);
+      ++paren_depth_;
+      return;
+    case ']':
+      emit(TokenKind::RBracket, start, 1);
+      if (paren_depth_ > 0) {
+        --paren_depth_;
+      }
+      return;
+
+    case '-':
+      if (peek() == '>') {
+        ++pos_;
+        emit(TokenKind::Arrow, start, 2);
+      } else {
+        emit(TokenKind::Minus, start, 1);
+      }
+      return;
+
+    case '=':
+      if (peek() == '=') {
+        ++pos_;
+        emit(TokenKind::EqEq, start, 2);
+      } else if (peek() == '>') {
+        ++pos_;
+        emit(TokenKind::FatArrow, start, 2);
+      } else {
+        emit(TokenKind::Eq, start, 1);
+      }
+      return;
+
+    case '!':
+      if (peek() == '=') {
+        ++pos_;
+        emit(TokenKind::BangEq, start, 2);
+      } else {
+        emit(TokenKind::Bang, start, 1);
+      }
+      return;
+
+    case '<':
+      if (peek() == '=') {
+        ++pos_;
+        emit(TokenKind::LtEq, start, 2);
+      } else {
+        emit(TokenKind::Lt, start, 1);
+      }
+      return;
+
+    case '>':
+      if (peek() == '=') {
+        ++pos_;
+        emit(TokenKind::GtEq, start, 2);
+      } else {
+        emit(TokenKind::Gt, start, 1);
+      }
+      return;
+
+    case '|':
+      if (peek() == '>') {
+        ++pos_;
+        emit(TokenKind::PipeGt, start, 2);
+      } else {
+        emit(TokenKind::Pipe, start, 1);
+      }
+      return;
+
+    case '*':
+      emit(TokenKind::Star, start, 1);
+      return;
+    case '/':
+      emit(TokenKind::Slash, start, 1);
+      return;
+
+    case '"':
+      lex_string(start);
+      return;
+
+    default:
+      break;
+    }
+
+    // Numbers
+    if (std::isdigit(static_cast<unsigned char>(cur)) != 0) {
+      lex_number(start);
+      return;
+    }
+
+    // Identifiers and keywords
+    if (cur == '_' || std::isalpha(static_cast<unsigned char>(cur)) != 0) {
+      lex_identifier(start);
+      return;
+    }
+
+    emit_error(start, 1, std::string("unexpected character: ") + cur);
+  }
+
+  void lex_string(uint32_t start) {
+    // start is the position of the opening quote, already consumed.
+    while (pos_ < src_.size()) {
+      char cur = src_[pos_];
+      if (cur == '"') {
+        ++pos_;
+        emit(TokenKind::StringLiteral, start, pos_ - start);
+        return;
+      }
+      if (cur == '\\') {
+        ++pos_; // skip escaped character
+        if (pos_ < src_.size()) {
+          ++pos_;
+        }
+        continue;
+      }
+      if (cur == '\n') {
+        break;
+      }
+      ++pos_;
+    }
+    emit_error(start, pos_ - start, "unterminated string literal");
+  }
+
+  void lex_number(uint32_t start) {
+    // First digit already consumed via advance().
+    while (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_])) != 0) {
+      ++pos_;
+    }
+
+    bool is_float = false;
+
+    // Check for decimal point followed by a digit.
+    if (pos_ < src_.size() && src_[pos_] == '.' && pos_ + 1 < src_.size() &&
+        std::isdigit(static_cast<unsigned char>(src_[pos_ + 1])) != 0) {
+      is_float = true;
+      ++pos_; // consume '.'
+      while (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_])) != 0) {
+        ++pos_;
+      }
+    }
+
+    emit(is_float ? TokenKind::FloatLiteral : TokenKind::IntLiteral, start, pos_ - start);
+  }
+
+  void lex_identifier(uint32_t start) {
+    // First character already consumed.
+    while (pos_ < src_.size()) {
+      char cur = src_[pos_];
+      if (cur == '_' || std::isalnum(static_cast<unsigned char>(cur)) != 0) {
+        ++pos_;
+      } else {
+        break;
+      }
+    }
+
+    std::string_view word = src_.substr(start, pos_ - start);
+    TokenKind kind = classify_keyword(word);
+    emit(kind, start, pos_ - start);
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  static auto classify_keyword(std::string_view word) -> TokenKind {
+    if (word == "import") {
+      return TokenKind::KwImport;
+    }
+    if (word == "fn") {
+      return TokenKind::KwFn;
+    }
+    if (word == "struct") {
+      return TokenKind::KwStruct;
+    }
+    if (word == "type") {
+      return TokenKind::KwType;
+    }
+    if (word == "let") {
+      return TokenKind::KwLet;
+    }
+    if (word == "if") {
+      return TokenKind::KwIf;
+    }
+    if (word == "else") {
+      return TokenKind::KwElse;
+    }
+    if (word == "while") {
+      return TokenKind::KwWhile;
+    }
+    if (word == "for") {
+      return TokenKind::KwFor;
+    }
+    if (word == "in") {
+      return TokenKind::KwIn;
+    }
+    if (word == "return") {
+      return TokenKind::KwReturn;
+    }
+    if (word == "mode") {
+      return TokenKind::KwMode;
+    }
+    if (word == "resource") {
+      return TokenKind::KwResource;
+    }
+    if (word == "true") {
+      return TokenKind::KwTrue;
+    }
+    if (word == "false") {
+      return TokenKind::KwFalse;
+    }
+    if (word == "and") {
+      return TokenKind::KwAnd;
+    }
+    if (word == "or") {
+      return TokenKind::KwOr;
+    }
+    return TokenKind::Identifier;
+  }
+};
+
+} // namespace
+
+auto lex(const SourceBuffer& source) -> LexResult {
+  LexerImpl lexer(source);
+  return lexer.run();
+}
+
+} // namespace dao

--- a/compiler/frontend/lexer/lexer.h
+++ b/compiler/frontend/lexer/lexer.h
@@ -1,0 +1,21 @@
+#ifndef DAO_FRONTEND_LEXER_LEXER_H
+#define DAO_FRONTEND_LEXER_LEXER_H
+
+#include "frontend/diagnostics/diagnostic.h"
+#include "frontend/diagnostics/source.h"
+#include "frontend/lexer/token.h"
+
+#include <vector>
+
+namespace dao {
+
+struct LexResult {
+  std::vector<Token> tokens;
+  std::vector<Diagnostic> diagnostics;
+};
+
+auto lex(const SourceBuffer& source) -> LexResult;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_LEXER_LEXER_H

--- a/compiler/frontend/lexer/lexer_test.cpp
+++ b/compiler/frontend/lexer/lexer_test.cpp
@@ -1,0 +1,269 @@
+#include "frontend/lexer/lexer.h"
+
+#define BOOST_UT_DISABLE_MODULE
+#include <boost/ut.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace boost::ut;
+using namespace dao;
+
+auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+// Holds both the source buffer and lex result so string_view tokens
+// remain valid for the lifetime of the returned object.
+struct LexOutput {
+  std::unique_ptr<SourceBuffer> source;
+  LexResult result;
+};
+
+auto lex_string(std::string_view src) -> LexOutput {
+  auto source = std::make_unique<SourceBuffer>("<test>", std::string(src));
+  auto result = lex(*source);
+  return {.source = std::move(source), .result = std::move(result)};
+}
+
+auto count_kind(const std::vector<Token>& tokens, TokenKind kind) -> int {
+  int count = 0;
+  for (const auto& tok : tokens) {
+    if (tok.kind == kind) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// NOLINTBEGIN(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
+
+suite keyword_tests = [] {
+  "all keywords recognized"_test = [] {
+    auto output = lex_string("import fn struct type let if else while for in return mode resource "
+                             "true false and or\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    expect(kinds.size() == 17_u);
+    expect(kinds[0] == TokenKind::KwImport);
+    expect(kinds[1] == TokenKind::KwFn);
+    expect(kinds[2] == TokenKind::KwStruct);
+    expect(kinds[3] == TokenKind::KwType);
+    expect(kinds[4] == TokenKind::KwLet);
+    expect(kinds[5] == TokenKind::KwIf);
+    expect(kinds[6] == TokenKind::KwElse);
+    expect(kinds[7] == TokenKind::KwWhile);
+    expect(kinds[8] == TokenKind::KwFor);
+    expect(kinds[9] == TokenKind::KwIn);
+    expect(kinds[10] == TokenKind::KwReturn);
+    expect(kinds[11] == TokenKind::KwMode);
+    expect(kinds[12] == TokenKind::KwResource);
+    expect(kinds[13] == TokenKind::KwTrue);
+    expect(kinds[14] == TokenKind::KwFalse);
+    expect(kinds[15] == TokenKind::KwAnd);
+    expect(kinds[16] == TokenKind::KwOr);
+  };
+};
+
+suite operator_tests = [] {
+  "all operators recognized"_test = [] {
+    auto output = lex_string(": -> => = == != < <= > >= + - * / % & ! . , | |>\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    expect(kinds.size() == 21_u);
+    expect(kinds[0] == TokenKind::Colon);
+    expect(kinds[1] == TokenKind::Arrow);
+    expect(kinds[2] == TokenKind::FatArrow);
+    expect(kinds[3] == TokenKind::Eq);
+    expect(kinds[4] == TokenKind::EqEq);
+    expect(kinds[5] == TokenKind::BangEq);
+    expect(kinds[6] == TokenKind::Lt);
+    expect(kinds[7] == TokenKind::LtEq);
+    expect(kinds[8] == TokenKind::Gt);
+    expect(kinds[9] == TokenKind::GtEq);
+    expect(kinds[10] == TokenKind::Plus);
+    expect(kinds[11] == TokenKind::Minus);
+    expect(kinds[12] == TokenKind::Star);
+    expect(kinds[13] == TokenKind::Slash);
+    expect(kinds[14] == TokenKind::Percent);
+    expect(kinds[15] == TokenKind::Amp);
+    expect(kinds[16] == TokenKind::Bang);
+    expect(kinds[17] == TokenKind::Dot);
+    expect(kinds[18] == TokenKind::Comma);
+    expect(kinds[19] == TokenKind::Pipe);
+    expect(kinds[20] == TokenKind::PipeGt);
+  };
+
+  "delimiters"_test = [] {
+    auto output = lex_string("( ) [ ]\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    expect(kinds.size() == 4_u);
+    expect(kinds[0] == TokenKind::LParen);
+    expect(kinds[1] == TokenKind::RParen);
+    expect(kinds[2] == TokenKind::LBracket);
+    expect(kinds[3] == TokenKind::RBracket);
+  };
+};
+
+suite literal_tests = [] {
+  "integer literals"_test = [] {
+    auto output = lex_string("0 42 12345\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind == TokenKind::IntLiteral) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    expect(kinds.size() == 3_u);
+  };
+
+  "float literals"_test = [] {
+    auto output = lex_string("0.0 3.14 100.5\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind == TokenKind::FloatLiteral) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    expect(kinds.size() == 3_u);
+  };
+
+  "string literals"_test = [] {
+    auto output = lex_string(R"("hello" "world" "escaped\"quote")"
+                             "\n");
+    int count = count_kind(output.result.tokens, TokenKind::StringLiteral);
+    expect(count == 3_i);
+  };
+};
+
+suite identifier_tests = [] {
+  "identifiers not confused with keywords"_test = [] {
+    auto output = lex_string("foo bar _baz import_thing fn2\n");
+    auto ids = std::vector<std::string_view>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind == TokenKind::Identifier) {
+        ids.push_back(tok.text);
+      }
+    }
+    expect(ids.size() == 5_u);
+    expect(ids[0] == "foo");
+    expect(ids[1] == "bar");
+    expect(ids[2] == "_baz");
+    expect(ids[3] == "import_thing");
+    expect(ids[4] == "fn2");
+  };
+};
+
+suite indentation_tests = [] {
+  "simple indent dedent"_test = [] {
+    auto output = lex_string("fn main(): int32\n    0\n");
+    int indents = count_kind(output.result.tokens, TokenKind::Indent);
+    int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
+    expect(indents == dedents) << "INDENT/DEDENT must be balanced";
+    expect(indents == 1_i);
+  };
+
+  "nested indentation"_test = [] {
+    auto output = lex_string("fn f(): int32\n    if true:\n        0\n    1\n");
+    int indents = count_kind(output.result.tokens, TokenKind::Indent);
+    int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
+    expect(indents == dedents) << "INDENT/DEDENT must be balanced";
+    expect(indents == 2_i);
+  };
+
+  "blank lines do not affect indentation"_test = [] {
+    auto output = lex_string("fn f(): int32\n    let x: int32\n\n    x\n");
+    int indents = count_kind(output.result.tokens, TokenKind::Indent);
+    int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
+    expect(indents == dedents) << "INDENT/DEDENT must be balanced";
+    expect(output.result.diagnostics.empty()) << "no errors expected";
+  };
+
+  "tabs rejected"_test = [] {
+    auto output = lex_string("fn f(): int32\n\t0\n");
+    expect(!output.result.diagnostics.empty()) << "tabs must produce a diagnostic";
+  };
+
+  "paren depth suppresses indent"_test = [] {
+    auto output = lex_string("let x = foo(\n    1,\n    2\n)\n");
+    int indents = count_kind(output.result.tokens, TokenKind::Indent);
+    expect(indents == 0_i) << "no INDENT inside parens";
+  };
+};
+
+suite span_tests = [] {
+  "token spans are accurate"_test = [] {
+    auto output = lex_string("fn add\n");
+    // fn at offset 0, length 2
+    expect(output.result.tokens[0].kind == TokenKind::KwFn);
+    expect(output.result.tokens[0].span.offset == 0_u);
+    expect(output.result.tokens[0].span.length == 2_u);
+    // add at offset 3, length 3
+    expect(output.result.tokens[1].kind == TokenKind::Identifier);
+    expect(output.result.tokens[1].span.offset == 3_u);
+    expect(output.result.tokens[1].span.length == 3_u);
+  };
+};
+
+suite file_tests = [] {
+  "examples lex without error"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    for (const auto& entry : std::filesystem::directory_iterator(root / "examples")) {
+      if (entry.path().extension() == ".dao") {
+        auto contents = read_file(entry.path());
+        SourceBuffer buf(entry.path().filename().string(), contents);
+        auto result = lex(buf);
+        expect(result.diagnostics.empty()) << "errors in " << entry.path().filename().string();
+
+        // Verify INDENT/DEDENT balance.
+        int indents = count_kind(result.tokens, TokenKind::Indent);
+        int dedents = count_kind(result.tokens, TokenKind::Dedent);
+        expect(indents == dedents)
+            << "unbalanced INDENT/DEDENT in " << entry.path().filename().string();
+      }
+    }
+  };
+
+  "syntax probes lex without error"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    for (const auto& entry : std::filesystem::directory_iterator(root / "spec" / "syntax_probes")) {
+      if (entry.path().extension() == ".dao") {
+        auto contents = read_file(entry.path());
+        SourceBuffer buf(entry.path().filename().string(), contents);
+        auto result = lex(buf);
+        expect(result.diagnostics.empty()) << "errors in " << entry.path().filename().string();
+
+        // Verify INDENT/DEDENT balance.
+        int indents = count_kind(result.tokens, TokenKind::Indent);
+        int dedents = count_kind(result.tokens, TokenKind::Dedent);
+        expect(indents == dedents)
+            << "unbalanced INDENT/DEDENT in " << entry.path().filename().string();
+      }
+    }
+  };
+};
+
+// NOLINTEND(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
+
+} // namespace
+
+auto main() -> int {
+} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -1,0 +1,97 @@
+#ifndef DAO_FRONTEND_LEXER_TOKEN_H
+#define DAO_FRONTEND_LEXER_TOKEN_H
+
+#include "frontend/diagnostics/source.h"
+
+#include <cstdint>
+#include <string_view>
+
+namespace dao {
+
+// Token kinds map directly to the lexical surface in spec/grammar/dao.lex.
+// Fine-grained keyword kinds support trivial mapping to the semantic token
+// taxonomy in CONTRACT_LANGUAGE_TOOLING.md.
+enum class TokenKind : std::uint8_t {
+  // Keywords — control
+  KwImport,
+  KwFn,
+  KwStruct,
+  KwType,
+  KwLet,
+  KwIf,
+  KwElse,
+  KwWhile,
+  KwFor,
+  KwIn,
+  KwReturn,
+
+  // Keywords — execution / resource constructs
+  KwMode,
+  KwResource,
+
+  // Keywords — literals
+  KwTrue,
+  KwFalse,
+
+  // Keywords — logical operators
+  KwAnd,
+  KwOr,
+
+  // Operators
+  Colon,    // :
+  Arrow,    // ->
+  FatArrow, // =>
+  Eq,       // =
+  EqEq,     // ==
+  BangEq,   // !=
+  Lt,       // <
+  LtEq,     // <=
+  Gt,       // >
+  GtEq,     // >=
+  Plus,     // +
+  Minus,    // -
+  Star,     // *
+  Slash,    // /
+  Percent,  // %
+  Amp,      // &
+  Bang,     // !
+  Dot,      // .
+  Comma,    // ,
+  Pipe,     // |
+  PipeGt,   // |>
+
+  // Delimiters
+  LParen,   // (
+  RParen,   // )
+  LBracket, // [
+  RBracket, // ]
+
+  // Literals
+  IntLiteral,
+  FloatLiteral,
+  StringLiteral,
+
+  // Identifier
+  Identifier,
+
+  // Synthetic
+  Newline,
+  Indent,
+  Dedent,
+  Eof,
+
+  // Error recovery
+  Error,
+};
+
+struct Token {
+  TokenKind kind;
+  Span span;
+  std::string_view text;
+};
+
+auto token_kind_name(TokenKind kind) -> const char*;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_LEXER_TOKEN_H


### PR DESCRIPTION
## Summary

Implements Task 1 from the implementation plan: a complete indentation-aware lexer that translates `spec/grammar/dao.lex` into a working token stream, with source diagnostics infrastructure and a `daoc lex` subcommand.

## Highlights

- **Token types**: Fine-grained `TokenKind` enum covering all 17 keywords, 21 operators/punctuation, 3 literal types, identifier, and 4 synthetic tokens (INDENT, DEDENT, NEWLINE, EOF) — maps trivially to the semantic token taxonomy in `CONTRACT_LANGUAGE_TOOLING.md`
- **Indentation handling**: Python-style indent stack with INDENT/DEDENT emission, paren/bracket depth suppression, tab rejection with diagnostics, and blank line skipping
- **Diagnostics infrastructure**: `SourceBuffer` (filename, contents, line/column mapping), `Span`, `Diagnostic` with severity — shared foundation for parser and later phases
- **Driver**: `daoc lex <file>` prints the full token stream with line:col positions
- **Tests**: 15 tests with 84 assertions covering keywords, operators, literals, identifiers, indentation (simple, nested, blank lines, tabs, parens), span accuracy, and all 8 `.dao` files (4 examples + 4 syntax probes)
- **CI**: Added ctest step to the build pipeline

## Test plan

- [ ] `cmake --build build/debug` succeeds
- [ ] `ctest --test-dir build/debug --output-on-failure` — 1/1 test passes (15 subtests, 84 assertions)
- [ ] `daoc lex examples/hello.dao` produces correct token stream
- [ ] `daoc lex` on all 8 `.dao` files exits cleanly with balanced INDENT/DEDENT
- [ ] `clang-format --dry-run --Werror` passes on all source
- [ ] `clang-tidy -p build/debug` reports 0 user-code warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)