### PR TITLE
feat(lexer): ✨ add :: (ColonColon) token and capture design philosophy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,14 @@ jobs:
           echo "CMake version $cmake_version satisfies >= 3.30"
 
       - name: Install Conan
-        run: pip install conan
+        run: |
+          pip install conan
+          conan profile detect
 
       - name: Detect Clang version
         id: clang
         run: |
-          version=$(clang++ --version | grep -oP 'clang version \K\d+')
+          version=$(clang++-21 --version | grep -oP 'clang version \K\d+')
           echo "major=$version" >> "$GITHUB_OUTPUT"
           echo "Detected clang major version: $version"
 
@@ -59,7 +61,9 @@ jobs:
             --output-folder=build/debug \
             --build=missing \
             -pr profiles/clang-21-debug \
+            -pr:b profiles/clang-21-debug \
             -s compiler.version=${{ steps.clang.outputs.major }} \
+            -s:b compiler.version=${{ steps.clang.outputs.major }} \
             --lockfile=locks/clang-21-debug.lock
 
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Install LLVM/Clang
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main"
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc > /dev/null
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
           sudo apt-get install -y clang clang-format clang-tidy
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install LLVM/Clang
+        env:
+          LLVM_VERSION: 21
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc > /dev/null
-          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          codename=$(lsb_release -cs)
+          echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${LLVM_VERSION} main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install -y clang clang-format clang-tidy
+          sudo apt-get install -y clang-${LLVM_VERSION} clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION}
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} 100
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${LLVM_VERSION} 100
 
       - name: Install CMake
         uses: lukka/get-cmake@latest

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -42,6 +42,8 @@ auto token_kind_name(TokenKind kind) -> const char* {
     return "KwOr";
   case TokenKind::Colon:
     return "Colon";
+  case TokenKind::ColonColon:
+    return "ColonColon";
   case TokenKind::Arrow:
     return "Arrow";
   case TokenKind::FatArrow:
@@ -289,7 +291,12 @@ private:
 
     switch (cur) {
     case ':':
-      emit(TokenKind::Colon, start, 1);
+      if (peek() == ':') {
+        ++pos_;
+        emit(TokenKind::ColonColon, start, 2);
+      } else {
+        emit(TokenKind::Colon, start, 1);
+      }
       return;
     case '+':
       emit(TokenKind::Plus, start, 1);

--- a/compiler/frontend/lexer/lexer_test.cpp
+++ b/compiler/frontend/lexer/lexer_test.cpp
@@ -76,35 +76,57 @@ suite keyword_tests = [] {
 
 suite operator_tests = [] {
   "all operators recognized"_test = [] {
-    auto output = lex_string(": -> => = == != < <= > >= + - * / % & ! . , | |>\n");
+    auto output = lex_string(": :: -> => = == != < <= > >= + - * / % & ! . , | |>\n");
     auto kinds = std::vector<TokenKind>{};
     for (const auto& tok : output.result.tokens) {
       if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof) {
         kinds.push_back(tok.kind);
       }
     }
-    expect(kinds.size() == 21_u);
+    expect(kinds.size() == 22_u);
     expect(kinds[0] == TokenKind::Colon);
-    expect(kinds[1] == TokenKind::Arrow);
-    expect(kinds[2] == TokenKind::FatArrow);
-    expect(kinds[3] == TokenKind::Eq);
-    expect(kinds[4] == TokenKind::EqEq);
-    expect(kinds[5] == TokenKind::BangEq);
-    expect(kinds[6] == TokenKind::Lt);
-    expect(kinds[7] == TokenKind::LtEq);
-    expect(kinds[8] == TokenKind::Gt);
-    expect(kinds[9] == TokenKind::GtEq);
-    expect(kinds[10] == TokenKind::Plus);
-    expect(kinds[11] == TokenKind::Minus);
-    expect(kinds[12] == TokenKind::Star);
-    expect(kinds[13] == TokenKind::Slash);
-    expect(kinds[14] == TokenKind::Percent);
-    expect(kinds[15] == TokenKind::Amp);
-    expect(kinds[16] == TokenKind::Bang);
-    expect(kinds[17] == TokenKind::Dot);
-    expect(kinds[18] == TokenKind::Comma);
-    expect(kinds[19] == TokenKind::Pipe);
-    expect(kinds[20] == TokenKind::PipeGt);
+    expect(kinds[1] == TokenKind::ColonColon);
+    expect(kinds[2] == TokenKind::Arrow);
+    expect(kinds[3] == TokenKind::FatArrow);
+    expect(kinds[4] == TokenKind::Eq);
+    expect(kinds[5] == TokenKind::EqEq);
+    expect(kinds[6] == TokenKind::BangEq);
+    expect(kinds[7] == TokenKind::Lt);
+    expect(kinds[8] == TokenKind::LtEq);
+    expect(kinds[9] == TokenKind::Gt);
+    expect(kinds[10] == TokenKind::GtEq);
+    expect(kinds[11] == TokenKind::Plus);
+    expect(kinds[12] == TokenKind::Minus);
+    expect(kinds[13] == TokenKind::Star);
+    expect(kinds[14] == TokenKind::Slash);
+    expect(kinds[15] == TokenKind::Percent);
+    expect(kinds[16] == TokenKind::Amp);
+    expect(kinds[17] == TokenKind::Bang);
+    expect(kinds[18] == TokenKind::Dot);
+    expect(kinds[19] == TokenKind::Comma);
+    expect(kinds[20] == TokenKind::Pipe);
+    expect(kinds[21] == TokenKind::PipeGt);
+  };
+
+  "colon vs coloncolon disambiguation"_test = [] {
+    auto output = lex_string("x: int32\nnet::http::get\n");
+    auto kinds = std::vector<TokenKind>{};
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof &&
+          tok.kind != TokenKind::Indent && tok.kind != TokenKind::Dedent) {
+        kinds.push_back(tok.kind);
+      }
+    }
+    // x : int32 net :: http :: get
+    expect(kinds.size() == 8_u);
+    expect(kinds[0] == TokenKind::Identifier); // x
+    expect(kinds[1] == TokenKind::Colon);      // :
+    expect(kinds[2] == TokenKind::Identifier); // int32
+    expect(kinds[3] == TokenKind::Identifier); // net
+    expect(kinds[4] == TokenKind::ColonColon); // ::
+    expect(kinds[5] == TokenKind::Identifier); // http
+    expect(kinds[6] == TokenKind::ColonColon); // ::
+    expect(kinds[7] == TokenKind::Identifier); // get
   };
 
   "delimiters"_test = [] {

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -38,27 +38,28 @@ enum class TokenKind : std::uint8_t {
   KwOr,
 
   // Operators
-  Colon,    // :
-  Arrow,    // ->
-  FatArrow, // =>
-  Eq,       // =
-  EqEq,     // ==
-  BangEq,   // !=
-  Lt,       // <
-  LtEq,     // <=
-  Gt,       // >
-  GtEq,     // >=
-  Plus,     // +
-  Minus,    // -
-  Star,     // *
-  Slash,    // /
-  Percent,  // %
-  Amp,      // &
-  Bang,     // !
-  Dot,      // .
-  Comma,    // ,
-  Pipe,     // |
-  PipeGt,   // |>
+  Colon,      // :
+  ColonColon, // ::
+  Arrow,      // ->
+  FatArrow,   // =>
+  Eq,         // =
+  EqEq,       // ==
+  BangEq,     // !=
+  Lt,         // <
+  LtEq,       // <=
+  Gt,         // >
+  GtEq,       // >=
+  Plus,       // +
+  Minus,      // -
+  Star,       // *
+  Slash,      // /
+  Percent,    // %
+  Amp,        // &
+  Bang,       // !
+  Dot,        // .
+  Comma,      // ,
+  Pipe,       // |
+  PipeGt,     // |>
 
   // Delimiters
   LParen,   // (

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -25,6 +25,7 @@ Contracts and explanatory material.
 - `PLAYGROUND_ARCHITECTURE.md` — explanatory architecture for the playground as a first-class development surface and future web IDE
 - `IDE_AND_TOOLING.md` — explanatory posture for semantic tooling, LSP, and why some tooling decisions are contract-level while others stay freestanding
 - `COMPILER_SERVICE_API.md` — explanatory shared analysis payloads for CLI, playground, and LSP
+- `language_vision.md` — explanatory design doctrine, stdlib posture, module/namespace design, and GPU strategy
 
 ## `spec/`
 

--- a/docs/contracts/CONTRACT_LANGUAGE_TOOLING.md
+++ b/docs/contracts/CONTRACT_LANGUAGE_TOOLING.md
@@ -82,6 +82,7 @@ classify at least the following categories:
 - `operator.arrow`
 - `operator.context`
 - `operator.assignment`
+- `operator.namespace`
 - `punctuation`
 
 ### Lambda / pipeline support

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -96,9 +96,22 @@ Rules:
 - `resource <kind> <name> =>` introduces a resource-binding context
 - `=>` is reserved for semantic-context entry, not structural blocks
 
+## Namespace Qualification
+
+```dao
+import net::http
+net::http::get(url)
+```
+
+Rules:
+- `::` is the namespace/module path separator
+- `.` is for runtime member access on values
+- these two are not interchangeable
+
 ## Arrow Taxonomy
 
 - `:` is used for type annotations and control-flow block introducers
+- `::` is used for namespace and module path qualification
 - `->` is used for expression-bodied functions and lambdas
 - `=>` is used only for `mode` and `resource` suites
 

--- a/docs/language_vision.md
+++ b/docs/language_vision.md
@@ -55,6 +55,16 @@ These are official but not compiler-coupled. They follow the same module
 conventions as third-party code. A package graduating from first-party
 to stdlib (or being removed) is a semver event.
 
+### Early dogfooding targets
+
+A strong web framework and wire protocol support are priority
+dogfooding surfaces. Getting `net::http`, `web`, and `json` to
+production quality early exercises the full stack — stdlib primitives,
+first-party package conventions, module system, error handling, and
+concurrency — under real workload pressure. If Dao cannot build a
+competitive web server from its own libraries, the platform story is
+not credible.
+
 ## Module and Namespace System
 
 - `::` is the namespace/module path separator

--- a/docs/language_vision.md
+++ b/docs/language_vision.md
@@ -8,3 +8,96 @@ Dao aims for:
 
 This file is explanatory only.
 Normative decisions live under `docs/contracts/`.
+
+## Design Doctrine
+
+Dao grows by strengthening general mechanisms, not by accumulating
+special forms. Before adding a keyword, sigil, or language-level
+construct, ask whether an existing mechanism can absorb the need
+through compiler recognition or library design.
+
+Principles:
+- Minimize keywords and syntactic sigils
+- Prefer compiler pattern recognition over syntax promotion
+- New constructs must justify themselves against composition of existing ones
+- "Special form" is a cost; generality is a feature
+
+## Standard Library Posture
+
+**Small standard library, large standard platform.**
+
+The `stdlib` ships only foundational types and low-level primitives that
+the compiler or runtime depend on. Everything above that threshold lives
+in first-party packages maintained alongside the compiler but versioned
+and distributed independently.
+
+### stdlib (ships with compiler)
+
+Core types, numeric primitives, and minimal runtime support. This is the
+floor — programs that import nothing beyond `stdlib` must still compile
+and link.
+
+### First-party packages (batteries-included, separately versioned)
+
+Dao provides a curated set of first-party packages covering common needs:
+- `io` — file/stream I/O
+- `net` — sockets, DNS, low-level networking
+- `net::http` — HTTP client/server
+- `sync` — concurrency primitives
+- `time` — clocks, durations, formatting
+- `json` — serialization
+- `web` — routing, middleware, templating
+- `db` — connection pooling, SQL, query building
+- `test` — test runner, assertions, benchmarking
+- `obs` — logging, metrics, tracing
+
+These are official but not compiler-coupled. They follow the same module
+conventions as third-party code. A package graduating from first-party
+to stdlib (or being removed) is a semver event.
+
+## Module and Namespace System
+
+- `::` is the namespace/module path separator
+- `.` is for runtime member access on values
+- these two are not interchangeable
+
+Modules use hierarchical `::` paths that map to logical identities, not
+repository URLs or filesystem paths. Import examples:
+
+```dao
+import net::http
+import db::sql
+```
+
+Visibility tiers (not yet frozen):
+- module-private (default)
+- package-visible
+- public
+
+The module system distinguishes packages, modules, and workspaces as
+separate concepts with explicit boundaries.
+
+## GPU and Accelerator Support
+
+GPU workloads are expressed through the existing `mode` and `resource`
+constructs. There is no special GPU syntax.
+
+```dao
+fn vector_add(a: Tensor, b: Tensor): Tensor
+    resource memory result =>
+        let out = Tensor::zeros(a.shape)
+    mode gpu =>
+        for i in range(a.len):
+            out[i] = a[i] + b[i]
+    out
+```
+
+The compiler recognizes kernel-eligible functions from structural
+patterns (mode entry, resource binding, loop shape) and lowers them
+to GPU targets. This is compiler recognition, not syntax promotion.
+
+Key constraints:
+- No `@kernel` annotations or GPU-specific keywords
+- `mode gpu =>` is the same `mode` construct used for `unsafe`, `parallel`, etc.
+- `resource memory =>` is the same `resource` construct used for CPU allocation domains
+- GPU is a deployment target for existing language semantics, not a separate sublanguage

--- a/docs/language_vision.md
+++ b/docs/language_vision.md
@@ -33,14 +33,14 @@ and distributed independently.
 
 ### stdlib (ships with compiler)
 
-Core types, numeric primitives, and minimal runtime support. This is the
-floor — programs that import nothing beyond `stdlib` must still compile
-and link.
+Core types, numeric primitives, IO, and minimal runtime support. This is
+the floor — programs that import nothing beyond `stdlib` must still
+compile and link. Foundational modules include `core`, `io`, and
+`numerics`.
 
 ### First-party packages (batteries-included, separately versioned)
 
 Dao provides a curated set of first-party packages covering common needs:
-- `io` — file/stream I/O
 - `net` — sockets, DNS, low-level networking
 - `net::http` — HTTP client/server
 - `sync` — concurrency primitives

--- a/spec/grammar/dao.ebnf
+++ b/spec/grammar/dao.ebnf
@@ -9,7 +9,7 @@ import :=
     "import" module_path NEWLINE
 
 module_path :=
-    identifier ("." identifier)*
+    identifier ("::" identifier)*
 
 
 declaration :=
@@ -144,11 +144,14 @@ arguments :=
     expression ("," expression)*
 
 primary :=
-      identifier
+      qualified_name
     | literal
     | lambda
     | list_literal
     | "(" expression ")"
+
+qualified_name :=
+    identifier ("::" identifier)*
 
 lambda :=
     "|" lambda_params? "|" "->" expression
@@ -178,7 +181,7 @@ pointer_type :=
     "*" type
 
 named_type :=
-    identifier ("[" type_list "]")?
+    qualified_name ("[" type_list "]")?
 
 type_list :=
     type ("," type)*

--- a/spec/grammar/dao.lex
+++ b/spec/grammar/dao.lex
@@ -21,6 +21,7 @@ Reserved keywords:
 
 Reserved punctuation/operators:
 - :
+- ::
 - ->
 - =>
 - =


### PR DESCRIPTION
## Summary

Add `::` as a first-class lexer token for namespace/module path qualification, distinct from `:` (type annotation / block introducer). Capture long-term design doctrine covering stdlib posture, module system, and GPU-through-modes strategy in `language_vision.md`.

## Highlights

- Add `ColonColon` variant to `TokenKind` with lookahead disambiguation from `Colon`
- Update `spec/grammar/dao.lex`, `CONTRACT_SYNTAX_SURFACE.md`, and `CONTRACT_LANGUAGE_TOOLING.md`
- Add `operator.namespace` to the frozen semantic token taxonomy
- Add `Namespace Qualification` section to syntax surface contract establishing `::` vs `.` distinction
- Expand `language_vision.md` with design doctrine, stdlib layering (small stdlib / large platform), module/namespace design (`::` paths, visibility tiers), and GPU-through-modes strategy
- Add `ARCH_INDEX.md` entry for `language_vision.md`
- Add disambiguation test verifying `:` vs `::` in mixed contexts (`x: int32` + `net::http::get`)

## Test plan

- [x] All existing lexer tests pass
- [x] New `colon vs coloncolon disambiguation` test validates mixed `:` / `::` contexts
- [x] Updated `all operators recognized` test covers 22 operators including `ColonColon`
- [x] `daoc lex` correctly emits `ColonColon` for `import net::http`
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)