### PR TITLE
feat(parser): ✨ add recursive descent parser with arena-allocated AST

### DIFF
--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -67,11 +67,6 @@ void cmd_parse(const std::filesystem::path& path) {
 
   auto parse_result = dao::parse(lex_result.tokens);
 
-  if (parse_result.file != nullptr) {
-    std::cout << "File: " << parse_result.file->imports().size() << " imports, "
-              << parse_result.file->declarations().size() << " declarations\n";
-  }
-
   if (!parse_result.diagnostics.empty()) {
     for (const auto& diag : parse_result.diagnostics) {
       auto loc = source.line_col(diag.span.offset);
@@ -79,6 +74,11 @@ void cmd_parse(const std::filesystem::path& path) {
                 << ": error: " << diag.message << "\n";
     }
     std::exit(EXIT_FAILURE);
+  }
+
+  if (parse_result.file != nullptr) {
+    std::cout << "File: " << parse_result.file->imports().size() << " imports, "
+              << parse_result.file->declarations().size() << " declarations\n";
   }
 }
 

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -1,4 +1,5 @@
 #include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -49,12 +50,34 @@ void cmd_lex(const std::filesystem::path& path) {
   }
 }
 
+// Debug-only parse diagnostic dump. Output format is not stable.
+void cmd_parse(const std::filesystem::path& path) {
+  auto contents = read_file(path);
+  dao::SourceBuffer source(path.filename().string(), std::move(contents));
+  auto lex_result = dao::lex(source);
+  auto parse_result = dao::parse(lex_result.tokens);
+
+  if (parse_result.file != nullptr) {
+    std::cout << "File: " << parse_result.file->imports().size() << " imports, "
+              << parse_result.file->declarations().size() << " declarations\n";
+  }
+
+  if (!parse_result.diagnostics.empty()) {
+    for (const auto& diag : parse_result.diagnostics) {
+      auto loc = source.line_col(diag.span.offset);
+      std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+                << ": error: " << diag.message << "\n";
+    }
+    std::exit(EXIT_FAILURE);
+  }
+}
+
 } // namespace
 
 auto main(int argc, char* argv[]) -> int {
   if (argc < 2) {
     std::cerr << "usage: daoc <command> <file>\n";
-    std::cerr << "commands: lex\n";
+    std::cerr << "commands: lex, parse\n";
     return EXIT_FAILURE;
   }
 
@@ -72,6 +95,21 @@ auto main(int argc, char* argv[]) -> int {
       return EXIT_FAILURE;
     }
     cmd_lex(path);
+    return EXIT_SUCCESS;
+  }
+
+  // daoc parse <file>
+  if (arg1 == "parse") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc parse <file>\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path parse_path(argv[2]);
+    if (!std::filesystem::exists(parse_path)) {
+      std::cerr << "error: file not found: " << parse_path << "\n";
+      return EXIT_FAILURE;
+    }
+    cmd_parse(parse_path);
     return EXIT_SUCCESS;
   }
 

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -55,6 +55,16 @@ void cmd_parse(const std::filesystem::path& path) {
   auto contents = read_file(path);
   dao::SourceBuffer source(path.filename().string(), std::move(contents));
   auto lex_result = dao::lex(source);
+
+  if (!lex_result.diagnostics.empty()) {
+    for (const auto& diag : lex_result.diagnostics) {
+      auto loc = source.line_col(diag.span.offset);
+      std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+                << ": error: " << diag.message << "\n";
+    }
+    std::exit(EXIT_FAILURE);
+  }
+
   auto parse_result = dao::parse(lex_result.tokens);
 
   if (parse_result.file != nullptr) {

--- a/compiler/frontend/CMakeLists.txt
+++ b/compiler/frontend/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(dao_frontend STATIC
+  ast/ast.cpp
   lexer/lexer.cpp
+  parser/parser.cpp
 )
 
 target_include_directories(dao_frontend PUBLIC
@@ -19,5 +21,16 @@ target_compile_definitions(lexer_test PRIVATE
   DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
+add_executable(parser_test
+  parser/parser_test.cpp
+)
+
+target_link_libraries(parser_test PRIVATE dao_frontend Boost::ut)
+
+target_compile_definitions(parser_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
 include(CTest)
 add_test(NAME lexer_test COMMAND lexer_test)
+add_test(NAME parser_test COMMAND parser_test)

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -1,0 +1,72 @@
+#include "frontend/ast/ast.h"
+
+namespace dao {
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+auto node_kind_name(NodeKind kind) -> const char* {
+  switch (kind) {
+  case NodeKind::File:
+    return "File";
+  case NodeKind::Import:
+    return "Import";
+  case NodeKind::FunctionDecl:
+    return "FunctionDecl";
+  case NodeKind::StructDecl:
+    return "StructDecl";
+  case NodeKind::AliasDecl:
+    return "AliasDecl";
+  case NodeKind::LetStatement:
+    return "LetStatement";
+  case NodeKind::Assignment:
+    return "Assignment";
+  case NodeKind::IfStatement:
+    return "IfStatement";
+  case NodeKind::WhileStatement:
+    return "WhileStatement";
+  case NodeKind::ForStatement:
+    return "ForStatement";
+  case NodeKind::ModeBlock:
+    return "ModeBlock";
+  case NodeKind::ResourceBlock:
+    return "ResourceBlock";
+  case NodeKind::ReturnStatement:
+    return "ReturnStatement";
+  case NodeKind::ExpressionStatement:
+    return "ExpressionStatement";
+  case NodeKind::BinaryExpr:
+    return "BinaryExpr";
+  case NodeKind::UnaryExpr:
+    return "UnaryExpr";
+  case NodeKind::CallExpr:
+    return "CallExpr";
+  case NodeKind::IndexExpr:
+    return "IndexExpr";
+  case NodeKind::FieldExpr:
+    return "FieldExpr";
+  case NodeKind::PipeExpr:
+    return "PipeExpr";
+  case NodeKind::Lambda:
+    return "Lambda";
+  case NodeKind::IntLiteral:
+    return "IntLiteral";
+  case NodeKind::FloatLiteral:
+    return "FloatLiteral";
+  case NodeKind::StringLiteral:
+    return "StringLiteral";
+  case NodeKind::BoolLiteral:
+    return "BoolLiteral";
+  case NodeKind::ListLiteral:
+    return "ListLiteral";
+  case NodeKind::Identifier:
+    return "Identifier";
+  case NodeKind::QualifiedName:
+    return "QualifiedName";
+  case NodeKind::NamedType:
+    return "NamedType";
+  case NodeKind::PointerType:
+    return "PointerType";
+  }
+  return "Unknown";
+}
+
+} // namespace dao

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -1,0 +1,878 @@
+#ifndef DAO_FRONTEND_AST_AST_H
+#define DAO_FRONTEND_AST_AST_H
+
+#include "frontend/diagnostics/source.h"
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <ranges>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Arena allocator — owns all AST nodes for a compilation unit.
+// ---------------------------------------------------------------------------
+
+class AstContext {
+public:
+  AstContext() = default;
+  ~AstContext() {
+    // Destruct in reverse allocation order.
+    for (auto& dtor : std::ranges::reverse_view(dtors_)) {
+      dtor();
+    }
+    for (auto* block : blocks_) {
+      ::operator delete(block);
+    }
+  }
+
+  AstContext(const AstContext&) = delete;
+  auto operator=(const AstContext&) -> AstContext& = delete;
+
+  AstContext(AstContext&& other) noexcept
+      : blocks_(std::move(other.blocks_)), offset_(other.offset_), dtors_(std::move(other.dtors_)) {
+    other.blocks_.clear();
+    other.offset_ = kBlockSize;
+    other.dtors_.clear();
+  }
+
+  auto operator=(AstContext&& other) noexcept -> AstContext& {
+    if (this != &other) {
+      // Destroy current contents first.
+      for (auto& dtor : std::ranges::reverse_view(dtors_)) {
+        dtor();
+      }
+      for (auto* block : blocks_) {
+        ::operator delete(block);
+      }
+      blocks_ = std::move(other.blocks_);
+      offset_ = other.offset_;
+      dtors_ = std::move(other.dtors_);
+      other.blocks_.clear();
+      other.offset_ = kBlockSize;
+      other.dtors_.clear();
+    }
+    return *this;
+  }
+
+  template <typename T, typename... Args> auto alloc(Args&&... args) -> T* {
+    void* mem = allocate(sizeof(T), alignof(T));
+    auto* ptr = new (mem) T(std::forward<Args>(args)...);
+    if constexpr (!std::is_trivially_destructible_v<T>) {
+      dtors_.push_back([ptr]() { ptr->~T(); }); // NOLINT(modernize-use-trailing-return-type)
+    }
+    return ptr;
+  }
+
+private:
+  static constexpr size_t kBlockSize = 4096;
+
+  struct Block {
+    char data[kBlockSize]; // NOLINT(modernize-avoid-c-arrays)
+  };
+
+  std::vector<Block*> blocks_;
+  size_t offset_ = kBlockSize; // Force first allocation to create a block.
+  std::vector<std::function<void()>> dtors_;
+
+  auto allocate(size_t size, size_t align) -> void* {
+    // Align up.
+    offset_ = (offset_ + align - 1) & ~(align - 1);
+    if (offset_ + size > kBlockSize) {
+      if (size > kBlockSize) {
+        // Oversized allocation — give it its own block.
+        auto* mem = ::operator new(size);
+        blocks_.push_back(static_cast<Block*>(mem));
+        return mem;
+      }
+      blocks_.push_back(new Block);
+      offset_ = 0;
+    }
+    void* ptr =
+        blocks_.back()->data + offset_; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    offset_ += size;
+    return ptr;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Node kind tags
+// ---------------------------------------------------------------------------
+
+enum class NodeKind : std::uint8_t {
+  // File
+  File,
+  Import,
+
+  // Declarations
+  FunctionDecl,
+  StructDecl,
+  AliasDecl,
+
+  // Statements
+  LetStatement,
+  Assignment,
+  IfStatement,
+  WhileStatement,
+  ForStatement,
+  ModeBlock,
+  ResourceBlock,
+  ReturnStatement,
+  ExpressionStatement,
+
+  // Expressions
+  BinaryExpr,
+  UnaryExpr,
+  CallExpr,
+  IndexExpr,
+  FieldExpr,
+  PipeExpr,
+  Lambda,
+  IntLiteral,
+  FloatLiteral,
+  StringLiteral,
+  BoolLiteral,
+  ListLiteral,
+  Identifier,
+  QualifiedName,
+
+  // Types
+  NamedType,
+  PointerType,
+};
+
+// ---------------------------------------------------------------------------
+// Base classes
+// ---------------------------------------------------------------------------
+
+class AstNode {
+public:
+  explicit AstNode(NodeKind kind, Span span) : kind_(kind), span_(span) {
+  }
+  virtual ~AstNode() = default;
+
+  AstNode(const AstNode&) = delete;
+  auto operator=(const AstNode&) -> AstNode& = delete;
+  AstNode(AstNode&&) = delete;
+  auto operator=(AstNode&&) -> AstNode& = delete;
+
+  [[nodiscard]] auto kind() const -> NodeKind {
+    return kind_;
+  }
+  [[nodiscard]] auto span() const -> Span {
+    return span_;
+  }
+
+protected:
+  void set_span(Span span) {
+    span_ = span;
+  }
+
+private:
+  NodeKind kind_;
+  Span span_;
+};
+
+class Decl : public AstNode {
+public:
+  using AstNode::AstNode;
+  static auto classof(const AstNode* node) -> bool {
+    return node->kind() >= NodeKind::FunctionDecl && node->kind() <= NodeKind::AliasDecl;
+  }
+};
+
+class Stmt : public AstNode {
+public:
+  using AstNode::AstNode;
+  static auto classof(const AstNode* node) -> bool {
+    return node->kind() >= NodeKind::LetStatement && node->kind() <= NodeKind::ExpressionStatement;
+  }
+};
+
+class Expr : public AstNode {
+public:
+  using AstNode::AstNode;
+  static auto classof(const AstNode* node) -> bool {
+    return node->kind() >= NodeKind::BinaryExpr && node->kind() <= NodeKind::QualifiedName;
+  }
+};
+
+class TypeNode : public AstNode {
+public:
+  using AstNode::AstNode;
+  static auto classof(const AstNode* node) -> bool {
+    return node->kind() >= NodeKind::NamedType && node->kind() <= NodeKind::PointerType;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Utility types
+// ---------------------------------------------------------------------------
+
+struct QualifiedPath {
+  std::vector<std::string_view> segments;
+  Span span;
+};
+
+struct Param {
+  std::string_view name;
+  Span name_span;
+  TypeNode* type;
+};
+
+// ---------------------------------------------------------------------------
+// Binary / Unary operator tags
+// ---------------------------------------------------------------------------
+
+enum class BinaryOp : std::uint8_t {
+  Add,    // +
+  Sub,    // -
+  Mul,    // *
+  Div,    // /
+  Mod,    // %
+  EqEq,   // ==
+  BangEq, // !=
+  Lt,     // <
+  LtEq,   // <=
+  Gt,     // >
+  GtEq,   // >=
+  And,    // and
+  Or,     // or
+};
+
+enum class UnaryOp : std::uint8_t {
+  Negate, // -
+  Not,    // !
+  Deref,  // *
+  AddrOf, // &
+};
+
+// ---------------------------------------------------------------------------
+// File-level nodes
+// ---------------------------------------------------------------------------
+
+class FileNode : public AstNode {
+public:
+  FileNode(Span span, std::vector<AstNode*> imports, std::vector<Decl*> declarations)
+      : AstNode(NodeKind::File, span), imports_(std::move(imports)),
+        declarations_(std::move(declarations)) {
+  }
+
+  [[nodiscard]] auto imports() const -> const std::vector<AstNode*>& {
+    return imports_;
+  }
+  [[nodiscard]] auto declarations() const -> const std::vector<Decl*>& {
+    return declarations_;
+  }
+
+private:
+  std::vector<AstNode*> imports_;
+  std::vector<Decl*> declarations_;
+};
+
+class ImportNode : public AstNode {
+public:
+  ImportNode(Span span, QualifiedPath path)
+      : AstNode(NodeKind::Import, span), path_(std::move(path)) {
+  }
+
+  [[nodiscard]] auto path() const -> const QualifiedPath& {
+    return path_;
+  }
+
+private:
+  QualifiedPath path_;
+};
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+class FunctionDeclNode : public Decl {
+public:
+  FunctionDeclNode(Span span,
+                   std::string_view name,
+                   Span name_span,
+                   std::vector<Param> params,
+                   TypeNode* return_type,
+                   std::vector<Stmt*> body,
+                   Expr* expr_body)
+      : Decl(NodeKind::FunctionDecl, span), name_(name), name_span_(name_span),
+        params_(std::move(params)), return_type_(return_type), body_(std::move(body)),
+        expr_body_(expr_body) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view {
+    return name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto params() const -> const std::vector<Param>& {
+    return params_;
+  }
+  [[nodiscard]] auto return_type() const -> TypeNode* {
+    return return_type_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
+    return body_;
+  }
+  [[nodiscard]] auto expr_body() const -> Expr* {
+    return expr_body_;
+  }
+  [[nodiscard]] auto is_expr_bodied() const -> bool {
+    return expr_body_ != nullptr;
+  }
+
+private:
+  std::string_view name_;
+  Span name_span_;
+  std::vector<Param> params_;
+  TypeNode* return_type_;   // nullable
+  std::vector<Stmt*> body_; // empty if expression-bodied
+  Expr* expr_body_;         // nullptr if block-bodied
+};
+
+class StructDeclNode : public Decl {
+public:
+  StructDeclNode(Span span, std::string_view name, Span name_span, std::vector<Stmt*> members)
+      : Decl(NodeKind::StructDecl, span), name_(name), name_span_(name_span),
+        members_(std::move(members)) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view {
+    return name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto members() const -> const std::vector<Stmt*>& {
+    return members_;
+  }
+
+private:
+  std::string_view name_;
+  Span name_span_;
+  std::vector<Stmt*> members_;
+};
+
+class AliasDeclNode : public Decl {
+public:
+  AliasDeclNode(Span span, std::string_view name, Span name_span, TypeNode* type)
+      : Decl(NodeKind::AliasDecl, span), name_(name), name_span_(name_span), type_(type) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view {
+    return name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto type() const -> TypeNode* {
+    return type_;
+  }
+
+private:
+  std::string_view name_;
+  Span name_span_;
+  TypeNode* type_;
+};
+
+// ---------------------------------------------------------------------------
+// Statements
+// ---------------------------------------------------------------------------
+
+class LetStatementNode : public Stmt {
+public:
+  LetStatementNode(
+      Span span, std::string_view name, Span name_span, TypeNode* type, Expr* initializer)
+      : Stmt(NodeKind::LetStatement, span), name_(name), name_span_(name_span), type_(type),
+        initializer_(initializer) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view {
+    return name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto type() const -> TypeNode* {
+    return type_;
+  }
+  [[nodiscard]] auto initializer() const -> Expr* {
+    return initializer_;
+  }
+
+private:
+  std::string_view name_;
+  Span name_span_;
+  TypeNode* type_;    // nullable
+  Expr* initializer_; // nullable
+};
+
+class AssignmentNode : public Stmt {
+public:
+  AssignmentNode(Span span, Expr* target, Expr* value)
+      : Stmt(NodeKind::Assignment, span), target_(target), value_(value) {
+  }
+
+  [[nodiscard]] auto target() const -> Expr* {
+    return target_;
+  }
+  [[nodiscard]] auto value() const -> Expr* {
+    return value_;
+  }
+
+private:
+  Expr* target_;
+  Expr* value_;
+};
+
+class IfStatementNode : public Stmt {
+public:
+  IfStatementNode(Span span,
+                  Expr* condition,
+                  std::vector<Stmt*> then_body,
+                  std::vector<Stmt*> else_body)
+      : Stmt(NodeKind::IfStatement, span), condition_(condition), then_body_(std::move(then_body)),
+        else_body_(std::move(else_body)) {
+  }
+
+  [[nodiscard]] auto condition() const -> Expr* {
+    return condition_;
+  }
+  [[nodiscard]] auto then_body() const -> const std::vector<Stmt*>& {
+    return then_body_;
+  }
+  [[nodiscard]] auto else_body() const -> const std::vector<Stmt*>& {
+    return else_body_;
+  }
+  [[nodiscard]] auto has_else() const -> bool {
+    return !else_body_.empty();
+  }
+
+private:
+  Expr* condition_;
+  std::vector<Stmt*> then_body_;
+  std::vector<Stmt*> else_body_;
+};
+
+class WhileStatementNode : public Stmt {
+public:
+  WhileStatementNode(Span span, Expr* condition, std::vector<Stmt*> body)
+      : Stmt(NodeKind::WhileStatement, span), condition_(condition), body_(std::move(body)) {
+  }
+
+  [[nodiscard]] auto condition() const -> Expr* {
+    return condition_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
+    return body_;
+  }
+
+private:
+  Expr* condition_;
+  std::vector<Stmt*> body_;
+};
+
+class ForStatementNode : public Stmt {
+public:
+  ForStatementNode(
+      Span span, std::string_view var, Span var_span, Expr* iterable, std::vector<Stmt*> body)
+      : Stmt(NodeKind::ForStatement, span), var_(var), var_span_(var_span), iterable_(iterable),
+        body_(std::move(body)) {
+  }
+
+  [[nodiscard]] auto var() const -> std::string_view {
+    return var_;
+  }
+  [[nodiscard]] auto var_span() const -> Span {
+    return var_span_;
+  }
+  [[nodiscard]] auto iterable() const -> Expr* {
+    return iterable_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
+    return body_;
+  }
+
+private:
+  std::string_view var_;
+  Span var_span_;
+  Expr* iterable_;
+  std::vector<Stmt*> body_;
+};
+
+class ModeBlockNode : public Stmt {
+public:
+  ModeBlockNode(Span span, std::string_view mode_name, Span name_span, std::vector<Stmt*> body)
+      : Stmt(NodeKind::ModeBlock, span), mode_name_(mode_name), name_span_(name_span),
+        body_(std::move(body)) {
+  }
+
+  [[nodiscard]] auto mode_name() const -> std::string_view {
+    return mode_name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
+    return body_;
+  }
+
+private:
+  std::string_view mode_name_;
+  Span name_span_;
+  std::vector<Stmt*> body_;
+};
+
+class ResourceBlockNode : public Stmt {
+public:
+  ResourceBlockNode(Span span,
+                    std::string_view resource_kind,
+                    Span kind_span,
+                    std::string_view resource_name,
+                    Span name_span,
+                    std::vector<Stmt*> body)
+      : Stmt(NodeKind::ResourceBlock, span), resource_kind_(resource_kind), kind_span_(kind_span),
+        resource_name_(resource_name), name_span_(name_span), body_(std::move(body)) {
+  }
+
+  [[nodiscard]] auto resource_kind() const -> std::string_view {
+    return resource_kind_;
+  }
+  [[nodiscard]] auto kind_span() const -> Span {
+    return kind_span_;
+  }
+  [[nodiscard]] auto resource_name() const -> std::string_view {
+    return resource_name_;
+  }
+  [[nodiscard]] auto name_span() const -> Span {
+    return name_span_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
+    return body_;
+  }
+
+private:
+  std::string_view resource_kind_;
+  Span kind_span_;
+  std::string_view resource_name_;
+  Span name_span_;
+  std::vector<Stmt*> body_;
+};
+
+class ReturnStatementNode : public Stmt {
+public:
+  ReturnStatementNode(Span span, Expr* value)
+      : Stmt(NodeKind::ReturnStatement, span), value_(value) {
+  }
+
+  [[nodiscard]] auto value() const -> Expr* {
+    return value_;
+  }
+
+private:
+  Expr* value_;
+};
+
+class ExpressionStatementNode : public Stmt {
+public:
+  ExpressionStatementNode(Span span, Expr* expr)
+      : Stmt(NodeKind::ExpressionStatement, span), expr_(expr) {
+  }
+
+  [[nodiscard]] auto expr() const -> Expr* {
+    return expr_;
+  }
+
+private:
+  Expr* expr_;
+};
+
+// ---------------------------------------------------------------------------
+// Expressions
+// ---------------------------------------------------------------------------
+
+class BinaryExprNode : public Expr {
+public:
+  // NOLINTNEXTLINE(readability-identifier-length)
+  BinaryExprNode(Span span, BinaryOp op, Expr* left, Expr* right)
+      : Expr(NodeKind::BinaryExpr, span), op_(op), left_(left), right_(right) {
+  }
+
+  [[nodiscard]] auto op() const -> BinaryOp {
+    return op_;
+  }
+  [[nodiscard]] auto left() const -> Expr* {
+    return left_;
+  }
+  [[nodiscard]] auto right() const -> Expr* {
+    return right_;
+  }
+
+private:
+  BinaryOp op_;
+  Expr* left_;
+  Expr* right_;
+};
+
+class UnaryExprNode : public Expr {
+public:
+  // NOLINTNEXTLINE(readability-identifier-length)
+  UnaryExprNode(Span span, UnaryOp op, Expr* operand)
+      : Expr(NodeKind::UnaryExpr, span), op_(op), operand_(operand) {
+  }
+
+  [[nodiscard]] auto op() const -> UnaryOp {
+    return op_;
+  }
+  [[nodiscard]] auto operand() const -> Expr* {
+    return operand_;
+  }
+
+private:
+  UnaryOp op_;
+  Expr* operand_;
+};
+
+class CallExprNode : public Expr {
+public:
+  CallExprNode(Span span, Expr* callee, std::vector<Expr*> args)
+      : Expr(NodeKind::CallExpr, span), callee_(callee), args_(std::move(args)) {
+  }
+
+  [[nodiscard]] auto callee() const -> Expr* {
+    return callee_;
+  }
+  [[nodiscard]] auto args() const -> const std::vector<Expr*>& {
+    return args_;
+  }
+
+private:
+  Expr* callee_;
+  std::vector<Expr*> args_;
+};
+
+class IndexExprNode : public Expr {
+public:
+  IndexExprNode(Span span, Expr* object, std::vector<Expr*> indices)
+      : Expr(NodeKind::IndexExpr, span), object_(object), indices_(std::move(indices)) {
+  }
+
+  [[nodiscard]] auto object() const -> Expr* {
+    return object_;
+  }
+  [[nodiscard]] auto indices() const -> const std::vector<Expr*>& {
+    return indices_;
+  }
+
+private:
+  Expr* object_;
+  std::vector<Expr*> indices_;
+};
+
+class FieldExprNode : public Expr {
+public:
+  FieldExprNode(Span span, Expr* object, std::string_view field, Span field_span)
+      : Expr(NodeKind::FieldExpr, span), object_(object), field_(field), field_span_(field_span) {
+  }
+
+  [[nodiscard]] auto object() const -> Expr* {
+    return object_;
+  }
+  [[nodiscard]] auto field() const -> std::string_view {
+    return field_;
+  }
+  [[nodiscard]] auto field_span() const -> Span {
+    return field_span_;
+  }
+
+private:
+  Expr* object_;
+  std::string_view field_;
+  Span field_span_;
+};
+
+class PipeExprNode : public Expr {
+public:
+  PipeExprNode(Span span, Expr* left, Expr* right)
+      : Expr(NodeKind::PipeExpr, span), left_(left), right_(right) {
+  }
+
+  [[nodiscard]] auto left() const -> Expr* {
+    return left_;
+  }
+  [[nodiscard]] auto right() const -> Expr* {
+    return right_;
+  }
+
+private:
+  Expr* left_;
+  Expr* right_;
+};
+
+class LambdaNode : public Expr {
+public:
+  LambdaNode(Span span, std::vector<std::pair<std::string_view, Span>> params, Expr* body)
+      : Expr(NodeKind::Lambda, span), params_(std::move(params)), body_(body) {
+  }
+
+  [[nodiscard]] auto params() const -> const std::vector<std::pair<std::string_view, Span>>& {
+    return params_;
+  }
+  [[nodiscard]] auto body() const -> Expr* {
+    return body_;
+  }
+
+private:
+  std::vector<std::pair<std::string_view, Span>> params_;
+  Expr* body_;
+};
+
+class IntLiteralNode : public Expr {
+public:
+  IntLiteralNode(Span span, std::string_view text) : Expr(NodeKind::IntLiteral, span), text_(text) {
+  }
+
+  [[nodiscard]] auto text() const -> std::string_view {
+    return text_;
+  }
+
+private:
+  std::string_view text_;
+};
+
+class FloatLiteralNode : public Expr {
+public:
+  FloatLiteralNode(Span span, std::string_view text)
+      : Expr(NodeKind::FloatLiteral, span), text_(text) {
+  }
+
+  [[nodiscard]] auto text() const -> std::string_view {
+    return text_;
+  }
+
+private:
+  std::string_view text_;
+};
+
+class StringLiteralNode : public Expr {
+public:
+  StringLiteralNode(Span span, std::string_view text)
+      : Expr(NodeKind::StringLiteral, span), text_(text) {
+  }
+
+  [[nodiscard]] auto text() const -> std::string_view {
+    return text_;
+  }
+
+private:
+  std::string_view text_;
+};
+
+class BoolLiteralNode : public Expr {
+public:
+  BoolLiteralNode(Span span, bool value) : Expr(NodeKind::BoolLiteral, span), value_(value) {
+  }
+
+  [[nodiscard]] auto value() const -> bool {
+    return value_;
+  }
+
+private:
+  bool value_;
+};
+
+class ListLiteralNode : public Expr {
+public:
+  ListLiteralNode(Span span, std::vector<Expr*> elements)
+      : Expr(NodeKind::ListLiteral, span), elements_(std::move(elements)) {
+  }
+
+  [[nodiscard]] auto elements() const -> const std::vector<Expr*>& {
+    return elements_;
+  }
+
+private:
+  std::vector<Expr*> elements_;
+};
+
+class IdentifierNode : public Expr {
+public:
+  IdentifierNode(Span span, std::string_view name) : Expr(NodeKind::Identifier, span), name_(name) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view {
+    return name_;
+  }
+
+private:
+  std::string_view name_;
+};
+
+class QualifiedNameNode : public Expr {
+public:
+  QualifiedNameNode(Span span, std::vector<std::string_view> segments)
+      : Expr(NodeKind::QualifiedName, span), segments_(std::move(segments)) {
+  }
+
+  [[nodiscard]] auto segments() const -> const std::vector<std::string_view>& {
+    return segments_;
+  }
+
+private:
+  std::vector<std::string_view> segments_;
+};
+
+// ---------------------------------------------------------------------------
+// Type nodes
+// ---------------------------------------------------------------------------
+
+class NamedTypeNode : public TypeNode {
+public:
+  NamedTypeNode(Span span, QualifiedPath name, std::vector<TypeNode*> type_args)
+      : TypeNode(NodeKind::NamedType, span), name_(std::move(name)),
+        type_args_(std::move(type_args)) {
+  }
+
+  [[nodiscard]] auto name() const -> const QualifiedPath& {
+    return name_;
+  }
+  [[nodiscard]] auto type_args() const -> const std::vector<TypeNode*>& {
+    return type_args_;
+  }
+
+private:
+  QualifiedPath name_;
+  std::vector<TypeNode*> type_args_;
+};
+
+class PointerTypeNode : public TypeNode {
+public:
+  PointerTypeNode(Span span, TypeNode* pointee)
+      : TypeNode(NodeKind::PointerType, span), pointee_(pointee) {
+  }
+
+  [[nodiscard]] auto pointee() const -> TypeNode* {
+    return pointee_;
+  }
+
+private:
+  TypeNode* pointee_;
+};
+
+// ---------------------------------------------------------------------------
+// Convenience: node_kind_name
+// ---------------------------------------------------------------------------
+
+auto node_kind_name(NodeKind kind) -> const char*;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_AST_AST_H

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1,0 +1,852 @@
+#include "frontend/parser/parser.h"
+
+#include <string>
+
+namespace dao {
+
+namespace {
+
+// NOLINTBEGIN(readability-identifier-length)
+class ParserImpl {
+public:
+  explicit ParserImpl(const std::vector<Token>& tokens) : tokens_(tokens) {
+  }
+
+  auto run() -> ParseResult {
+    auto* file = parse_file();
+    return {.context = std::move(ctx_), .file = file, .diagnostics = std::move(diagnostics_)};
+  }
+
+private:
+  const std::vector<Token>& tokens_;
+  uint32_t pos_ = 0;
+  AstContext ctx_;
+  std::vector<Diagnostic> diagnostics_;
+  bool in_pipe_target_ = false;
+
+  // -----------------------------------------------------------------------
+  // Token access
+  // -----------------------------------------------------------------------
+
+  [[nodiscard]] auto peek() const -> const Token& {
+    return tokens_[pos_];
+  }
+
+  [[nodiscard]] auto peek_kind() const -> TokenKind {
+    return tokens_[pos_].kind;
+  }
+
+  [[nodiscard]] auto at_end() const -> bool {
+    return peek_kind() == TokenKind::Eof;
+  }
+
+  auto advance() -> const Token& {
+    const auto& tok = tokens_[pos_];
+    if (!at_end()) {
+      ++pos_;
+    }
+    return tok;
+  }
+
+  auto consume(TokenKind kind) -> const Token& {
+    if (peek_kind() != kind) {
+      error("expected " + std::string(token_kind_name(kind)) + ", got " +
+            std::string(token_kind_name(peek_kind())));
+    }
+    return advance();
+  }
+
+  auto match(TokenKind kind) -> bool {
+    if (peek_kind() == kind) {
+      advance();
+      return true;
+    }
+    return false;
+  }
+
+  void skip_newlines() {
+    while (peek_kind() == TokenKind::Newline) {
+      advance();
+    }
+  }
+
+  void error(const std::string& message) {
+    diagnostics_.push_back(Diagnostic::error(peek().span, message));
+  }
+
+  // -----------------------------------------------------------------------
+  // File
+  // -----------------------------------------------------------------------
+
+  auto parse_file() -> FileNode* {
+    skip_newlines();
+    Span file_span = peek().span;
+
+    std::vector<AstNode*> imports;
+    while (peek_kind() == TokenKind::KwImport) {
+      imports.push_back(parse_import());
+      skip_newlines();
+    }
+
+    std::vector<Decl*> declarations;
+    while (!at_end()) {
+      skip_newlines();
+      if (at_end()) {
+        break;
+      }
+      auto* decl = parse_declaration();
+      if (decl != nullptr) {
+        declarations.push_back(decl);
+      }
+      skip_newlines();
+    }
+
+    Span total = {.offset = file_span.offset, .length = peek().span.offset - file_span.offset};
+    return ctx_.alloc<FileNode>(total, std::move(imports), std::move(declarations));
+  }
+
+  // -----------------------------------------------------------------------
+  // Import
+  // -----------------------------------------------------------------------
+
+  auto parse_import() -> ImportNode* {
+    const auto& kw = consume(TokenKind::KwImport);
+    auto path = parse_module_path();
+    consume(TokenKind::Newline);
+    Span span = {.offset = kw.span.offset,
+                 .length = (path.span.offset + path.span.length) - kw.span.offset};
+    return ctx_.alloc<ImportNode>(span, std::move(path));
+  }
+
+  auto parse_module_path() -> QualifiedPath {
+    QualifiedPath path;
+    const auto& first = consume(TokenKind::Identifier);
+    path.segments.push_back(first.text);
+    path.span = first.span;
+
+    while (peek_kind() == TokenKind::ColonColon) {
+      advance(); // ::
+      const auto& seg = consume(TokenKind::Identifier);
+      path.segments.push_back(seg.text);
+      path.span.length = (seg.span.offset + seg.span.length) - path.span.offset;
+    }
+
+    return path;
+  }
+
+  // -----------------------------------------------------------------------
+  // Declarations
+  // -----------------------------------------------------------------------
+
+  auto parse_declaration() -> Decl* {
+    switch (peek_kind()) {
+    case TokenKind::KwFn:
+      return parse_function_decl();
+    case TokenKind::KwStruct:
+      return parse_struct_decl();
+    case TokenKind::KwType:
+      return parse_alias_decl();
+    default:
+      error("expected declaration (fn, struct, or type)");
+      advance(); // skip problematic token
+      return nullptr;
+    }
+  }
+
+  auto parse_function_decl() -> FunctionDeclNode* {
+    const auto& kw = consume(TokenKind::KwFn);
+    const auto& name_tok = consume(TokenKind::Identifier);
+
+    consume(TokenKind::LParen);
+    auto params = parse_params();
+    consume(TokenKind::RParen);
+
+    TypeNode* return_type = nullptr;
+    if (peek_kind() == TokenKind::Colon) {
+      advance(); // :
+      return_type = parse_type();
+    }
+
+    std::vector<Stmt*> body;
+    Expr* expr_body = nullptr;
+
+    if (peek_kind() == TokenKind::Arrow) {
+      // Expression-bodied: -> expression NEWLINE
+      advance(); // ->
+      expr_body = parse_expression();
+      // The trailing newline may have been consumed by pipe continuation.
+      match(TokenKind::Newline);
+    } else {
+      // Block-bodied: NEWLINE INDENT statement+ DEDENT
+      consume(TokenKind::Newline);
+      consume(TokenKind::Indent);
+      body = parse_statement_list();
+      consume(TokenKind::Dedent);
+    }
+
+    Span span = span_from(kw.span);
+    return ctx_.alloc<FunctionDeclNode>(span,
+                                        name_tok.text,
+                                        name_tok.span,
+                                        std::move(params),
+                                        return_type,
+                                        std::move(body),
+                                        expr_body);
+  }
+
+  auto parse_params() -> std::vector<Param> {
+    std::vector<Param> params;
+    if (peek_kind() == TokenKind::RParen) {
+      return params;
+    }
+    params.push_back(parse_param());
+    while (peek_kind() == TokenKind::Comma) {
+      advance(); // ,
+      params.push_back(parse_param());
+    }
+    return params;
+  }
+
+  auto parse_param() -> Param {
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::Colon);
+    auto* type = parse_type();
+    return {.name = name_tok.text, .name_span = name_tok.span, .type = type};
+  }
+
+  auto parse_struct_decl() -> StructDeclNode* {
+    const auto& kw = consume(TokenKind::KwStruct);
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::Colon);
+    auto members = parse_suite();
+    Span span = span_from(kw.span);
+    return ctx_.alloc<StructDeclNode>(span, name_tok.text, name_tok.span, std::move(members));
+  }
+
+  auto parse_alias_decl() -> AliasDeclNode* {
+    const auto& kw = consume(TokenKind::KwType);
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::Eq);
+    auto* type = parse_type();
+    consume(TokenKind::Newline);
+    Span span = span_from(kw.span);
+    return ctx_.alloc<AliasDeclNode>(span, name_tok.text, name_tok.span, type);
+  }
+
+  // -----------------------------------------------------------------------
+  // Suites and statements
+  // -----------------------------------------------------------------------
+
+  auto parse_suite() -> std::vector<Stmt*> {
+    consume(TokenKind::Newline);
+    consume(TokenKind::Indent);
+    auto stmts = parse_statement_list();
+    consume(TokenKind::Dedent);
+    return stmts;
+  }
+
+  auto parse_statement_list() -> std::vector<Stmt*> {
+    std::vector<Stmt*> stmts;
+    while (peek_kind() != TokenKind::Dedent && peek_kind() != TokenKind::Eof) {
+      skip_newlines();
+      if (peek_kind() == TokenKind::Dedent || peek_kind() == TokenKind::Eof) {
+        break;
+      }
+      auto* stmt = parse_statement();
+      if (stmt != nullptr) {
+        stmts.push_back(stmt);
+      }
+    }
+    return stmts;
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  auto parse_statement() -> Stmt* {
+    switch (peek_kind()) {
+    case TokenKind::KwLet:
+      return parse_let_statement();
+    case TokenKind::KwIf:
+      return parse_if_statement();
+    case TokenKind::KwWhile:
+      return parse_while_statement();
+    case TokenKind::KwFor:
+      return parse_for_statement();
+    case TokenKind::KwMode:
+      return parse_mode_block();
+    case TokenKind::KwResource:
+      return parse_resource_block();
+    case TokenKind::KwReturn:
+      return parse_return_statement();
+    default:
+      break;
+    }
+
+    // Expression or assignment.
+    auto* expr = parse_expression();
+    if (expr == nullptr) {
+      advance();
+      return nullptr;
+    }
+
+    // Check for assignment: expr = expr
+    if (peek_kind() == TokenKind::Eq) {
+      advance(); // =
+      auto* value = parse_expression();
+      consume(TokenKind::Newline);
+      Span span = {.offset = expr->span().offset,
+                   .length = (value->span().offset + value->span().length) - expr->span().offset};
+      return ctx_.alloc<AssignmentNode>(span, expr, value);
+    }
+
+    consume(TokenKind::Newline);
+    return ctx_.alloc<ExpressionStatementNode>(expr->span(), expr);
+  }
+
+  auto parse_let_statement() -> LetStatementNode* {
+    const auto& kw = consume(TokenKind::KwLet);
+    const auto& name_tok = consume(TokenKind::Identifier);
+
+    TypeNode* type = nullptr;
+    Expr* init = nullptr;
+
+    if (peek_kind() == TokenKind::Colon) {
+      advance(); // :
+      type = parse_type();
+      if (peek_kind() == TokenKind::Eq) {
+        advance(); // =
+        init = parse_expression();
+      }
+    } else if (peek_kind() == TokenKind::Eq) {
+      advance(); // =
+      init = parse_expression();
+    } else {
+      error("expected ':' or '=' after let binding name");
+    }
+
+    consume(TokenKind::Newline);
+    Span span = span_from(kw.span);
+    return ctx_.alloc<LetStatementNode>(span, name_tok.text, name_tok.span, type, init);
+  }
+
+  auto parse_if_statement() -> IfStatementNode* {
+    const auto& kw = consume(TokenKind::KwIf);
+    auto* condition = parse_expression();
+    consume(TokenKind::Colon);
+    auto then_body = parse_suite();
+
+    std::vector<Stmt*> else_body;
+    if (peek_kind() == TokenKind::KwElse) {
+      advance(); // else
+      consume(TokenKind::Colon);
+      else_body = parse_suite();
+    }
+
+    Span span = span_from(kw.span);
+    return ctx_.alloc<IfStatementNode>(span, condition, std::move(then_body), std::move(else_body));
+  }
+
+  auto parse_while_statement() -> WhileStatementNode* {
+    const auto& kw = consume(TokenKind::KwWhile);
+    auto* condition = parse_expression();
+    consume(TokenKind::Colon);
+    auto body = parse_suite();
+    Span span = span_from(kw.span);
+    return ctx_.alloc<WhileStatementNode>(span, condition, std::move(body));
+  }
+
+  auto parse_for_statement() -> ForStatementNode* {
+    const auto& kw = consume(TokenKind::KwFor);
+    const auto& var_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::KwIn);
+    auto* iterable = parse_expression();
+    consume(TokenKind::Colon);
+    auto body = parse_suite();
+    Span span = span_from(kw.span);
+    return ctx_.alloc<ForStatementNode>(
+        span, var_tok.text, var_tok.span, iterable, std::move(body));
+  }
+
+  auto parse_mode_block() -> ModeBlockNode* {
+    const auto& kw = consume(TokenKind::KwMode);
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::FatArrow);
+    auto body = parse_suite();
+    Span span = span_from(kw.span);
+    return ctx_.alloc<ModeBlockNode>(span, name_tok.text, name_tok.span, std::move(body));
+  }
+
+  auto parse_resource_block() -> ResourceBlockNode* {
+    const auto& kw = consume(TokenKind::KwResource);
+    const auto& kind_tok = consume(TokenKind::Identifier);
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::FatArrow);
+    auto body = parse_suite();
+    Span span = span_from(kw.span);
+    return ctx_.alloc<ResourceBlockNode>(
+        span, kind_tok.text, kind_tok.span, name_tok.text, name_tok.span, std::move(body));
+  }
+
+  auto parse_return_statement() -> ReturnStatementNode* {
+    const auto& kw = consume(TokenKind::KwReturn);
+    auto* value = parse_expression();
+    consume(TokenKind::Newline);
+    Span span = span_from(kw.span);
+    return ctx_.alloc<ReturnStatementNode>(span, value);
+  }
+
+  // -----------------------------------------------------------------------
+  // Expressions — precedence climbing
+  // -----------------------------------------------------------------------
+
+  auto parse_expression() -> Expr* {
+    return parse_pipe_expression();
+  }
+
+  auto parse_pipe_expression() -> Expr* {
+    auto* left = parse_logical_or();
+
+    // Track whether we consumed an INDENT for pipe continuation so we
+    // can consume the matching DEDENT when the chain ends.
+    int pipe_indents = 0;
+
+    while (is_pipe_continuation()) {
+      // Consume whitespace tokens before |>.
+      if (peek_kind() == TokenKind::Newline) {
+        advance();
+      }
+      if (peek_kind() == TokenKind::Indent) {
+        advance();
+        pipe_indents++;
+      }
+      advance(); // |>
+      Expr* right = nullptr;
+      if (peek_kind() == TokenKind::Pipe) {
+        right = parse_lambda();
+      } else {
+        in_pipe_target_ = true;
+        right = parse_application();
+        in_pipe_target_ = false;
+      }
+      Span span = {.offset = left->span().offset,
+                   .length = (right->span().offset + right->span().length) - left->span().offset};
+      left = ctx_.alloc<PipeExprNode>(span, left, right);
+    }
+
+    // Consume matching DEDENTs for pipe continuation indents.
+    for (int i = 0; i < pipe_indents; ++i) {
+      // There may be a Newline before DEDENT.
+      if (peek_kind() == TokenKind::Newline) {
+        advance();
+      }
+      if (peek_kind() == TokenKind::Dedent) {
+        advance();
+      }
+    }
+
+    return left;
+  }
+
+  [[nodiscard]] auto is_pipe_continuation() const -> bool {
+    if (peek_kind() == TokenKind::PipeGt) {
+      return true;
+    }
+    // Check for newline (optionally followed by indent) then |>.
+    uint32_t look = pos_;
+    if (look < tokens_.size() && tokens_[look].kind == TokenKind::Newline) {
+      ++look;
+    } else {
+      return false;
+    }
+    if (look < tokens_.size() && tokens_[look].kind == TokenKind::Indent) {
+      ++look;
+    }
+    return look < tokens_.size() && tokens_[look].kind == TokenKind::PipeGt;
+  }
+
+  auto parse_logical_or() -> Expr* {
+    auto* left = parse_logical_and();
+    while (peek_kind() == TokenKind::KwOr) {
+      advance();
+      auto* right = parse_logical_and();
+      left = make_binary(BinaryOp::Or, left, right);
+    }
+    return left;
+  }
+
+  auto parse_logical_and() -> Expr* {
+    auto* left = parse_equality();
+    while (peek_kind() == TokenKind::KwAnd) {
+      advance();
+      auto* right = parse_equality();
+      left = make_binary(BinaryOp::And, left, right);
+    }
+    return left;
+  }
+
+  auto parse_equality() -> Expr* {
+    auto* left = parse_relational();
+    while (peek_kind() == TokenKind::EqEq || peek_kind() == TokenKind::BangEq) {
+      auto op = peek_kind() == TokenKind::EqEq ? BinaryOp::EqEq : BinaryOp::BangEq;
+      advance();
+      auto* right = parse_relational();
+      left = make_binary(op, left, right);
+    }
+    return left;
+  }
+
+  auto parse_relational() -> Expr* {
+    auto* left = parse_additive();
+    while (peek_kind() == TokenKind::Lt || peek_kind() == TokenKind::Gt ||
+           peek_kind() == TokenKind::LtEq || peek_kind() == TokenKind::GtEq) {
+      BinaryOp op{};
+      switch (peek_kind()) {
+      case TokenKind::Lt:
+        op = BinaryOp::Lt;
+        break;
+      case TokenKind::Gt:
+        op = BinaryOp::Gt;
+        break;
+      case TokenKind::LtEq:
+        op = BinaryOp::LtEq;
+        break;
+      case TokenKind::GtEq:
+        op = BinaryOp::GtEq;
+        break;
+      default:
+        break;
+      }
+      advance();
+      auto* right = parse_additive();
+      left = make_binary(op, left, right);
+    }
+    return left;
+  }
+
+  auto parse_additive() -> Expr* {
+    auto* left = parse_multiplicative();
+    while (peek_kind() == TokenKind::Plus || peek_kind() == TokenKind::Minus) {
+      auto op = peek_kind() == TokenKind::Plus ? BinaryOp::Add : BinaryOp::Sub;
+      advance();
+      auto* right = parse_multiplicative();
+      left = make_binary(op, left, right);
+    }
+    return left;
+  }
+
+  auto parse_multiplicative() -> Expr* {
+    auto* left = parse_unary();
+    while (peek_kind() == TokenKind::Star || peek_kind() == TokenKind::Slash ||
+           peek_kind() == TokenKind::Percent) {
+      BinaryOp op{};
+      switch (peek_kind()) {
+      case TokenKind::Star:
+        op = BinaryOp::Mul;
+        break;
+      case TokenKind::Slash:
+        op = BinaryOp::Div;
+        break;
+      case TokenKind::Percent:
+        op = BinaryOp::Mod;
+        break;
+      default:
+        break;
+      }
+      advance();
+      auto* right = parse_unary();
+      left = make_binary(op, left, right);
+    }
+    return left;
+  }
+
+  auto parse_unary() -> Expr* {
+    if (peek_kind() == TokenKind::Bang || peek_kind() == TokenKind::Minus ||
+        peek_kind() == TokenKind::Star || peek_kind() == TokenKind::Amp) {
+      const auto& op_tok = advance();
+      UnaryOp op{};
+      switch (op_tok.kind) {
+      case TokenKind::Bang:
+        op = UnaryOp::Not;
+        break;
+      case TokenKind::Minus:
+        op = UnaryOp::Negate;
+        break;
+      case TokenKind::Star:
+        op = UnaryOp::Deref;
+        break;
+      case TokenKind::Amp:
+        op = UnaryOp::AddrOf;
+        break;
+      default:
+        break;
+      }
+      auto* operand = parse_unary();
+      Span span = {.offset = op_tok.span.offset,
+                   .length =
+                       (operand->span().offset + operand->span().length) - op_tok.span.offset};
+      return ctx_.alloc<UnaryExprNode>(span, op, operand);
+    }
+    return parse_application();
+  }
+
+  auto parse_application() -> Expr* {
+    auto* callee = parse_postfix();
+
+    // In pipe target position, a bare identifier/qualified-name followed
+    // by another primary (lambda or identifier) is juxtaposition application:
+    //   xs |> filter |x| -> x > 0    →  filter(|x| -> x > 0)
+    //   xs |> filter is_valid         →  filter(is_valid)
+    if (in_pipe_target_ && is_pipe_argument_start()) {
+      std::vector<Expr*> args;
+      while (is_pipe_argument_start()) {
+        if (peek_kind() == TokenKind::Pipe) {
+          args.push_back(parse_lambda());
+        } else {
+          args.push_back(parse_postfix());
+        }
+      }
+      Span span = {.offset = callee->span().offset,
+                   .length = (args.back()->span().offset + args.back()->span().length) -
+                             callee->span().offset};
+      return ctx_.alloc<CallExprNode>(span, callee, std::move(args));
+    }
+
+    return callee;
+  }
+
+  [[nodiscard]] auto is_pipe_argument_start() const -> bool {
+    auto kind = peek_kind();
+    return kind == TokenKind::Pipe || kind == TokenKind::Identifier ||
+           kind == TokenKind::IntLiteral || kind == TokenKind::FloatLiteral ||
+           kind == TokenKind::StringLiteral || kind == TokenKind::KwTrue ||
+           kind == TokenKind::KwFalse;
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  auto parse_postfix() -> Expr* {
+    auto* expr = parse_primary();
+
+    while (true) {
+      if (peek_kind() == TokenKind::LParen) {
+        // Call: expr(args)
+        advance(); // (
+        std::vector<Expr*> args;
+        if (peek_kind() != TokenKind::RParen) {
+          args.push_back(parse_expression());
+          while (peek_kind() == TokenKind::Comma) {
+            advance();
+            args.push_back(parse_expression());
+          }
+        }
+        const auto& rparen = consume(TokenKind::RParen);
+        Span span = {.offset = expr->span().offset,
+                     .length = (rparen.span.offset + rparen.span.length) - expr->span().offset};
+        expr = ctx_.alloc<CallExprNode>(span, expr, std::move(args));
+      } else if (peek_kind() == TokenKind::Dot) {
+        // Field access: expr.field
+        advance(); // .
+        const auto& field_tok = consume(TokenKind::Identifier);
+        Span span = {.offset = expr->span().offset,
+                     .length =
+                         (field_tok.span.offset + field_tok.span.length) - expr->span().offset};
+        expr = ctx_.alloc<FieldExprNode>(span, expr, field_tok.text, field_tok.span);
+      } else if (peek_kind() == TokenKind::LBracket) {
+        // Index or type-parameter application: expr[args]
+        advance(); // [
+        std::vector<Expr*> indices;
+        indices.push_back(parse_expression());
+        while (peek_kind() == TokenKind::Comma) {
+          advance();
+          indices.push_back(parse_expression());
+        }
+        const auto& rbracket = consume(TokenKind::RBracket);
+        Span span = {.offset = expr->span().offset,
+                     .length = (rbracket.span.offset + rbracket.span.length) - expr->span().offset};
+        expr = ctx_.alloc<IndexExprNode>(span, expr, std::move(indices));
+      } else {
+        break;
+      }
+    }
+
+    return expr;
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  auto parse_primary() -> Expr* {
+    switch (peek_kind()) {
+    case TokenKind::IntLiteral: {
+      const auto& tok = advance();
+      return ctx_.alloc<IntLiteralNode>(tok.span, tok.text);
+    }
+    case TokenKind::FloatLiteral: {
+      const auto& tok = advance();
+      return ctx_.alloc<FloatLiteralNode>(tok.span, tok.text);
+    }
+    case TokenKind::StringLiteral: {
+      const auto& tok = advance();
+      return ctx_.alloc<StringLiteralNode>(tok.span, tok.text);
+    }
+    case TokenKind::KwTrue: {
+      const auto& tok = advance();
+      return ctx_.alloc<BoolLiteralNode>(tok.span, true);
+    }
+    case TokenKind::KwFalse: {
+      const auto& tok = advance();
+      return ctx_.alloc<BoolLiteralNode>(tok.span, false);
+    }
+    case TokenKind::LParen: {
+      advance(); // (
+      auto* expr = parse_expression();
+      consume(TokenKind::RParen);
+      return expr;
+    }
+    case TokenKind::LBracket:
+      return parse_list_literal();
+    case TokenKind::Pipe:
+      return parse_lambda();
+    case TokenKind::Identifier:
+      return parse_qualified_name_or_identifier();
+    default:
+      error("expected expression");
+      const auto& tok = advance();
+      // Return an error placeholder.
+      return ctx_.alloc<IdentifierNode>(tok.span, tok.text);
+    }
+  }
+
+  auto parse_list_literal() -> Expr* {
+    const auto& lbracket = advance(); // [
+    std::vector<Expr*> elements;
+    if (peek_kind() != TokenKind::RBracket) {
+      elements.push_back(parse_expression());
+      while (peek_kind() == TokenKind::Comma) {
+        advance();
+        elements.push_back(parse_expression());
+      }
+    }
+    const auto& rbracket = consume(TokenKind::RBracket);
+    Span span = {.offset = lbracket.span.offset,
+                 .length = (rbracket.span.offset + rbracket.span.length) - lbracket.span.offset};
+    return ctx_.alloc<ListLiteralNode>(span, std::move(elements));
+  }
+
+  auto parse_lambda() -> Expr* {
+    const auto& open_pipe = consume(TokenKind::Pipe);
+    std::vector<std::pair<std::string_view, Span>> params;
+    if (peek_kind() != TokenKind::Pipe) {
+      const auto& first = consume(TokenKind::Identifier);
+      params.emplace_back(first.text, first.span);
+      while (peek_kind() == TokenKind::Comma) {
+        advance();
+        const auto& param = consume(TokenKind::Identifier);
+        params.emplace_back(param.text, param.span);
+      }
+    }
+    consume(TokenKind::Pipe);
+    consume(TokenKind::Arrow);
+    auto* body = parse_expression();
+    Span span = {.offset = open_pipe.span.offset,
+                 .length = (body->span().offset + body->span().length) - open_pipe.span.offset};
+    return ctx_.alloc<LambdaNode>(span, std::move(params), body);
+  }
+
+  auto parse_qualified_name_or_identifier() -> Expr* {
+    const auto& first = consume(TokenKind::Identifier);
+    if (peek_kind() != TokenKind::ColonColon) {
+      return ctx_.alloc<IdentifierNode>(first.span, first.text);
+    }
+
+    // Qualified name: ident :: ident (:: ident)*
+    std::vector<std::string_view> segments;
+    segments.push_back(first.text);
+    Span span = first.span;
+
+    while (peek_kind() == TokenKind::ColonColon) {
+      advance(); // ::
+      const auto& seg = consume(TokenKind::Identifier);
+      segments.push_back(seg.text);
+      span.length = (seg.span.offset + seg.span.length) - span.offset;
+    }
+
+    return ctx_.alloc<QualifiedNameNode>(span, std::move(segments));
+  }
+
+  // -----------------------------------------------------------------------
+  // Types
+  // -----------------------------------------------------------------------
+
+  auto parse_type() -> TypeNode* {
+    if (peek_kind() == TokenKind::Star) {
+      const auto& star = advance();
+      auto* pointee = parse_type();
+      Span span = {.offset = star.span.offset,
+                   .length = (pointee->span().offset + pointee->span().length) - star.span.offset};
+      return ctx_.alloc<PointerTypeNode>(span, pointee);
+    }
+
+    return parse_named_type();
+  }
+
+  auto parse_named_type() -> NamedTypeNode* {
+    auto path = parse_type_path();
+
+    std::vector<TypeNode*> type_args;
+    if (peek_kind() == TokenKind::LBracket) {
+      advance(); // [
+      type_args.push_back(parse_type());
+      while (peek_kind() == TokenKind::Comma) {
+        advance();
+        type_args.push_back(parse_type());
+      }
+      const auto& rbracket = consume(TokenKind::RBracket);
+      path.span.length = (rbracket.span.offset + rbracket.span.length) - path.span.offset;
+    }
+
+    return ctx_.alloc<NamedTypeNode>(path.span, std::move(path), std::move(type_args));
+  }
+
+  auto parse_type_path() -> QualifiedPath {
+    QualifiedPath path;
+    const auto& first = consume(TokenKind::Identifier);
+    path.segments.push_back(first.text);
+    path.span = first.span;
+
+    while (peek_kind() == TokenKind::ColonColon) {
+      advance(); // ::
+      const auto& seg = consume(TokenKind::Identifier);
+      path.segments.push_back(seg.text);
+      path.span.length = (seg.span.offset + seg.span.length) - path.span.offset;
+    }
+
+    return path;
+  }
+
+  // -----------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------
+
+  auto make_binary(BinaryOp op, Expr* left, Expr* right) -> BinaryExprNode* {
+    Span span = {.offset = left->span().offset,
+                 .length = (right->span().offset + right->span().length) - left->span().offset};
+    return ctx_.alloc<BinaryExprNode>(span, op, left, right);
+  }
+
+  auto span_from(Span start) -> Span {
+    // Span from start to the token just before current position.
+    if (pos_ > 0) {
+      const auto& prev = tokens_[pos_ - 1];
+      return {.offset = start.offset,
+              .length = (prev.span.offset + prev.span.length) - start.offset};
+    }
+    return start;
+  }
+};
+// NOLINTEND(readability-identifier-length)
+
+} // namespace
+
+auto parse(const std::vector<Token>& tokens) -> ParseResult {
+  ParserImpl parser(tokens);
+  return parser.run();
+}
+
+} // namespace dao

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -290,15 +290,22 @@ private:
 
     // Check for assignment: expr = expr
     if (peek_kind() == TokenKind::Eq) {
+      // Validate LHS is a legal assignment target.
+      if (expr->kind() != NodeKind::Identifier && expr->kind() != NodeKind::FieldExpr &&
+          expr->kind() != NodeKind::IndexExpr) {
+        error("invalid assignment target");
+      }
       advance(); // =
       auto* value = parse_expression();
-      consume(TokenKind::Newline);
+      // Trailing newline may have been consumed by pipe continuation.
+      match(TokenKind::Newline);
       Span span = {.offset = expr->span().offset,
                    .length = (value->span().offset + value->span().length) - expr->span().offset};
       return ctx_.alloc<AssignmentNode>(span, expr, value);
     }
 
-    consume(TokenKind::Newline);
+    // Trailing newline may have been consumed by pipe continuation.
+    match(TokenKind::Newline);
     return ctx_.alloc<ExpressionStatementNode>(expr->span(), expr);
   }
 
@@ -323,7 +330,8 @@ private:
       error("expected ':' or '=' after let binding name");
     }
 
-    consume(TokenKind::Newline);
+    // Trailing newline may have been consumed by pipe continuation.
+    match(TokenKind::Newline);
     Span span = span_from(kw.span);
     return ctx_.alloc<LetStatementNode>(span, name_tok.text, name_tok.span, type, init);
   }
@@ -389,7 +397,8 @@ private:
   auto parse_return_statement() -> ReturnStatementNode* {
     const auto& kw = consume(TokenKind::KwReturn);
     auto* value = parse_expression();
-    consume(TokenKind::Newline);
+    // Trailing newline may have been consumed by pipe continuation.
+    match(TokenKind::Newline);
     Span span = span_from(kw.span);
     return ctx_.alloc<ReturnStatementNode>(span, value);
   }

--- a/compiler/frontend/parser/parser.h
+++ b/compiler/frontend/parser/parser.h
@@ -1,0 +1,22 @@
+#ifndef DAO_FRONTEND_PARSER_PARSER_H
+#define DAO_FRONTEND_PARSER_PARSER_H
+
+#include "frontend/ast/ast.h"
+#include "frontend/diagnostics/diagnostic.h"
+#include "frontend/lexer/token.h"
+
+#include <vector>
+
+namespace dao {
+
+struct ParseResult {
+  AstContext context;
+  FileNode* file = nullptr;
+  std::vector<Diagnostic> diagnostics;
+};
+
+auto parse(const std::vector<Token>& tokens) -> ParseResult;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_PARSER_PARSER_H

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -1,0 +1,427 @@
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+
+#define BOOST_UT_DISABLE_MODULE
+#include <boost/ut.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace boost::ut;
+using namespace dao;
+
+auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+struct ParseOutput {
+  std::unique_ptr<SourceBuffer> source;
+  LexResult lex_result;
+  ParseResult parse_result;
+};
+
+auto parse_string(std::string_view src) -> ParseOutput {
+  auto source = std::make_unique<SourceBuffer>("<test>", std::string(src));
+  auto lex_result = lex(*source);
+  auto parse_result = parse(lex_result.tokens);
+  return {.source = std::move(source),
+          .lex_result = std::move(lex_result),
+          .parse_result = std::move(parse_result)};
+}
+
+auto parse_file(const std::filesystem::path& path) -> ParseOutput {
+  auto contents = read_file(path);
+  auto source = std::make_unique<SourceBuffer>(path.filename().string(), contents);
+  auto lex_result = lex(*source);
+  auto parse_result = parse(lex_result.tokens);
+  return {.source = std::move(source),
+          .lex_result = std::move(lex_result),
+          .parse_result = std::move(parse_result)};
+}
+
+// NOLINTBEGIN(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
+
+suite function_tests = [] {
+  "expression-bodied function"_test = [] {
+    auto output = parse_string("fn add(a: int32, b: int32): int32 -> a + b\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    auto* file = output.parse_result.file;
+    expect(file != nullptr);
+    expect(file->declarations().size() == 1_u);
+
+    auto* fn = static_cast<FunctionDeclNode*>(file->declarations()[0]);
+    expect(fn->kind() == NodeKind::FunctionDecl);
+    expect(fn->name() == "add");
+    expect(fn->params().size() == 2_u);
+    expect(fn->params()[0].name == "a");
+    expect(fn->params()[1].name == "b");
+    expect(fn->return_type() != nullptr);
+    expect(fn->is_expr_bodied());
+    expect(fn->expr_body() != nullptr);
+    expect(fn->expr_body()->kind() == NodeKind::BinaryExpr);
+  };
+
+  "block-bodied function"_test = [] {
+    auto output = parse_string("fn main(): int32\n    0\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    auto* file = output.parse_result.file;
+    expect(file->declarations().size() == 1_u);
+
+    auto* fn = static_cast<FunctionDeclNode*>(file->declarations()[0]);
+    expect(!fn->is_expr_bodied());
+    expect(fn->body().size() == 1_u);
+    expect(fn->body()[0]->kind() == NodeKind::ExpressionStatement);
+  };
+
+  "no-param function"_test = [] {
+    auto output = parse_string("fn greet(): int32 -> 0\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    expect(fn->params().empty());
+  };
+};
+
+suite let_tests = [] {
+  "let with type and initializer"_test = [] {
+    auto output = parse_string("fn f(): int32\n    let x: int32 = 42\n    x\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    expect(fn->body().size() == 2_u);
+
+    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
+    expect(let_stmt->kind() == NodeKind::LetStatement);
+    expect(let_stmt->name() == "x");
+    expect(let_stmt->type() != nullptr);
+    expect(let_stmt->initializer() != nullptr);
+  };
+
+  "let with type only"_test = [] {
+    auto output = parse_string("fn f(): int32\n    let x: int32\n    x\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
+    expect(let_stmt->type() != nullptr);
+    expect(let_stmt->initializer() == nullptr);
+  };
+
+  "let with initializer only"_test = [] {
+    auto output = parse_string("fn f(): int32\n    let x = 42\n    x\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
+    expect(let_stmt->type() == nullptr);
+    expect(let_stmt->initializer() != nullptr);
+  };
+};
+
+suite control_flow_tests = [] {
+  "if statement"_test = [] {
+    auto output = parse_string("fn f(): int32\n    if true:\n        0\n    1\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
+    expect(if_stmt->kind() == NodeKind::IfStatement);
+    expect(if_stmt->condition()->kind() == NodeKind::BoolLiteral);
+    expect(if_stmt->then_body().size() == 1_u);
+    expect(!if_stmt->has_else());
+  };
+
+  "if-else statement"_test = [] {
+    auto output = parse_string("fn f(): int32\n    if true:\n        0\n    else:\n        1\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
+    expect(if_stmt->has_else());
+    expect(if_stmt->else_body().size() == 1_u);
+  };
+
+  "while statement"_test = [] {
+    auto output = parse_string("fn f(): int32\n    while true:\n        0\n    1\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* while_stmt = static_cast<WhileStatementNode*>(fn->body()[0]);
+    expect(while_stmt->kind() == NodeKind::WhileStatement);
+    expect(while_stmt->body().size() == 1_u);
+  };
+
+  "for statement"_test = [] {
+    auto output = parse_string("fn f(): int32\n    for i in items:\n        i\n    0\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* for_stmt = static_cast<ForStatementNode*>(fn->body()[0]);
+    expect(for_stmt->kind() == NodeKind::ForStatement);
+    expect(for_stmt->var() == "i");
+  };
+};
+
+suite expression_tests = [] {
+  "binary operators"_test = [] {
+    auto output = parse_string("fn f(): int32 -> 1 + 2 * 3\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    // Should be BinaryExpr(+, 1, BinaryExpr(*, 2, 3)) — * binds tighter than +
+    auto* add = static_cast<BinaryExprNode*>(fn->expr_body());
+    expect(add->kind() == NodeKind::BinaryExpr);
+    expect(add->op() == BinaryOp::Add);
+    expect(add->left()->kind() == NodeKind::IntLiteral);
+    expect(add->right()->kind() == NodeKind::BinaryExpr);
+    auto* mul = static_cast<BinaryExprNode*>(add->right());
+    expect(mul->op() == BinaryOp::Mul);
+  };
+
+  "unary operators"_test = [] {
+    auto output = parse_string("fn f(p: *int32): int32 -> *p\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* deref = static_cast<UnaryExprNode*>(fn->expr_body());
+    expect(deref->kind() == NodeKind::UnaryExpr);
+    expect(deref->op() == UnaryOp::Deref);
+  };
+
+  "function call"_test = [] {
+    auto output = parse_string("fn f(): int32\n    foo(1, 2)\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
+    expect(call->kind() == NodeKind::CallExpr);
+    expect(call->args().size() == 2_u);
+  };
+
+  "field access"_test = [] {
+    auto output = parse_string("fn f(): int32\n    x.y.z\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* outer = static_cast<FieldExprNode*>(expr_stmt->expr());
+    expect(outer->kind() == NodeKind::FieldExpr);
+    expect(outer->field() == "z");
+    auto* inner = static_cast<FieldExprNode*>(outer->object());
+    expect(inner->field() == "y");
+  };
+
+  "index expression"_test = [] {
+    auto output = parse_string("fn f(): int32\n    a[0]\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* idx = static_cast<IndexExprNode*>(expr_stmt->expr());
+    expect(idx->kind() == NodeKind::IndexExpr);
+    expect(idx->indices().size() == 1_u);
+  };
+
+  "multi-arg bracket"_test = [] {
+    auto output = parse_string("fn f(): int32\n    Map[int32, string]()\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
+    expect(call->kind() == NodeKind::CallExpr);
+    auto* idx = static_cast<IndexExprNode*>(call->callee());
+    expect(idx->indices().size() == 2_u);
+  };
+
+  "comparison operators"_test = [] {
+    auto output = parse_string("fn f(): int32 -> 1 == 2\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* eq = static_cast<BinaryExprNode*>(fn->expr_body());
+    expect(eq->op() == BinaryOp::EqEq);
+  };
+
+  "logical operators"_test = [] {
+    auto output = parse_string("fn f(): int32 -> true and false or true\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    // or binds less tightly than and: or(and(true, false), true)
+    auto* or_expr = static_cast<BinaryExprNode*>(fn->expr_body());
+    expect(or_expr->op() == BinaryOp::Or);
+    auto* and_expr = static_cast<BinaryExprNode*>(or_expr->left());
+    expect(and_expr->op() == BinaryOp::And);
+  };
+};
+
+suite lambda_tests = [] {
+  "simple lambda"_test = [] {
+    auto output = parse_string("fn f(): int32 -> |x| -> x + 1\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+  };
+
+  "lambda in pipe"_test = [] {
+    auto output = parse_string("fn f(): int32\n    xs |> map |x| -> x * x\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    expect(expr_stmt->expr()->kind() == NodeKind::PipeExpr);
+  };
+};
+
+suite pipe_tests = [] {
+  "simple pipe"_test = [] {
+    auto output = parse_string("fn f(): int32\n    x |> foo |> bar\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* outer = static_cast<PipeExprNode*>(expr_stmt->expr());
+    expect(outer->kind() == NodeKind::PipeExpr);
+    expect(outer->left()->kind() == NodeKind::PipeExpr);
+  };
+};
+
+suite mode_resource_tests = [] {
+  "mode block"_test = [] {
+    auto output = parse_string("fn f(): int32\n    mode unsafe =>\n        0\n    1\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* mode = static_cast<ModeBlockNode*>(fn->body()[0]);
+    expect(mode->kind() == NodeKind::ModeBlock);
+    expect(mode->mode_name() == "unsafe");
+    expect(mode->body().size() == 1_u);
+  };
+
+  "resource block"_test = [] {
+    auto output = parse_string("fn f(): int32\n    resource memory Search =>\n        0\n    1\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* res = static_cast<ResourceBlockNode*>(fn->body()[0]);
+    expect(res->kind() == NodeKind::ResourceBlock);
+    expect(res->resource_kind() == "memory");
+    expect(res->resource_name() == "Search");
+    expect(res->body().size() == 1_u);
+  };
+};
+
+suite type_tests = [] {
+  "pointer type"_test = [] {
+    auto output = parse_string("fn f(p: *int32): int32 -> 0\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* param_type = fn->params()[0].type;
+    expect(param_type->kind() == NodeKind::PointerType);
+  };
+
+  "parameterized type"_test = [] {
+    auto output = parse_string("fn f(): List[int32] -> []\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
+    expect(ret->kind() == NodeKind::NamedType);
+    expect(ret->name().segments.size() == 1_u);
+    expect(ret->name().segments[0] == "List");
+    expect(ret->type_args().size() == 1_u);
+  };
+
+  "multi-param type"_test = [] {
+    auto output = parse_string("fn f(): Map[int32, string] -> []\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
+    expect(ret->type_args().size() == 2_u);
+  };
+};
+
+suite import_tests = [] {
+  "simple import"_test = [] {
+    auto output = parse_string("import foo\nfn f(): int32 -> 0\n");
+    expect(output.parse_result.diagnostics.empty());
+    expect(output.parse_result.file->imports().size() == 1_u);
+    auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
+    expect(imp->path().segments.size() == 1_u);
+    expect(imp->path().segments[0] == "foo");
+  };
+
+  "qualified import"_test = [] {
+    auto output = parse_string("import net::http\nfn f(): int32 -> 0\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
+    expect(imp->path().segments.size() == 2_u);
+    expect(imp->path().segments[0] == "net");
+    expect(imp->path().segments[1] == "http");
+  };
+};
+
+suite assignment_tests = [] {
+  "simple assignment"_test = [] {
+    auto output = parse_string("fn f(): int32\n    x = 42\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
+    expect(assign->kind() == NodeKind::Assignment);
+    expect(assign->target()->kind() == NodeKind::Identifier);
+    expect(assign->value()->kind() == NodeKind::IntLiteral);
+  };
+
+  "field assignment"_test = [] {
+    auto output = parse_string("fn f(): int32\n    x.y = 42\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
+    expect(assign->target()->kind() == NodeKind::FieldExpr);
+  };
+};
+
+suite return_tests = [] {
+  "return statement"_test = [] {
+    auto output = parse_string("fn f(): int32\n    return 42\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* ret = static_cast<ReturnStatementNode*>(fn->body()[0]);
+    expect(ret->kind() == NodeKind::ReturnStatement);
+    expect(ret->value()->kind() == NodeKind::IntLiteral);
+  };
+};
+
+suite file_tests = [] {
+  "examples parse without error"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    for (const auto& entry : std::filesystem::directory_iterator(root / "examples")) {
+      if (entry.path().extension() == ".dao") {
+        auto output = parse_file(entry.path());
+        expect(output.parse_result.diagnostics.empty())
+            << "parse errors in " << entry.path().filename().string();
+        expect(output.parse_result.file != nullptr)
+            << "null file for " << entry.path().filename().string();
+      }
+    }
+  };
+
+  "syntax probes parse without error"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    for (const auto& entry : std::filesystem::directory_iterator(root / "spec" / "syntax_probes")) {
+      if (entry.path().extension() == ".dao") {
+        auto output = parse_file(entry.path());
+        expect(output.parse_result.diagnostics.empty())
+            << "parse errors in " << entry.path().filename().string();
+        expect(output.parse_result.file != nullptr)
+            << "null file for " << entry.path().filename().string();
+      }
+    }
+  };
+};
+
+suite qualified_name_tests = [] {
+  "qualified name in expression"_test = [] {
+    auto output = parse_string("fn f(): int32\n    Foo::bar()\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
+    expect(call->callee()->kind() == NodeKind::QualifiedName);
+    auto* qn = static_cast<QualifiedNameNode*>(call->callee());
+    expect(qn->segments().size() == 2_u);
+    expect(qn->segments()[0] == "Foo");
+    expect(qn->segments()[1] == "bar");
+  };
+};
+
+// NOLINTEND(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
+
+} // namespace
+
+auto main() -> int {
+} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -271,6 +271,15 @@ suite pipe_tests = [] {
     expect(outer->kind() == NodeKind::PipeExpr);
     expect(outer->left()->kind() == NodeKind::PipeExpr);
   };
+
+  "multi-line pipe in suite"_test = [] {
+    auto output = parse_string("fn f(): int32\n    xs\n        |> map |x| -> x\n    0\n");
+    expect(output.parse_result.diagnostics.empty()) << "multi-line pipe in suite";
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    expect(fn->body().size() == 2_u) << "pipe expr + trailing 0";
+    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
+    expect(expr_stmt->expr()->kind() == NodeKind::PipeExpr);
+  };
 };
 
 suite mode_resource_tests = [] {
@@ -362,6 +371,19 @@ suite assignment_tests = [] {
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
     expect(assign->target()->kind() == NodeKind::FieldExpr);
+  };
+
+  "index assignment"_test = [] {
+    auto output = parse_string("fn f(): int32\n    a[0] = 42\n");
+    expect(output.parse_result.diagnostics.empty());
+    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
+    expect(assign->target()->kind() == NodeKind::IndexExpr);
+  };
+
+  "invalid assignment target"_test = [] {
+    auto output = parse_string("fn f(): int32\n    1 = 2\n");
+    expect(!output.parse_result.diagnostics.empty()) << "should reject invalid LHS";
   };
 };
 


### PR DESCRIPTION
## Summary

Implement Task 2 from the implementation plan: a complete recursive descent parser covering the full `dao.ebnf` grammar. The parser produces an arena-allocated AST with full span tracking on every node, supporting all Dao syntax constructs including indentation-significant blocks, expression-bodied functions, multi-line pipes, mode/resource blocks, and parameterized types.

## Highlights

- **Arena-backed `AstContext`** with bump allocation and reverse-order destruction — no `unique_ptr` churn, phase-local ownership
- **Full node hierarchy**: `AstNode` → `Decl`, `Stmt`, `Expr`, `TypeNode` with `NodeKind` tags for safe downcasting
- **Dedicated `PipeExpr` node** (not `BinaryExpr`) — first-class treatment for `|>` per design decision
- **`QualifiedName`** as its own node, distinct from `Identifier` — supports `Foo::bar::baz` paths
- **`ExpressionStatement`** wrapper, `TypeNode` separate from semantic types
- **Multi-line pipe continuation**: parser peeks past `Newline` + optional `Indent` to find `|>` continuations
- **Juxtaposition application in pipe targets**: `filter |x| -> x > 0` parses as `filter(|x| -> x > 0)`
- **Multi-arg bracket expressions**: `PriorityQueue[NodeId, float64]()` parses correctly as type parameterization + constructor call
- **34 parser unit tests** covering all EBNF productions + file tests against all 8 `.dao` examples and syntax probes
- **`daoc parse <file>`** subcommand for diagnostics

## Test plan

- [x] All 34 parser unit tests pass
- [x] All 22 lexer tests still pass
- [x] All 4 examples parse without error (`hello.dao`, `astar.dao`, `pipelines.dao`, `unsafe.dao`)
- [x] All 4 syntax probes parse without error (`functions.dao`, `astar.dao`, `pipelines.dao`, `modes_and_resources.dao`)
- [x] `daoc parse` smoke test on all examples
- [x] clang-format clean
- [x] clang-tidy clean
- [ ] CI build + test pass

## Known Limitations

- Golden AST snapshots in `testdata/` are deferred to Task 3 (AST Printer), which will add deterministic output suitable for snapshot testing
- `IndexExprNode` uses a vector of indices to handle both single-element indexing and multi-arg type parameterization; semantic distinction is deferred to later phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)