### PR TITLE
feat(ast): ✨ add AST pretty-printer with golden-file tests

### DIFF
--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -1,3 +1,4 @@
+#include "frontend/ast/ast_printer.h"
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
 
@@ -50,8 +51,13 @@ void cmd_lex(const std::filesystem::path& path) {
   }
 }
 
-// Debug-only parse diagnostic dump. Output format is not stable.
-void cmd_parse(const std::filesystem::path& path) {
+struct ParsedFile {
+  dao::SourceBuffer source;
+  dao::ParseResult parse_result;
+};
+
+// Lex and parse a file, printing diagnostics on failure.
+auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
   auto contents = read_file(path);
   dao::SourceBuffer source(path.filename().string(), std::move(contents));
   auto lex_result = dao::lex(source);
@@ -76,9 +82,23 @@ void cmd_parse(const std::filesystem::path& path) {
     std::exit(EXIT_FAILURE);
   }
 
-  if (parse_result.file != nullptr) {
-    std::cout << "File: " << parse_result.file->imports().size() << " imports, "
-              << parse_result.file->declarations().size() << " declarations\n";
+  return {.source = std::move(source), .parse_result = std::move(parse_result)};
+}
+
+// Debug-only parse diagnostic dump. Output format is not stable.
+void cmd_parse(const std::filesystem::path& path) {
+  auto result = lex_and_parse(path);
+  if (result.parse_result.file != nullptr) {
+    std::cout << "File: " << result.parse_result.file->imports().size() << " imports, "
+              << result.parse_result.file->declarations().size() << " declarations\n";
+  }
+}
+
+// Pretty-print AST. Output is deterministic and suitable for golden-file testing.
+void cmd_ast(const std::filesystem::path& path) {
+  auto result = lex_and_parse(path);
+  if (result.parse_result.file != nullptr) {
+    dao::print_ast(std::cout, *result.parse_result.file);
   }
 }
 
@@ -87,7 +107,7 @@ void cmd_parse(const std::filesystem::path& path) {
 auto main(int argc, char* argv[]) -> int {
   if (argc < 2) {
     std::cerr << "usage: daoc <command> <file>\n";
-    std::cerr << "commands: lex, parse\n";
+    std::cerr << "commands: lex, parse, ast\n";
     return EXIT_FAILURE;
   }
 
@@ -120,6 +140,21 @@ auto main(int argc, char* argv[]) -> int {
       return EXIT_FAILURE;
     }
     cmd_parse(parse_path);
+    return EXIT_SUCCESS;
+  }
+
+  // daoc ast <file>
+  if (arg1 == "ast") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc ast <file>\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path ast_path(argv[2]);
+    if (!std::filesystem::exists(ast_path)) {
+      std::cerr << "error: file not found: " << ast_path << "\n";
+      return EXIT_FAILURE;
+    }
+    cmd_ast(ast_path);
     return EXIT_SUCCESS;
   }
 

--- a/compiler/frontend/CMakeLists.txt
+++ b/compiler/frontend/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(dao_frontend STATIC
   ast/ast.cpp
+  ast/ast_printer.cpp
   lexer/lexer.cpp
   parser/parser.cpp
 )
@@ -31,6 +32,17 @@ target_compile_definitions(parser_test PRIVATE
   DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
+add_executable(ast_printer_test
+  ast/ast_printer_test.cpp
+)
+
+target_link_libraries(ast_printer_test PRIVATE dao_frontend Boost::ut)
+
+target_compile_definitions(ast_printer_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
 include(CTest)
 add_test(NAME lexer_test COMMAND lexer_test)
 add_test(NAME parser_test COMMAND parser_test)
+add_test(NAME ast_printer_test COMMAND ast_printer_test)

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -1,0 +1,574 @@
+#include "frontend/ast/ast_printer.h"
+
+#include <string>
+
+namespace dao {
+
+namespace {
+
+// NOLINTBEGIN(readability-identifier-length)
+
+class AstPrinter {
+public:
+  explicit AstPrinter(std::ostream& out) : out_(out) {
+  }
+
+  void print(const FileNode& file) {
+    out_ << "File\n";
+    for (const auto* imp : file.imports()) {
+      print_import(static_cast<const ImportNode&>(*imp));
+    }
+    for (const auto* decl : file.declarations()) {
+      print_decl(*decl);
+    }
+  }
+
+private:
+  std::ostream& out_;
+  int depth_ = 1;
+
+  void indent() {
+    for (int i = 0; i < depth_; ++i) {
+      out_ << "  ";
+    }
+  }
+
+  struct Scope {
+    int& depth;
+    explicit Scope(int& d) : depth(d) {
+      ++depth;
+    }
+    ~Scope() {
+      --depth;
+    }
+    Scope(const Scope&) = delete;
+    auto operator=(const Scope&) -> Scope& = delete;
+    Scope(Scope&&) = delete;
+    auto operator=(Scope&&) -> Scope& = delete;
+  };
+
+  // -----------------------------------------------------------------------
+  // Import
+  // -----------------------------------------------------------------------
+
+  void print_import(const ImportNode& node) {
+    indent();
+    out_ << "Import ";
+    print_qualified_path(node.path());
+    out_ << "\n";
+  }
+
+  // -----------------------------------------------------------------------
+  // Declarations
+  // -----------------------------------------------------------------------
+
+  void print_decl(const Decl& decl) {
+    switch (decl.kind()) {
+    case NodeKind::FunctionDecl:
+      print_function_decl(static_cast<const FunctionDeclNode&>(decl));
+      break;
+    case NodeKind::StructDecl:
+      print_struct_decl(static_cast<const StructDeclNode&>(decl));
+      break;
+    case NodeKind::AliasDecl:
+      print_alias_decl(static_cast<const AliasDeclNode&>(decl));
+      break;
+    default:
+      indent();
+      out_ << "UnknownDecl\n";
+      break;
+    }
+  }
+
+  void print_function_decl(const FunctionDeclNode& fn) {
+    indent();
+    out_ << "FunctionDecl " << fn.name() << "\n";
+    Scope scope(depth_);
+
+    for (const auto& param : fn.params()) {
+      indent();
+      out_ << "Param " << param.name << ": ";
+      print_type_inline(*param.type);
+      out_ << "\n";
+    }
+
+    if (fn.return_type() != nullptr) {
+      indent();
+      out_ << "ReturnType: ";
+      print_type_inline(*fn.return_type());
+      out_ << "\n";
+    }
+
+    if (fn.is_expr_bodied()) {
+      indent();
+      out_ << "ExprBody\n";
+      {
+        Scope body_scope(depth_);
+        print_expr(*fn.expr_body());
+      }
+    } else {
+      for (const auto* stmt : fn.body()) {
+        print_stmt(*stmt);
+      }
+    }
+  }
+
+  void print_struct_decl(const StructDeclNode& node) {
+    indent();
+    out_ << "StructDecl " << node.name() << "\n";
+    Scope scope(depth_);
+    for (const auto* member : node.members()) {
+      print_stmt(*member);
+    }
+  }
+
+  void print_alias_decl(const AliasDeclNode& node) {
+    indent();
+    out_ << "AliasDecl " << node.name() << " = ";
+    print_type_inline(*node.type());
+    out_ << "\n";
+  }
+
+  // -----------------------------------------------------------------------
+  // Statements
+  // -----------------------------------------------------------------------
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void print_stmt(const Stmt& stmt) {
+    switch (stmt.kind()) {
+    case NodeKind::LetStatement:
+      print_let(static_cast<const LetStatementNode&>(stmt));
+      break;
+    case NodeKind::Assignment:
+      print_assignment(static_cast<const AssignmentNode&>(stmt));
+      break;
+    case NodeKind::IfStatement:
+      print_if(static_cast<const IfStatementNode&>(stmt));
+      break;
+    case NodeKind::WhileStatement:
+      print_while(static_cast<const WhileStatementNode&>(stmt));
+      break;
+    case NodeKind::ForStatement:
+      print_for(static_cast<const ForStatementNode&>(stmt));
+      break;
+    case NodeKind::ModeBlock:
+      print_mode(static_cast<const ModeBlockNode&>(stmt));
+      break;
+    case NodeKind::ResourceBlock:
+      print_resource(static_cast<const ResourceBlockNode&>(stmt));
+      break;
+    case NodeKind::ReturnStatement:
+      print_return(static_cast<const ReturnStatementNode&>(stmt));
+      break;
+    case NodeKind::ExpressionStatement:
+      print_expr_stmt(static_cast<const ExpressionStatementNode&>(stmt));
+      break;
+    default:
+      indent();
+      out_ << "UnknownStmt\n";
+      break;
+    }
+  }
+
+  void print_let(const LetStatementNode& node) {
+    indent();
+    out_ << "LetStatement " << node.name();
+    if (node.type() != nullptr) {
+      out_ << ": ";
+      print_type_inline(*node.type());
+    }
+    out_ << "\n";
+    if (node.initializer() != nullptr) {
+      Scope scope(depth_);
+      print_expr(*node.initializer());
+    }
+  }
+
+  void print_assignment(const AssignmentNode& node) {
+    indent();
+    out_ << "Assignment\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Target\n";
+    {
+      Scope target_scope(depth_);
+      print_expr(*node.target());
+    }
+    indent();
+    out_ << "Value\n";
+    {
+      Scope value_scope(depth_);
+      print_expr(*node.value());
+    }
+  }
+
+  void print_if(const IfStatementNode& node) {
+    indent();
+    out_ << "IfStatement\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Condition\n";
+    {
+      Scope cond_scope(depth_);
+      print_expr(*node.condition());
+    }
+    indent();
+    out_ << "Then\n";
+    {
+      Scope then_scope(depth_);
+      for (const auto* stmt : node.then_body()) {
+        print_stmt(*stmt);
+      }
+    }
+    if (node.has_else()) {
+      indent();
+      out_ << "Else\n";
+      Scope else_scope(depth_);
+      for (const auto* stmt : node.else_body()) {
+        print_stmt(*stmt);
+      }
+    }
+  }
+
+  void print_while(const WhileStatementNode& node) {
+    indent();
+    out_ << "WhileStatement\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Condition\n";
+    {
+      Scope cond_scope(depth_);
+      print_expr(*node.condition());
+    }
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_for(const ForStatementNode& node) {
+    indent();
+    out_ << "ForStatement " << node.var() << "\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Iterable\n";
+    {
+      Scope iter_scope(depth_);
+      print_expr(*node.iterable());
+    }
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_mode(const ModeBlockNode& node) {
+    indent();
+    out_ << "ModeBlock " << node.mode_name() << "\n";
+    Scope scope(depth_);
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_resource(const ResourceBlockNode& node) {
+    indent();
+    out_ << "ResourceBlock " << node.resource_kind() << " " << node.resource_name() << "\n";
+    Scope scope(depth_);
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_return(const ReturnStatementNode& node) {
+    indent();
+    out_ << "ReturnStatement\n";
+    Scope scope(depth_);
+    print_expr(*node.value());
+  }
+
+  void print_expr_stmt(const ExpressionStatementNode& node) {
+    print_expr(*node.expr());
+  }
+
+  // -----------------------------------------------------------------------
+  // Expressions
+  // -----------------------------------------------------------------------
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void print_expr(const Expr& expr) {
+    switch (expr.kind()) {
+    case NodeKind::IntLiteral:
+      print_int_literal(static_cast<const IntLiteralNode&>(expr));
+      break;
+    case NodeKind::FloatLiteral:
+      print_float_literal(static_cast<const FloatLiteralNode&>(expr));
+      break;
+    case NodeKind::StringLiteral:
+      print_string_literal(static_cast<const StringLiteralNode&>(expr));
+      break;
+    case NodeKind::BoolLiteral:
+      print_bool_literal(static_cast<const BoolLiteralNode&>(expr));
+      break;
+    case NodeKind::Identifier:
+      print_identifier(static_cast<const IdentifierNode&>(expr));
+      break;
+    case NodeKind::QualifiedName:
+      print_qualified_name(static_cast<const QualifiedNameNode&>(expr));
+      break;
+    case NodeKind::BinaryExpr:
+      print_binary(static_cast<const BinaryExprNode&>(expr));
+      break;
+    case NodeKind::UnaryExpr:
+      print_unary(static_cast<const UnaryExprNode&>(expr));
+      break;
+    case NodeKind::CallExpr:
+      print_call(static_cast<const CallExprNode&>(expr));
+      break;
+    case NodeKind::IndexExpr:
+      print_index(static_cast<const IndexExprNode&>(expr));
+      break;
+    case NodeKind::FieldExpr:
+      print_field(static_cast<const FieldExprNode&>(expr));
+      break;
+    case NodeKind::PipeExpr:
+      print_pipe(static_cast<const PipeExprNode&>(expr));
+      break;
+    case NodeKind::Lambda:
+      print_lambda(static_cast<const LambdaNode&>(expr));
+      break;
+    case NodeKind::ListLiteral:
+      print_list_literal(static_cast<const ListLiteralNode&>(expr));
+      break;
+    default:
+      indent();
+      out_ << "UnknownExpr\n";
+      break;
+    }
+  }
+
+  void print_int_literal(const IntLiteralNode& node) {
+    indent();
+    out_ << "IntLiteral " << node.text() << "\n";
+  }
+
+  void print_float_literal(const FloatLiteralNode& node) {
+    indent();
+    out_ << "FloatLiteral " << node.text() << "\n";
+  }
+
+  void print_string_literal(const StringLiteralNode& node) {
+    indent();
+    out_ << "StringLiteral " << node.text() << "\n";
+  }
+
+  void print_bool_literal(const BoolLiteralNode& node) {
+    indent();
+    out_ << "BoolLiteral " << (node.value() ? "true" : "false") << "\n";
+  }
+
+  void print_identifier(const IdentifierNode& node) {
+    indent();
+    out_ << "Identifier " << node.name() << "\n";
+  }
+
+  void print_qualified_name(const QualifiedNameNode& node) {
+    indent();
+    out_ << "QualifiedName ";
+    for (size_t i = 0; i < node.segments().size(); ++i) {
+      if (i > 0) {
+        out_ << "::";
+      }
+      out_ << node.segments()[i];
+    }
+    out_ << "\n";
+  }
+
+  static auto binary_op_str(BinaryOp op) -> const char* {
+    switch (op) {
+    case BinaryOp::Add:
+      return "+";
+    case BinaryOp::Sub:
+      return "-";
+    case BinaryOp::Mul:
+      return "*";
+    case BinaryOp::Div:
+      return "/";
+    case BinaryOp::Mod:
+      return "%";
+    case BinaryOp::EqEq:
+      return "==";
+    case BinaryOp::BangEq:
+      return "!=";
+    case BinaryOp::Lt:
+      return "<";
+    case BinaryOp::LtEq:
+      return "<=";
+    case BinaryOp::Gt:
+      return ">";
+    case BinaryOp::GtEq:
+      return ">=";
+    case BinaryOp::And:
+      return "and";
+    case BinaryOp::Or:
+      return "or";
+    }
+    return "?";
+  }
+
+  static auto unary_op_str(UnaryOp op) -> const char* {
+    switch (op) {
+    case UnaryOp::Negate:
+      return "-";
+    case UnaryOp::Not:
+      return "!";
+    case UnaryOp::Deref:
+      return "*";
+    case UnaryOp::AddrOf:
+      return "&";
+    }
+    return "?";
+  }
+
+  void print_binary(const BinaryExprNode& node) {
+    indent();
+    out_ << "BinaryExpr " << binary_op_str(node.op()) << "\n";
+    Scope scope(depth_);
+    print_expr(*node.left());
+    print_expr(*node.right());
+  }
+
+  void print_unary(const UnaryExprNode& node) {
+    indent();
+    out_ << "UnaryExpr " << unary_op_str(node.op()) << "\n";
+    Scope scope(depth_);
+    print_expr(*node.operand());
+  }
+
+  void print_call(const CallExprNode& node) {
+    indent();
+    out_ << "CallExpr\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Callee\n";
+    {
+      Scope callee_scope(depth_);
+      print_expr(*node.callee());
+    }
+    if (!node.args().empty()) {
+      indent();
+      out_ << "Args\n";
+      Scope args_scope(depth_);
+      for (const auto* arg : node.args()) {
+        print_expr(*arg);
+      }
+    }
+  }
+
+  void print_index(const IndexExprNode& node) {
+    indent();
+    out_ << "IndexExpr\n";
+    Scope scope(depth_);
+    print_expr(*node.object());
+    indent();
+    out_ << "Indices\n";
+    {
+      Scope indices_scope(depth_);
+      for (const auto* idx : node.indices()) {
+        print_expr(*idx);
+      }
+    }
+  }
+
+  void print_field(const FieldExprNode& node) {
+    indent();
+    out_ << "FieldExpr ." << node.field() << "\n";
+    Scope scope(depth_);
+    print_expr(*node.object());
+  }
+
+  void print_pipe(const PipeExprNode& node) {
+    indent();
+    out_ << "PipeExpr\n";
+    Scope scope(depth_);
+    print_expr(*node.left());
+    print_expr(*node.right());
+  }
+
+  void print_lambda(const LambdaNode& node) {
+    indent();
+    out_ << "Lambda";
+    for (const auto& [name, span] : node.params()) {
+      out_ << " " << name;
+    }
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.body());
+  }
+
+  void print_list_literal(const ListLiteralNode& node) {
+    indent();
+    out_ << "ListLiteral\n";
+    if (!node.elements().empty()) {
+      Scope scope(depth_);
+      for (const auto* elem : node.elements()) {
+        print_expr(*elem);
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Types (inline rendering)
+  // -----------------------------------------------------------------------
+
+  void print_type_inline(const TypeNode& type) {
+    switch (type.kind()) {
+    case NodeKind::NamedType:
+      print_named_type_inline(static_cast<const NamedTypeNode&>(type));
+      break;
+    case NodeKind::PointerType:
+      print_pointer_type_inline(static_cast<const PointerTypeNode&>(type));
+      break;
+    default:
+      out_ << "?";
+      break;
+    }
+  }
+
+  void print_named_type_inline(const NamedTypeNode& type) {
+    print_qualified_path(type.name());
+    if (!type.type_args().empty()) {
+      out_ << "[";
+      for (size_t i = 0; i < type.type_args().size(); ++i) {
+        if (i > 0) {
+          out_ << ", ";
+        }
+        print_type_inline(*type.type_args()[i]);
+      }
+      out_ << "]";
+    }
+  }
+
+  void print_pointer_type_inline(const PointerTypeNode& type) {
+    out_ << "*";
+    print_type_inline(*type.pointee());
+  }
+
+  void print_qualified_path(const QualifiedPath& path) {
+    for (size_t i = 0; i < path.segments.size(); ++i) {
+      if (i > 0) {
+        out_ << "::";
+      }
+      out_ << path.segments[i];
+    }
+  }
+};
+
+// NOLINTEND(readability-identifier-length)
+
+} // namespace
+
+void print_ast(std::ostream& out, const FileNode& file) {
+  AstPrinter printer(out);
+  printer.print(file);
+}
+
+} // namespace dao

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -286,6 +286,9 @@ private:
   }
 
   void print_expr_stmt(const ExpressionStatementNode& node) {
+    indent();
+    out_ << "ExpressionStatement\n";
+    Scope scope(depth_);
     print_expr(*node.expr());
   }
 

--- a/compiler/frontend/ast/ast_printer.h
+++ b/compiler/frontend/ast/ast_printer.h
@@ -1,0 +1,16 @@
+#ifndef DAO_FRONTEND_AST_AST_PRINTER_H
+#define DAO_FRONTEND_AST_AST_PRINTER_H
+
+#include "frontend/ast/ast.h"
+
+#include <ostream>
+
+namespace dao {
+
+/// Print a human-readable, indented AST dump to the given stream.
+/// Output is deterministic and suitable for golden-file testing.
+void print_ast(std::ostream& out, const FileNode& file);
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_AST_AST_PRINTER_H

--- a/compiler/frontend/ast/ast_printer_test.cpp
+++ b/compiler/frontend/ast/ast_printer_test.cpp
@@ -45,6 +45,8 @@ suite ast_golden_tests = [] {
         continue;
       }
       auto golden_path = golden_dir / ("examples_" + entry.path().stem().string() + ".ast");
+      expect(std::filesystem::exists(golden_path))
+          << "missing golden file for " << entry.path().filename().string();
       if (!std::filesystem::exists(golden_path)) {
         continue;
       }
@@ -65,6 +67,8 @@ suite ast_golden_tests = [] {
         continue;
       }
       auto golden_path = golden_dir / ("probes_" + entry.path().stem().string() + ".ast");
+      expect(std::filesystem::exists(golden_path))
+          << "missing golden file for " << entry.path().filename().string();
       if (!std::filesystem::exists(golden_path)) {
         continue;
       }

--- a/compiler/frontend/ast/ast_printer_test.cpp
+++ b/compiler/frontend/ast/ast_printer_test.cpp
@@ -1,0 +1,84 @@
+#include "frontend/ast/ast_printer.h"
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+
+#define BOOST_UT_DISABLE_MODULE
+#include <boost/ut.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+using namespace boost::ut;
+using namespace dao;
+
+auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+auto ast_string(const std::filesystem::path& source_path) -> std::string {
+  auto contents = read_file(source_path);
+  SourceBuffer source(source_path.filename().string(), contents);
+  auto lex_result = lex(source);
+  auto parse_result = parse(lex_result.tokens);
+
+  std::ostringstream out;
+  if (parse_result.file != nullptr) {
+    print_ast(out, *parse_result.file);
+  }
+  return out.str();
+}
+
+// NOLINTBEGIN(readability-function-cognitive-complexity,modernize-use-trailing-return-type)
+
+suite ast_golden_tests = [] {
+  "examples match golden files"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    auto golden_dir = root / "testdata" / "ast";
+
+    for (const auto& entry : std::filesystem::directory_iterator(root / "examples")) {
+      if (entry.path().extension() != ".dao") {
+        continue;
+      }
+      auto golden_path = golden_dir / ("examples_" + entry.path().stem().string() + ".ast");
+      if (!std::filesystem::exists(golden_path)) {
+        continue;
+      }
+
+      auto actual = ast_string(entry.path());
+      auto expected = read_file(golden_path);
+      expect(actual == expected) << "AST mismatch for " << entry.path().filename().string();
+    }
+  };
+
+  "syntax probes match golden files"_test = [] {
+    std::filesystem::path root(DAO_SOURCE_DIR);
+    auto golden_dir = root / "testdata" / "ast";
+
+    for (const auto& entry :
+         std::filesystem::directory_iterator(root / "spec" / "syntax_probes")) {
+      if (entry.path().extension() != ".dao") {
+        continue;
+      }
+      auto golden_path = golden_dir / ("probes_" + entry.path().stem().string() + ".ast");
+      if (!std::filesystem::exists(golden_path)) {
+        continue;
+      }
+
+      auto actual = ast_string(entry.path());
+      auto expected = read_file(golden_path);
+      expect(actual == expected) << "AST mismatch for " << entry.path().filename().string();
+    }
+  };
+};
+
+// NOLINTEND(readability-function-cognitive-complexity,modernize-use-trailing-return-type)
+
+} // namespace
+
+auto main() -> int {
+} // NOLINT(readability-named-parameter)

--- a/testdata/ast/examples_astar.ast
+++ b/testdata/ast/examples_astar.ast
@@ -1,0 +1,58 @@
+File
+  FunctionDecl heuristic
+    Param a: NodeId
+    Param b: NodeId
+    ReturnType: float64
+    ExprBody
+      FloatLiteral 0.0
+  FunctionDecl a_star
+    Param g: Graph
+    Param start: NodeId
+    Param goal: NodeId
+    ReturnType: List[NodeId]
+    ResourceBlock memory Search
+      LetStatement open
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier PriorityQueue
+              Indices
+                Identifier NodeId
+                Identifier float64
+      LetStatement came_from
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier Map
+              Indices
+                Identifier NodeId
+                Identifier NodeId
+      WhileStatement
+        Condition
+          FieldExpr .not_empty
+            Identifier open
+        LetStatement current
+          CallExpr
+            Callee
+              FieldExpr .pop_min
+                Identifier open
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier current
+              Identifier goal
+          Then
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier reconstruct_path
+                Args
+                  Identifier came_from
+                  Identifier start
+                  Identifier goal
+      CallExpr
+        Callee
+          IndexExpr
+            Identifier List
+            Indices
+              Identifier NodeId

--- a/testdata/ast/examples_astar.ast
+++ b/testdata/ast/examples_astar.ast
@@ -50,9 +50,10 @@ File
                   Identifier came_from
                   Identifier start
                   Identifier goal
-      CallExpr
-        Callee
-          IndexExpr
-            Identifier List
-            Indices
-              Identifier NodeId
+      ExpressionStatement
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier List
+              Indices
+                Identifier NodeId

--- a/testdata/ast/examples_hello.ast
+++ b/testdata/ast/examples_hello.ast
@@ -1,0 +1,9 @@
+File
+  FunctionDecl main
+    ReturnType: int32
+    CallExpr
+      Callee
+        Identifier print
+      Args
+        StringLiteral "hello, dao"
+    IntLiteral 0

--- a/testdata/ast/examples_hello.ast
+++ b/testdata/ast/examples_hello.ast
@@ -1,9 +1,11 @@
 File
   FunctionDecl main
     ReturnType: int32
-    CallExpr
-      Callee
-        Identifier print
-      Args
-        StringLiteral "hello, dao"
-    IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "hello, dao"
+    ExpressionStatement
+      IntLiteral 0

--- a/testdata/ast/examples_pipelines.ast
+++ b/testdata/ast/examples_pipelines.ast
@@ -1,0 +1,24 @@
+File
+  FunctionDecl positive_squares
+    Param xs: List[int32]
+    ReturnType: List[int32]
+    ExprBody
+      PipeExpr
+        Identifier xs
+        CallExpr
+          Callee
+            Identifier filter
+          Args
+            Lambda x
+              PipeExpr
+                BinaryExpr >
+                  Identifier x
+                  IntLiteral 0
+                CallExpr
+                  Callee
+                    Identifier map
+                  Args
+                    Lambda x
+                      BinaryExpr *
+                        Identifier x
+                        Identifier x

--- a/testdata/ast/examples_unsafe.ast
+++ b/testdata/ast/examples_unsafe.ast
@@ -1,0 +1,13 @@
+File
+  FunctionDecl read
+    Param ptr: *int32
+    ReturnType: int32
+    LetStatement value: int32
+    ModeBlock unsafe
+      Assignment
+        Target
+          Identifier value
+        Value
+          UnaryExpr *
+            Identifier ptr
+    Identifier value

--- a/testdata/ast/examples_unsafe.ast
+++ b/testdata/ast/examples_unsafe.ast
@@ -10,4 +10,5 @@ File
         Value
           UnaryExpr *
             Identifier ptr
-    Identifier value
+    ExpressionStatement
+      Identifier value

--- a/testdata/ast/probes_astar.ast
+++ b/testdata/ast/probes_astar.ast
@@ -1,0 +1,58 @@
+File
+  FunctionDecl heuristic
+    Param a: NodeId
+    Param b: NodeId
+    ReturnType: float64
+    ExprBody
+      FloatLiteral 0.0
+  FunctionDecl a_star
+    Param g: Graph
+    Param start: NodeId
+    Param goal: NodeId
+    ReturnType: List[NodeId]
+    ResourceBlock memory Search
+      LetStatement open
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier PriorityQueue
+              Indices
+                Identifier NodeId
+                Identifier float64
+      LetStatement came_from
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier Map
+              Indices
+                Identifier NodeId
+                Identifier NodeId
+      WhileStatement
+        Condition
+          FieldExpr .not_empty
+            Identifier open
+        LetStatement current
+          CallExpr
+            Callee
+              FieldExpr .pop_min
+                Identifier open
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier current
+              Identifier goal
+          Then
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier reconstruct_path
+                Args
+                  Identifier came_from
+                  Identifier start
+                  Identifier goal
+      CallExpr
+        Callee
+          IndexExpr
+            Identifier List
+            Indices
+              Identifier NodeId

--- a/testdata/ast/probes_astar.ast
+++ b/testdata/ast/probes_astar.ast
@@ -50,9 +50,10 @@ File
                   Identifier came_from
                   Identifier start
                   Identifier goal
-      CallExpr
-        Callee
-          IndexExpr
-            Identifier List
-            Indices
-              Identifier NodeId
+      ExpressionStatement
+        CallExpr
+          Callee
+            IndexExpr
+              Identifier List
+              Indices
+                Identifier NodeId

--- a/testdata/ast/probes_functions.ast
+++ b/testdata/ast/probes_functions.ast
@@ -19,4 +19,5 @@ File
         Value
           UnaryExpr *
             Identifier ptr
-    Identifier value
+    ExpressionStatement
+      Identifier value

--- a/testdata/ast/probes_functions.ast
+++ b/testdata/ast/probes_functions.ast
@@ -1,0 +1,22 @@
+File
+  FunctionDecl add
+    Param a: int32
+    Param b: int32
+    ReturnType: int32
+    ExprBody
+      BinaryExpr +
+        Identifier a
+        Identifier b
+  FunctionDecl read
+    Param ptr: *int32
+    ReturnType: int32
+    LetStatement value: int32
+      IntLiteral 0
+    ModeBlock unsafe
+      Assignment
+        Target
+          Identifier value
+        Value
+          UnaryExpr *
+            Identifier ptr
+    Identifier value

--- a/testdata/ast/probes_modes_and_resources.ast
+++ b/testdata/ast/probes_modes_and_resources.ast
@@ -1,0 +1,22 @@
+File
+  FunctionDecl search
+    Param start: NodeId
+    Param goal: NodeId
+    ReturnType: List[NodeId]
+    ResourceBlock memory Search
+      ModeBlock parallel
+        LetStatement frontier
+          CallExpr
+            Callee
+              IndexExpr
+                Identifier PriorityQueue
+                Indices
+                  Identifier NodeId
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier frontier
+          Args
+            Identifier start
+        ListLiteral
+          Identifier goal

--- a/testdata/ast/probes_modes_and_resources.ast
+++ b/testdata/ast/probes_modes_and_resources.ast
@@ -12,11 +12,13 @@ File
                 Identifier PriorityQueue
                 Indices
                   Identifier NodeId
-        CallExpr
-          Callee
-            FieldExpr .push
-              Identifier frontier
-          Args
-            Identifier start
-        ListLiteral
-          Identifier goal
+        ExpressionStatement
+          CallExpr
+            Callee
+              FieldExpr .push
+                Identifier frontier
+            Args
+              Identifier start
+        ExpressionStatement
+          ListLiteral
+            Identifier goal

--- a/testdata/ast/probes_pipelines.ast
+++ b/testdata/ast/probes_pipelines.ast
@@ -2,22 +2,23 @@ File
   FunctionDecl positive_squares
     Param xs: List[int32]
     ReturnType: List[int32]
-    PipeExpr
-      Identifier xs
-      CallExpr
-        Callee
-          Identifier filter
-        Args
-          Lambda x
-            PipeExpr
-              BinaryExpr >
-                Identifier x
-                IntLiteral 0
-              CallExpr
-                Callee
-                  Identifier map
-                Args
-                  Lambda x
-                    BinaryExpr *
-                      Identifier x
-                      Identifier x
+    ExpressionStatement
+      PipeExpr
+        Identifier xs
+        CallExpr
+          Callee
+            Identifier filter
+          Args
+            Lambda x
+              PipeExpr
+                BinaryExpr >
+                  Identifier x
+                  IntLiteral 0
+                CallExpr
+                  Callee
+                    Identifier map
+                  Args
+                    Lambda x
+                      BinaryExpr *
+                        Identifier x
+                        Identifier x

--- a/testdata/ast/probes_pipelines.ast
+++ b/testdata/ast/probes_pipelines.ast
@@ -1,0 +1,23 @@
+File
+  FunctionDecl positive_squares
+    Param xs: List[int32]
+    ReturnType: List[int32]
+    PipeExpr
+      Identifier xs
+      CallExpr
+        Callee
+          Identifier filter
+        Args
+          Lambda x
+            PipeExpr
+              BinaryExpr >
+                Identifier x
+                IntLiteral 0
+              CallExpr
+                Callee
+                  Identifier map
+                Args
+                  Lambda x
+                    BinaryExpr *
+                      Identifier x
+                      Identifier x


### PR DESCRIPTION
## Summary

Implements Task 3 from the implementation plan: a deterministic AST pretty-printer for `daoc`, golden-file regression tests, and the `daoc ast <file>` subcommand.

## Highlights

- **`ast_printer.h` / `ast_printer.cpp`** — tree-walking printer producing indented, human-readable output covering all 30 AST node kinds; types are rendered inline (e.g. `Param xs: List[int32]`)
- **`daoc ast <file>`** — new subcommand wired into the driver
- **`lex_and_parse()` helper** — extracted shared lex→parse→diagnose logic used by both `cmd_parse` and `cmd_ast`, eliminating duplication
- **Golden files** — 8 `.ast` snapshots under `testdata/ast/` (4 examples + 4 syntax probes), prefixed by directory to avoid stem collisions
- **`ast_printer_test`** — golden-file comparison test registered with CTest

## Test plan

- [x] `ast_printer_test` passes (8 golden-file assertions across 2 suites)
- [x] `parser_test` passes (140 assertions, 37 tests)
- [x] `lexer_test` passes (94 assertions, 16 tests)
- [x] `daoc ast` produces readable output for all examples and syntax probes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)