### PR TITLE
feat(playground): ✨ add structural playground with compiler service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
 
       - name: Check formatting
         run: |
-          find compiler -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
+          find compiler tools -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
 
       - name: Run clang-tidy
         run: |
-          find compiler -name '*.cpp' | xargs clang-tidy -p build/debug
+          find compiler tools -name '*.cpp' | xargs clang-tidy -p build/debug

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"aqua:go-task/task" = "3.40.1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,4 @@ enable_testing()
 
 add_subdirectory(compiler/frontend)
 add_subdirectory(compiler/driver)
+add_subdirectory(tools/playground)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
       - ctest --test-dir {{.BUILD_DIR}} --output-on-failure
 
   playground:
-    desc: Start the playground server (http://localhost:8080)
+    desc: Start the playground server (http://localhost:8090)
     deps: [build]
     cmds:
       - "{{.BUILD_DIR}}/tools/playground/compiler_service/dao_playground {{.CLI_ARGS}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,85 @@
+version: "3"
+
+vars:
+  BUILD_DIR: build/debug
+  PROFILE: profiles/clang-21-debug
+
+tasks:
+  deps:
+    desc: Install Conan dependencies
+    cmds:
+      - >-
+        conan install .
+        -pr {{.PROFILE}}
+        -pr:b {{.PROFILE}}
+        --build=missing
+        -of {{.BUILD_DIR}}
+    sources:
+      - conanfile.txt
+      - "{{.PROFILE}}"
+    generates:
+      - "{{.BUILD_DIR}}/conan_toolchain.cmake"
+
+  configure:
+    desc: Configure CMake
+    deps: [deps]
+    cmds:
+      - cmake --preset debug
+    sources:
+      - CMakeLists.txt
+      - compiler/**/CMakeLists.txt
+      - tools/**/CMakeLists.txt
+    generates:
+      - "{{.BUILD_DIR}}/Makefile"
+
+  build:
+    desc: Build all targets
+    deps: [configure]
+    cmds:
+      - cmake --build {{.BUILD_DIR}}
+
+  test:
+    desc: Run all tests
+    deps: [build]
+    cmds:
+      - ctest --test-dir {{.BUILD_DIR}} --output-on-failure
+
+  playground:
+    desc: Start the playground server (http://localhost:8080)
+    deps: [build]
+    cmds:
+      - "{{.BUILD_DIR}}/tools/playground/compiler_service/dao_playground {{.CLI_ARGS}}"
+
+  format:
+    desc: Run clang-format on all source files
+    cmds:
+      - find compiler tools -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+
+  format-check:
+    desc: Check clang-format without modifying files
+    cmds:
+      - find compiler tools -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
+
+  lint:
+    desc: Run clang-tidy on all source files
+    deps: [configure]
+    cmds:
+      - find compiler tools -name '*.cpp' | xargs clang-tidy -p {{.BUILD_DIR}}
+
+  lex:
+    desc: "Run daoc lex on a file (usage: task lex -- file.dao)"
+    deps: [build]
+    cmds:
+      - "{{.BUILD_DIR}}/compiler/driver/daoc lex {{.CLI_ARGS}}"
+
+  parse:
+    desc: "Run daoc parse on a file (usage: task parse -- file.dao)"
+    deps: [build]
+    cmds:
+      - "{{.BUILD_DIR}}/compiler/driver/daoc parse {{.CLI_ARGS}}"
+
+  ast:
+    desc: "Run daoc ast on a file (usage: task ast -- file.dao)"
+    deps: [build]
+    cmds:
+      - "{{.BUILD_DIR}}/compiler/driver/daoc ast {{.CLI_ARGS}}"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,7 @@
 [requires]
 boost-ext-ut/2.3.1
+cpp-httplib/0.18.3
+nlohmann_json/3.11.3
 
 [generators]
 CMakeDeps

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -12,6 +12,8 @@ Normative behavior lives in `CLAUDE.md` and `docs/contracts/`.
 | `README.md` | Project overview |
 | `.bonsai.yaml` | Repo-local Bonsai routing hints |
 | `.grove.yaml` | Grove project metadata and consolidation hints |
+| `.mise.toml` | mise tool version pins (task runner) |
+| `Taskfile.yml` | Task runner commands (build, test, playground, etc.) |
 
 ## `docs/`
 

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -104,6 +104,8 @@ Fixtures and golden inputs/outputs for future parser/compiler tests.
 Developer-surface tooling built on compiler analysis.
 
 - `playground/` — first-class web playground and future web-IDE surface
+  - `compiler_service/` — HTTP server wrapping the compiler frontend (cpp-httplib + nlohmann/json)
+  - `frontend/` — vanilla HTML/CSS/JS with CodeMirror 6 for structural token highlighting, AST panel, and diagnostics panel
 - `lsp/` — Language Server Protocol implementation
 - `formatter/` — reserved canonical formatter root
 - `diagnostics/` — presentation and diagnostics tooling experiments

--- a/locks/clang-21-debug.lock
+++ b/locks/clang-21-debug.lock
@@ -1,6 +1,8 @@
 {
     "version": "0.5",
     "requires": [
+        "nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d%1701220705.259",
+        "cpp-httplib/0.18.3#ad62795f35f0fecaea1fd4bdb7b949f0%1748426309.372",
         "boost-ext-ut/2.3.1#e0a2761f845926e65a8aee07e3995ed5%1749912869.147"
     ],
     "build_requires": [

--- a/tools/playground/CMakeLists.txt
+++ b/tools/playground/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(compiler_service)

--- a/tools/playground/README.md
+++ b/tools/playground/README.md
@@ -15,11 +15,11 @@ Long-term north star: lightweight web-based IDE.
 # from repo root, after cmake build:
 build/debug/tools/playground/compiler_service/dao_playground
 
-# open http://localhost:8080
+# open http://localhost:8090
 ```
 
 Options:
-- `--port N` — listen port (default 8080)
+- `--port N` — listen port (default 8090)
 - `--root DIR` — repository root (default: compile-time `DAO_SOURCE_DIR`)
 
 ## Architecture

--- a/tools/playground/README.md
+++ b/tools/playground/README.md
@@ -8,3 +8,29 @@ semantic tokens, hover payloads, and document symbol information as those
 services come online.
 
 Long-term north star: lightweight web-based IDE.
+
+## Quick start
+
+```
+# from repo root, after cmake build:
+build/debug/tools/playground/compiler_service/dao_playground
+
+# open http://localhost:8080
+```
+
+Options:
+- `--port N` — listen port (default 8080)
+- `--root DIR` — repository root (default: compile-time `DAO_SOURCE_DIR`)
+
+## Architecture
+
+- `compiler_service/` — C++ HTTP server (cpp-httplib) wrapping the
+  compiler frontend (lexer, parser, AST printer)
+- `frontend/` — vanilla HTML/CSS/JS with CodeMirror 6 (loaded from CDN)
+
+## API
+
+- `POST /api/analyze` — accepts `{"source": "..."}`, returns tokens,
+  AST text, and diagnostics
+- `GET /api/examples` — lists `examples/*.dao` files
+- `GET /api/examples/:name` — returns example source

--- a/tools/playground/compiler_service/CMakeLists.txt
+++ b/tools/playground/compiler_service/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(httplib REQUIRED)
+find_package(nlohmann_json REQUIRED)
+
+add_executable(dao_playground
+  main.cpp
+  analyze.cpp
+  examples.cpp
+)
+
+target_link_libraries(dao_playground PRIVATE
+  dao_frontend
+  httplib::httplib
+  nlohmann_json::nlohmann_json
+)
+
+target_compile_definitions(dao_playground PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -1,0 +1,101 @@
+#include "analyze.h"
+#include "token_category.h"
+
+#include "frontend/ast/ast_printer.h"
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+
+#include <nlohmann/json.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace dao::playground {
+
+// NOLINTBEGIN(readability-magic-numbers)
+void handle_analyze(const httplib::Request& req, httplib::Response& res) {
+  nlohmann::json request;
+  try {
+    request = nlohmann::json::parse(req.body);
+  } catch (const nlohmann::json::parse_error&) {
+    res.status = 400;
+    res.set_content(R"({"error":"invalid JSON"})", "application/json");
+    return;
+  }
+
+  if (!request.contains("source") || !request["source"].is_string()) {
+    res.status = 400;
+    res.set_content(R"({"error":"missing 'source' field"})", "application/json");
+    return;
+  }
+
+  auto source_text = request["source"].get<std::string>();
+  SourceBuffer source("<playground>", std::move(source_text));
+  auto lex_result = lex(source);
+
+  // Build token array (filtering synthetic tokens).
+  nlohmann::json tokens = nlohmann::json::array();
+  for (const auto& tok : lex_result.tokens) {
+    if (is_synthetic_token(tok.kind)) {
+      continue;
+    }
+    auto loc = source.line_col(tok.span.offset);
+    tokens.push_back({
+        {"kind", token_kind_name(tok.kind)},
+        {"category", token_category(tok.kind)},
+        {"offset", tok.span.offset},
+        {"length", tok.span.length},
+        {"line", loc.line},
+        {"col", loc.col},
+        {"text", std::string(tok.text)},
+    });
+  }
+
+  // Collect diagnostics from lexer.
+  nlohmann::json diagnostics = nlohmann::json::array();
+  for (const auto& diag : lex_result.diagnostics) {
+    auto loc = source.line_col(diag.span.offset);
+    diagnostics.push_back({
+        {"severity", "error"},
+        {"offset", diag.span.offset},
+        {"length", diag.span.length},
+        {"line", loc.line},
+        {"col", loc.col},
+        {"message", diag.message},
+    });
+  }
+
+  // Parse and collect AST + parse diagnostics.
+  std::string ast_text;
+  auto parse_result = parse(lex_result.tokens);
+
+  if (parse_result.file != nullptr) {
+    std::ostringstream ast_out;
+    print_ast(ast_out, *parse_result.file);
+    ast_text = ast_out.str();
+  }
+
+  for (const auto& diag : parse_result.diagnostics) {
+    auto loc = source.line_col(diag.span.offset);
+    diagnostics.push_back({
+        {"severity", "error"},
+        {"offset", diag.span.offset},
+        {"length", diag.span.length},
+        {"line", loc.line},
+        {"col", loc.col},
+        {"message", diag.message},
+    });
+  }
+
+  nlohmann::json response = {
+      {"tokens", tokens},
+      {"ast", ast_text},
+      {"diagnostics", diagnostics},
+  };
+
+  res.set_content(response.dump(), "application/json");
+}
+
+// NOLINTEND(readability-magic-numbers)
+
+} // namespace dao::playground

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -65,26 +65,29 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res) {
     });
   }
 
-  // Parse and collect AST + parse diagnostics.
+  // Only parse if lexing succeeded — matches CLI behavior.
   std::string ast_text;
-  auto parse_result = parse(lex_result.tokens);
+  if (lex_result.diagnostics.empty()) {
+    auto parse_result = parse(lex_result.tokens);
 
-  if (parse_result.file != nullptr) {
-    std::ostringstream ast_out;
-    print_ast(ast_out, *parse_result.file);
-    ast_text = ast_out.str();
-  }
+    for (const auto& diag : parse_result.diagnostics) {
+      auto loc = source.line_col(diag.span.offset);
+      diagnostics.push_back({
+          {"severity", "error"},
+          {"offset", diag.span.offset},
+          {"length", diag.span.length},
+          {"line", loc.line},
+          {"col", loc.col},
+          {"message", diag.message},
+      });
+    }
 
-  for (const auto& diag : parse_result.diagnostics) {
-    auto loc = source.line_col(diag.span.offset);
-    diagnostics.push_back({
-        {"severity", "error"},
-        {"offset", diag.span.offset},
-        {"length", diag.span.length},
-        {"line", loc.line},
-        {"col", loc.col},
-        {"message", diag.message},
-    });
+    // Only emit AST when there are no diagnostics at all.
+    if (diagnostics.empty() && parse_result.file != nullptr) {
+      std::ostringstream ast_out;
+      print_ast(ast_out, *parse_result.file);
+      ast_text = ast_out.str();
+    }
   }
 
   nlohmann::json response = {

--- a/tools/playground/compiler_service/analyze.h
+++ b/tools/playground/compiler_service/analyze.h
@@ -1,0 +1,12 @@
+#ifndef DAO_PLAYGROUND_ANALYZE_H
+#define DAO_PLAYGROUND_ANALYZE_H
+
+#include <httplib.h>
+
+namespace dao::playground {
+
+void handle_analyze(const httplib::Request& req, httplib::Response& res);
+
+} // namespace dao::playground
+
+#endif // DAO_PLAYGROUND_ANALYZE_H

--- a/tools/playground/compiler_service/examples.cpp
+++ b/tools/playground/compiler_service/examples.cpp
@@ -1,0 +1,66 @@
+#include "examples.h"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <ranges>
+#include <string>
+#include <vector>
+
+// NOLINTBEGIN(readability-magic-numbers)
+namespace dao::playground {
+
+void handle_examples_list(const httplib::Request& /*req*/,
+                          httplib::Response& res,
+                          const std::filesystem::path& examples_dir) {
+  nlohmann::json examples = nlohmann::json::array();
+
+  if (std::filesystem::exists(examples_dir)) {
+    std::vector<std::string> names;
+    for (const auto& entry : std::filesystem::directory_iterator(examples_dir)) {
+      if (entry.path().extension() == ".dao") {
+        names.push_back(entry.path().filename().string());
+      }
+    }
+    std::ranges::sort(names);
+    for (const auto& name : names) {
+      examples.push_back({{"name", name}});
+    }
+  }
+
+  nlohmann::json response = {{"examples", examples}};
+  res.set_content(response.dump(), "application/json");
+}
+
+void handle_example_get(const httplib::Request& req,
+                        httplib::Response& res,
+                        const std::filesystem::path& examples_dir) {
+  auto name = req.path_params.at("name");
+
+  // Path traversal guard: name must end with .dao and contain no
+  // slashes, backslashes, or parent references.
+  if (name.find('/') != std::string::npos || name.find('\\') != std::string::npos ||
+      name.find("..") != std::string::npos || name.size() < 5 ||
+      name.substr(name.size() - 4) != ".dao") {
+    res.status = 400;
+    res.set_content(R"({"error":"invalid example name"})", "application/json");
+    return;
+  }
+
+  auto path = examples_dir / name;
+  if (!std::filesystem::exists(path)) {
+    res.status = 404;
+    res.set_content(R"({"error":"example not found"})", "application/json");
+    return;
+  }
+
+  std::ifstream file(path);
+  std::string contents{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+
+  nlohmann::json response = {{"name", name}, {"source", contents}};
+  res.set_content(response.dump(), "application/json");
+}
+
+// NOLINTEND(readability-magic-numbers)
+
+} // namespace dao::playground

--- a/tools/playground/compiler_service/examples.h
+++ b/tools/playground/compiler_service/examples.h
@@ -1,0 +1,20 @@
+#ifndef DAO_PLAYGROUND_EXAMPLES_H
+#define DAO_PLAYGROUND_EXAMPLES_H
+
+#include <httplib.h>
+
+#include <filesystem>
+
+namespace dao::playground {
+
+void handle_examples_list(const httplib::Request& req,
+                          httplib::Response& res,
+                          const std::filesystem::path& examples_dir);
+
+void handle_example_get(const httplib::Request& req,
+                        httplib::Response& res,
+                        const std::filesystem::path& examples_dir);
+
+} // namespace dao::playground
+
+#endif // DAO_PLAYGROUND_EXAMPLES_H

--- a/tools/playground/compiler_service/main.cpp
+++ b/tools/playground/compiler_service/main.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -59,7 +60,21 @@ auto main(int argc, char* argv[]) -> int {
   // NOLINTEND(modernize-use-trailing-return-type)
 
   // Serve frontend static files.
+  auto index_path = frontend_dir / "index.html";
   svr.set_mount_point("/", frontend_dir.string());
+
+  // Explicit root handler to prevent any redirect behavior.
+  // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+  svr.Get("/", [index_path](const httplib::Request& /*req*/, httplib::Response& res) {
+    std::ifstream file(index_path);
+    if (!file) {
+      res.status = 500; // NOLINT(readability-magic-numbers)
+      res.set_content("index.html not found", "text/plain");
+      return;
+    }
+    std::string body{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+    res.set_content(body, "text/html");
+  });
 
   std::cout << "Dao playground: http://localhost:" << port << "\n";
   std::cout << "  frontend: " << frontend_dir << "\n";

--- a/tools/playground/compiler_service/main.cpp
+++ b/tools/playground/compiler_service/main.cpp
@@ -1,0 +1,74 @@
+#include "analyze.h"
+#include "examples.h"
+
+#include <httplib.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+auto find_repo_root() -> std::filesystem::path {
+  // DAO_SOURCE_DIR is baked in at compile time.
+  return DAO_SOURCE_DIR;
+}
+
+} // namespace
+
+auto main(int argc, char* argv[]) -> int {
+  int port = 8080; // NOLINT(readability-magic-numbers)
+  auto root = find_repo_root();
+
+  // Simple arg parsing: --port N and --root DIR
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    if (arg == "--port" && i + 1 < argc) {
+      port = std::atoi(argv[++i]); // NOLINT(cert-err34-c)
+    } else if (arg == "--root" && i + 1 < argc) {
+      root = argv[++i];
+    }
+  }
+
+  auto examples_dir = root / "examples";
+  auto frontend_dir = root / "tools" / "playground" / "frontend";
+
+  if (!std::filesystem::exists(frontend_dir)) {
+    std::cerr << "error: frontend directory not found: " << frontend_dir << "\n";
+    return EXIT_FAILURE;
+  }
+
+  httplib::Server svr;
+
+  // API endpoints.
+  // NOLINTBEGIN(modernize-use-trailing-return-type)
+  svr.Post("/api/analyze", [](const httplib::Request& req, httplib::Response& res) {
+    dao::playground::handle_analyze(req, res);
+  });
+
+  svr.Get("/api/examples", [&examples_dir](const httplib::Request& req, httplib::Response& res) {
+    dao::playground::handle_examples_list(req, res, examples_dir);
+  });
+
+  svr.Get("/api/examples/:name",
+          [&examples_dir](const httplib::Request& req, httplib::Response& res) {
+            dao::playground::handle_example_get(req, res, examples_dir);
+          });
+  // NOLINTEND(modernize-use-trailing-return-type)
+
+  // Serve frontend static files.
+  svr.set_mount_point("/", frontend_dir.string());
+
+  std::cout << "Dao playground: http://localhost:" << port << "\n";
+  std::cout << "  frontend: " << frontend_dir << "\n";
+  std::cout << "  examples: " << examples_dir << "\n";
+
+  if (!svr.listen("0.0.0.0", port)) {
+    std::cerr << "error: failed to start server on port " << port << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tools/playground/compiler_service/main.cpp
+++ b/tools/playground/compiler_service/main.cpp
@@ -20,7 +20,7 @@ auto find_repo_root() -> std::filesystem::path {
 } // namespace
 
 auto main(int argc, char* argv[]) -> int {
-  int port = 8080; // NOLINT(readability-magic-numbers)
+  int port = 8090; // NOLINT(readability-magic-numbers)
   auto root = find_repo_root();
 
   // Simple arg parsing: --port N and --root DIR

--- a/tools/playground/compiler_service/token_category.h
+++ b/tools/playground/compiler_service/token_category.h
@@ -1,0 +1,106 @@
+#ifndef DAO_PLAYGROUND_TOKEN_CATEGORY_H
+#define DAO_PLAYGROUND_TOKEN_CATEGORY_H
+
+#include "frontend/lexer/token.h"
+
+#include <string_view>
+
+namespace dao::playground {
+
+/// Map a TokenKind to a structural highlight category.
+/// This is a lexical classification only — semantic classification
+/// comes in Task 5.
+inline auto token_category(TokenKind kind) -> std::string_view {
+  switch (kind) {
+  // Keywords
+  case TokenKind::KwImport:
+  case TokenKind::KwFn:
+  case TokenKind::KwStruct:
+  case TokenKind::KwType:
+  case TokenKind::KwLet:
+  case TokenKind::KwIf:
+  case TokenKind::KwElse:
+  case TokenKind::KwWhile:
+  case TokenKind::KwFor:
+  case TokenKind::KwIn:
+  case TokenKind::KwReturn:
+  case TokenKind::KwMode:
+  case TokenKind::KwResource:
+  case TokenKind::KwAnd:
+  case TokenKind::KwOr:
+    return "keyword";
+
+  // Keyword literals
+  case TokenKind::KwTrue:
+  case TokenKind::KwFalse:
+    return "literal.bool";
+
+  // Numeric literals
+  case TokenKind::IntLiteral:
+  case TokenKind::FloatLiteral:
+    return "literal.number";
+
+  // String literals
+  case TokenKind::StringLiteral:
+    return "literal.string";
+
+  // Operators
+  case TokenKind::Colon:
+  case TokenKind::ColonColon:
+  case TokenKind::Arrow:
+  case TokenKind::FatArrow:
+  case TokenKind::Eq:
+  case TokenKind::EqEq:
+  case TokenKind::BangEq:
+  case TokenKind::Lt:
+  case TokenKind::LtEq:
+  case TokenKind::Gt:
+  case TokenKind::GtEq:
+  case TokenKind::Plus:
+  case TokenKind::Minus:
+  case TokenKind::Star:
+  case TokenKind::Slash:
+  case TokenKind::Percent:
+  case TokenKind::Amp:
+  case TokenKind::Bang:
+  case TokenKind::Dot:
+  case TokenKind::Comma:
+  case TokenKind::Pipe:
+  case TokenKind::PipeGt:
+    return "operator";
+
+  // Delimiters
+  case TokenKind::LParen:
+  case TokenKind::RParen:
+  case TokenKind::LBracket:
+  case TokenKind::RBracket:
+    return "punctuation";
+
+  // Identifier
+  case TokenKind::Identifier:
+    return "identifier";
+
+  // Synthetic
+  case TokenKind::Newline:
+  case TokenKind::Indent:
+  case TokenKind::Dedent:
+  case TokenKind::Eof:
+    return "synthetic";
+
+  // Error
+  case TokenKind::Error:
+    return "error";
+  }
+  return "unknown";
+}
+
+/// Returns true for synthetic tokens that should be filtered from
+/// the response (not useful for highlighting).
+inline auto is_synthetic_token(TokenKind kind) -> bool {
+  return kind == TokenKind::Newline || kind == TokenKind::Indent || kind == TokenKind::Dedent ||
+         kind == TokenKind::Eof;
+}
+
+} // namespace dao::playground
+
+#endif // DAO_PLAYGROUND_TOKEN_CATEGORY_H

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -1,16 +1,18 @@
+// All esm.sh imports pin @codemirror/state and @codemirror/view via ?deps
+// so that only one instance of each package is loaded at runtime.
+// Without this, instanceof checks inside CodeMirror break.
 import {
-  EditorView,
   basicSetup,
-} from "https://esm.sh/@codemirror/basic-setup@0.20.0";
-import { EditorState } from "https://esm.sh/@codemirror/state@6.5.2";
+} from "https://esm.sh/codemirror@6.0.2?deps=@codemirror/state@6.5.4,@codemirror/view@6.39.16";
+import { EditorState } from "https://esm.sh/@codemirror/state@6.5.4";
 import {
   Decoration,
+  EditorView,
   ViewPlugin,
-  WidgetType,
-} from "https://esm.sh/@codemirror/view@6.36.5";
+} from "https://esm.sh/@codemirror/view@6.39.16";
 import {
   oneDark,
-} from "https://esm.sh/@codemirror/theme-one-dark@6.1.2";
+} from "https://esm.sh/@codemirror/theme-one-dark@6.1.3?deps=@codemirror/state@6.5.4,@codemirror/view@6.39.16";
 
 // ---------------------------------------------------------------------------
 // State

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -1,0 +1,206 @@
+import {
+  EditorView,
+  basicSetup,
+} from "https://esm.sh/@codemirror/basic-setup@0.20.0";
+import { EditorState } from "https://esm.sh/@codemirror/state@6.5.2";
+import {
+  Decoration,
+  ViewPlugin,
+  WidgetType,
+} from "https://esm.sh/@codemirror/view@6.36.5";
+import {
+  oneDark,
+} from "https://esm.sh/@codemirror/theme-one-dark@6.1.2";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let currentTokens = [];
+let analyzeTimer = null;
+const DEBOUNCE_MS = 300;
+
+// ---------------------------------------------------------------------------
+// Token decoration plugin
+// ---------------------------------------------------------------------------
+
+const categoryToClass = {
+  "keyword": "dao-keyword",
+  "literal.number": "dao-literal-number",
+  "literal.string": "dao-literal-string",
+  "literal.bool": "dao-literal-bool",
+  "operator": "dao-operator",
+  "punctuation": "dao-punctuation",
+  "identifier": "dao-identifier",
+  "error": "dao-error",
+};
+
+function buildDecorations(view) {
+  const decorations = [];
+  const docLength = view.state.doc.length;
+
+  for (const tok of currentTokens) {
+    const from = tok.offset;
+    const to = tok.offset + tok.length;
+    if (from >= docLength || to > docLength || from >= to) continue;
+
+    const cls = categoryToClass[tok.category];
+    if (!cls) continue;
+
+    decorations.push(
+      Decoration.mark({ class: cls }).range(from, to)
+    );
+  }
+
+  return Decoration.set(decorations, true);
+}
+
+const tokenHighlighter = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      this.decorations = buildDecorations(view);
+    }
+    update(update) {
+      // Rebuild when tokens change (triggered by dispatching a no-op)
+      this.decorations = buildDecorations(update.view);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Editor setup
+// ---------------------------------------------------------------------------
+
+const defaultSource = `fn main(): int32
+    print("hello, dao")
+    0
+`;
+
+const editor = new EditorView({
+  state: EditorState.create({
+    doc: defaultSource,
+    extensions: [
+      basicSetup,
+      oneDark,
+      tokenHighlighter,
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          scheduleAnalyze();
+        }
+      }),
+    ],
+  }),
+  parent: document.getElementById("editor-container"),
+});
+
+// ---------------------------------------------------------------------------
+// Analysis
+// ---------------------------------------------------------------------------
+
+function scheduleAnalyze() {
+  if (analyzeTimer) clearTimeout(analyzeTimer);
+  analyzeTimer = setTimeout(doAnalyze, DEBOUNCE_MS);
+}
+
+async function doAnalyze() {
+  const source = editor.state.doc.toString();
+
+  try {
+    const resp = await fetch("/api/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source }),
+    });
+
+    if (!resp.ok) return;
+    const data = await resp.json();
+
+    // Update tokens and refresh decorations.
+    currentTokens = data.tokens || [];
+    // Force decoration rebuild by dispatching empty transaction.
+    editor.dispatch({});
+
+    // Update AST panel.
+    document.getElementById("ast-output").textContent = data.ast || "";
+
+    // Update diagnostics panel.
+    renderDiagnostics(data.diagnostics || []);
+  } catch (err) {
+    console.error("analyze failed:", err);
+  }
+}
+
+function renderDiagnostics(diagnostics) {
+  const container = document.getElementById("diagnostics-output");
+
+  if (diagnostics.length === 0) {
+    container.innerHTML = '<div class="no-diagnostics">No errors</div>';
+    return;
+  }
+
+  container.innerHTML = diagnostics
+    .map(
+      (d) =>
+        `<div class="diagnostic"><span class="location">${d.line}:${d.col}</span>${escapeHtml(d.message)}</div>`
+    )
+    .join("");
+}
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+// ---------------------------------------------------------------------------
+// Example loader
+// ---------------------------------------------------------------------------
+
+async function loadExamples() {
+  try {
+    const resp = await fetch("/api/examples");
+    if (!resp.ok) return;
+    const data = await resp.json();
+
+    const select = document.getElementById("example-select");
+    for (const example of data.examples || []) {
+      const option = document.createElement("option");
+      option.value = example.name;
+      option.textContent = example.name;
+      select.appendChild(option);
+    }
+
+    select.addEventListener("change", async () => {
+      const name = select.value;
+      if (!name) return;
+
+      try {
+        const resp = await fetch(`/api/examples/${encodeURIComponent(name)}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+
+        editor.dispatch({
+          changes: {
+            from: 0,
+            to: editor.state.doc.length,
+            insert: data.source,
+          },
+        });
+      } catch (err) {
+        console.error("failed to load example:", err);
+      }
+    });
+  } catch (err) {
+    console.error("failed to load example list:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+loadExamples();
+doAnalyze();

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -18,6 +18,7 @@ import {
 
 let currentTokens = [];
 let analyzeTimer = null;
+let analyzeSeq = 0;
 const DEBOUNCE_MS = 300;
 
 // ---------------------------------------------------------------------------
@@ -107,6 +108,7 @@ function scheduleAnalyze() {
 
 async function doAnalyze() {
   const source = editor.state.doc.toString();
+  const seq = ++analyzeSeq;
 
   try {
     const resp = await fetch("/api/analyze", {
@@ -115,8 +117,15 @@ async function doAnalyze() {
       body: JSON.stringify({ source }),
     });
 
+    // Discard stale responses — a newer request has been issued.
+    if (seq !== analyzeSeq) return;
+
     if (!resp.ok) return;
     const data = await resp.json();
+
+    // Double-check after await: another request may have started
+    // while we were parsing the response body.
+    if (seq !== analyzeSeq) return;
 
     // Update tokens and refresh decorations.
     currentTokens = data.tokens || [];

--- a/tools/playground/frontend/index.html
+++ b/tools/playground/frontend/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dao Playground</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Dao Playground</h1>
+    <div class="controls">
+      <select id="example-select">
+        <option value="">— load example —</option>
+      </select>
+    </div>
+  </header>
+  <main>
+    <div id="editor-panel">
+      <div class="panel-header">Source</div>
+      <div id="editor-container"></div>
+    </div>
+    <div id="right-panels">
+      <div id="ast-panel">
+        <div class="panel-header">AST</div>
+        <pre id="ast-output"></pre>
+      </div>
+      <div id="diagnostics-panel">
+        <div class="panel-header">Diagnostics</div>
+        <div id="diagnostics-output"></div>
+      </div>
+    </div>
+  </main>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/tools/playground/frontend/style.css
+++ b/tools/playground/frontend/style.css
@@ -1,0 +1,163 @@
+:root {
+  --bg: #1e1e2e;
+  --bg-panel: #181825;
+  --bg-header: #11111b;
+  --fg: #cdd6f4;
+  --fg-dim: #6c7086;
+  --border: #313244;
+  --accent: #89b4fa;
+  --error: #f38ba8;
+  --green: #a6e3a1;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  background: var(--bg);
+  color: var(--fg);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  background: var(--bg-header);
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+select {
+  background: var(--bg-panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+
+#editor-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  min-height: 0;
+}
+
+#editor-container {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+#right-panels {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#ast-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border);
+  min-height: 0;
+}
+
+#diagnostics-panel {
+  flex: 0 0 auto;
+  max-height: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  background: var(--bg-header);
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+}
+
+#ast-output {
+  flex: 1;
+  padding: 12px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+  min-height: 0;
+}
+
+#diagnostics-output {
+  flex: 1;
+  padding: 8px 12px;
+  overflow: auto;
+  font-size: 13px;
+}
+
+.diagnostic {
+  padding: 4px 0;
+  color: var(--error);
+}
+
+.diagnostic .location {
+  color: var(--fg-dim);
+  margin-right: 8px;
+}
+
+.no-diagnostics {
+  color: var(--green);
+  font-style: italic;
+}
+
+/* CodeMirror theme overrides */
+.cm-editor {
+  height: 100%;
+  font-size: 14px;
+}
+
+.cm-editor .cm-scroller {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+}
+
+.cm-editor .cm-content {
+  padding: 12px 0;
+}
+
+.cm-editor .cm-line {
+  padding: 0 12px;
+}
+
+/* Token highlight classes applied via decorations */
+.dao-keyword { color: #cba6f7; }
+.dao-literal-number { color: #fab387; }
+.dao-literal-string { color: #a6e3a1; }
+.dao-literal-bool { color: #fab387; }
+.dao-operator { color: #89dceb; }
+.dao-punctuation { color: #6c7086; }
+.dao-identifier { color: #cdd6f4; }
+.dao-error { color: #f38ba8; text-decoration: wavy underline; }


### PR DESCRIPTION
## Summary

Implements Task 4 from the implementation plan: a web playground tied to the compiler frontend with structural token highlighting, an AST panel, and a diagnostics panel. The playground consumes compiler-produced analysis — no bespoke regexes.

## Highlights

- **Compiler service** (`tools/playground/compiler_service/`) — cpp-httplib HTTP server exposing `POST /api/analyze`, `GET /api/examples`, and `GET /api/examples/:name` endpoints that wrap the existing lexer, parser, and AST printer
- **Frontend** (`tools/playground/frontend/`) — vanilla HTML/CSS/JS with CodeMirror 6 (loaded from CDN), dark theme, three-panel layout (editor, AST, diagnostics), debounced analysis on keystroke
- **Token categories** — structural classification mapping (`token_category.h`) from `TokenKind` to highlight categories (keyword, literal.number, literal.string, operator, etc.) applied as CodeMirror decorations
- **Example loader** — dropdown populated from `examples/*.dao`, loads source into the editor
- **New dependencies** — `cpp-httplib/0.18.3` and `nlohmann_json/3.11.3` via Conan; lockfile regenerated
- **CI updated** — `clang-format` and `clang-tidy` now cover `tools/` in addition to `compiler/`

## Test plan

- [x] All existing tests pass (lexer: 16, parser: 37, ast_printer: 2)
- [x] `daoc ast` still works on all examples and probes
- [x] `POST /api/analyze` returns tokens, AST, and diagnostics for valid and invalid input
- [x] `GET /api/examples` returns sorted list of example files
- [x] `GET /api/examples/hello.dao` returns example source
- [x] Path traversal guard rejects `../` and non-`.dao` names
- [x] `clang-format` and `clang-tidy` clean on all source files
- [ ] CI green
- [ ] Manual: open http://localhost:8080, verify structural highlighting, AST panel, diagnostics panel, and example loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)