### PR TITLE
docs(types): 📝 add type system contract, Task 7 spec, and scalar rename

### DIFF
--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -52,7 +52,8 @@ Source-facing compiler pipeline.
 - `ast/` — syntax tree / declaration and expression representation
 - `diagnostics/` — spans, reporting, and source diagnostics plumbing
 - `resolve/` — name resolution: scope chain, symbol binding, and identifier resolution
-- the intended next explicit roots are `types/`, `typecheck/`, and `lower/` rather than a monolithic semantic pass
+- `types/` — canonical semantic type universe: type kinds, interning, context, printing
+- the intended next explicit roots are `typecheck/` and `lower/` rather than a monolithic semantic pass
 
 ### `compiler/ir/`
 

--- a/docs/contracts/CONTRACT_COMPILER_PHASES.md
+++ b/docs/contracts/CONTRACT_COMPILER_PHASES.md
@@ -31,11 +31,11 @@ Required subroots:
 - `compiler/frontend/parser/`
 - `compiler/frontend/ast/`
 - `compiler/frontend/resolve/` — name resolution and scope analysis
-- `compiler/frontend/types/` — canonical semantic type universe
-  (types, interning, comparison, printing)
 - `compiler/frontend/diagnostics/`
 
 Expected next frontend subroots once implementation begins:
+- `compiler/frontend/types/` — canonical semantic type universe
+  (types, interning, comparison, printing)
 - `compiler/frontend/typecheck/` — semantic type-checking pass
 - `compiler/frontend/lower/`
 

--- a/docs/contracts/CONTRACT_COMPILER_PHASES.md
+++ b/docs/contracts/CONTRACT_COMPILER_PHASES.md
@@ -30,16 +30,19 @@ Required subroots:
 - `compiler/frontend/lexer/`
 - `compiler/frontend/parser/`
 - `compiler/frontend/ast/`
+- `compiler/frontend/resolve/` — name resolution and scope analysis
+- `compiler/frontend/types/` — canonical semantic type universe
+  (types, interning, comparison, printing)
 - `compiler/frontend/diagnostics/`
 
 Expected next frontend subroots once implementation begins:
-- `compiler/frontend/resolve/`
-- `compiler/frontend/types/` — type system representation (canonical
-  types, interning, comparison, printing)
 - `compiler/frontend/typecheck/` — semantic type-checking pass
 - `compiler/frontend/lower/`
 
-Dependency rule: `types/` must not depend on `typecheck/`.
+Dependency rules:
+- `types/` must not depend on `typecheck/`
+- `typecheck/` consumes syntax, resolution, and semantic types to
+  validate programs
 
 ## IR Responsibilities
 

--- a/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
+++ b/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
@@ -29,9 +29,12 @@ Defines the allowed top-level ontology and major subroots for Dao.
 - `parser/`
 - `ast/`
 - `resolve/`
+- `diagnostics/`
+
+Expected next subroots once implementation begins:
 - `types/`
 - `typecheck/`
-- `diagnostics/`
+- `lower/`
 
 ### Under `compiler/ir/`
 - `hir/`

--- a/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
+++ b/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
@@ -28,6 +28,9 @@ Defines the allowed top-level ontology and major subroots for Dao.
 - `lexer/`
 - `parser/`
 - `ast/`
+- `resolve/`
+- `types/`
+- `typecheck/`
 - `diagnostics/`
 
 ### Under `compiler/ir/`

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -16,8 +16,8 @@ Defines the currently frozen syntax surface for Dao's early design phase.
 ### Block-bodied form
 
 ```dao
-fn read(ptr: *i32): i32
-    let value: i32
+fn read(ptr: *int32): int32
+    let value: int32
     value
 ```
 
@@ -28,7 +28,7 @@ Rules:
 ### Expression-bodied form
 
 ```dao
-fn add(a: i32, b: i32): i32 -> a + b
+fn add(a: int32, b: int32): int32 -> a + b
 ```
 
 Rules:
@@ -59,9 +59,9 @@ Rules:
 ## Let Bindings
 
 ```dao
-let x: i32 = 42
+let x: int32 = 42
 let y = compute()
-let value: i32
+let value: int32
 ```
 
 Rules:

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -16,8 +16,8 @@ Defines the currently frozen syntax surface for Dao's early design phase.
 ### Block-bodied form
 
 ```dao
-fn read(ptr: *int32): int32
-    let value: int32
+fn read(ptr: *i32): i32
+    let value: i32
     value
 ```
 
@@ -28,7 +28,7 @@ Rules:
 ### Expression-bodied form
 
 ```dao
-fn add(a: int32, b: int32): int32 -> a + b
+fn add(a: i32, b: i32): i32 -> a + b
 ```
 
 Rules:
@@ -59,9 +59,9 @@ Rules:
 ## Let Bindings
 
 ```dao
-let x: int32 = 42
+let x: i32 = 42
 let y = compute()
-let value: int32
+let value: i32
 ```
 
 Rules:

--- a/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
+++ b/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
@@ -1,0 +1,208 @@
+# CONTRACT_TYPE_SYSTEM_FOUNDATIONS
+
+Status: normative
+Scope: Dao semantic type foundations
+Authority: language and compiler boundary contract
+
+## 1. Purpose
+
+This contract freezes the foundational type-system direction for Dao.
+
+It does not freeze final surface syntax for generics, conformance, or
+pattern matching. It does freeze the semantic categories and
+architectural boundaries that compiler work may rely on.
+
+## 2. Type system stance
+
+Dao is:
+
+- statically typed
+- nominal for named declarations
+- algebraic for enums / sum types
+- parametric for generics
+- inference-assisted, but not inference-dominated
+
+Dao is not a pure Hindley–Milner language and should not be designed
+around whole-program inference as the primary organizing principle.
+
+## 3. Foundational semantic type categories
+
+The compiler semantic type layer must support, at minimum:
+
+- builtin scalar types
+- pointer types
+- function types
+- named types
+- generic parameter types
+- struct types
+- enum types
+- alias-backed named references, whether aliases are preserved
+  semantically or normalized later
+
+These categories are semantic compiler concepts, not merely parser
+syntax.
+
+## 4. Builtin scalar surface
+
+The language-level builtin scalar names are terse.
+
+### Integers
+- `i8`
+- `i16`
+- `i32`
+- `i64`
+- `u8`
+- `u16`
+- `u32`
+- `u64`
+
+### Floating-point
+- `f32`
+- `f64`
+
+### Other
+- `bool`
+
+Additional builtins such as `isize` or `usize` may be introduced
+later, but are not required by this contract.
+
+## 5. Predeclared and compiler-supported types
+
+Dao distinguishes builtin scalar types from compiler-known predeclared
+named types.
+
+- `string` is not a builtin scalar. It is a compiler-known predeclared
+  named type. Its long-term home is the stdlib/core prelude, but for
+  now it is predeclared by the compiler so that examples and early
+  programs can use it without import.
+
+- `void` is a compiler-supported return/internal type. It is used as
+  the return type for functions that produce no meaningful value. The
+  question of whether `void` stays surface-visible or becomes a
+  unit-like type is deferred; for now it is available as a return type
+  annotation.
+
+These types are not part of the builtin scalar family and should not
+be conflated with it.
+
+## 6. Semantic builtin representation
+
+The semantic type system must represent builtin scalar types
+explicitly.
+
+The semantic naming convention should follow the `Type*` family, for
+example:
+
+- `TypeBuiltin`
+- `TypePointer`
+- `TypeFunction`
+- `TypeNamed`
+- `TypeGenericParam`
+- `TypeStruct`
+- `TypeEnum`
+
+The semantic representation may use enums such as `I32`, `U64`, `F32`,
+`F64`, `Bool` internally.
+
+## 7. Enums and algebraic data
+
+Dao enums are true sum types.
+
+This means the language direction assumes:
+
+- enums are not limited to C-style integer tags
+- payload-bearing variants are part of the intended model
+- later pattern matching and exhaustiveness checking are compatible
+  with the type model
+
+The exact surface syntax for payload-bearing variants may evolve, but
+the semantic direction is fixed.
+
+## 8. Generics
+
+Dao supports parametric generics.
+
+The type system must be able to represent:
+
+- generic type parameters
+- generic arguments on named types
+- instantiated generic named types
+
+The semantic type layer must be designed so later generic substitution
+and instantiation are possible without replacing the foundational
+representation.
+
+## 9. Conformance / trait-interface direction
+
+Dao will support an abstraction and conformance mechanism broadly in
+the space of traits, interfaces, or protocols.
+
+This mechanism is intended to be:
+
+- more expressive than Go interfaces
+- less surface-heavy and less syntactically dominant than Rust traits
+- statically resolved by default
+- capable of constraining generics
+
+This contract freezes the direction, not the final syntax or solving
+model.
+
+## 10. Nominal identity
+
+Named declarations such as structs, enums, and later
+trait/interface-like declarations are nominal.
+
+Two distinct named declarations are not equivalent merely because they
+have structurally identical fields or variants.
+
+## 11. Separation of layers
+
+The compiler must preserve a strict separation between:
+
+- parser syntax-level type nodes
+- semantic compiler type representations
+- type-checking and inference logic
+
+Specifically:
+
+- AST type syntax belongs in `compiler/frontend/ast/`
+- semantic types belong in `compiler/frontend/types/`
+- type checking belongs in `compiler/frontend/typecheck/`
+
+## 12. Non-goals of this contract
+
+This contract does not freeze:
+
+- final generic syntax
+- final conformance syntax
+- overload resolution semantics
+- inference algorithm details
+- pattern matching syntax
+- exhaustiveness diagnostics policy
+- effect typing
+- higher-kinded types
+- dependent typing
+
+## 13. Implementation consequences
+
+Compiler work may rely on the following architectural assumptions:
+
+- semantic types are canonical compiler-owned objects
+- semantic types are distinct from AST syntax
+- semantic type identity is stable enough for later HIR typing and
+  tooling
+- `types/` must not depend on `typecheck/`
+
+## 14. Stability rule
+
+Any change that would alter Dao from:
+
+- nominal + algebraic + parametric
+
+into:
+
+- purely structural
+- purely HM-style
+- or trait-surface-dominated
+
+requires explicit reconsideration of this contract.

--- a/docs/task_specs/TASK_7_TYPES.md
+++ b/docs/task_specs/TASK_7_TYPES.md
@@ -1,0 +1,302 @@
+# TASK_7_TYPES
+
+Status: implementation spec
+Phase: Semantic Frontend
+Scope: `compiler/frontend/types/`
+
+## 1. Objective
+
+Implement the canonical semantic type representation layer for Dao.
+
+This task establishes the compiler-owned type universe used by later
+type checking, HIR annotation, semantic tooling, and
+generic/conformance expansion.
+
+Task 7 is not type checking. It is not inference. It is not
+conformance solving.
+
+## 2. Non-goals
+
+Task 7 must not implement:
+
+- expression type checking
+- statement type checking
+- local type inference
+- overload resolution
+- trait/interface conformance solving
+- generic instantiation algorithms
+- enum exhaustiveness
+- method lookup
+- pattern matching semantics
+
+Those belong to later tasks.
+
+## 3. Architectural role
+
+Task 7 sits between:
+
+- parser / AST / resolve
+
+and
+
+- typecheck / HIR
+
+It defines the semantic type objects that later passes consume.
+
+## 4. Directory
+
+The implementation must live under:
+
+```text
+compiler/frontend/types/
+```
+
+## 5. Required deliverables
+
+### Core files
+
+Suggested shape:
+
+```text
+compiler/frontend/types/
+    type.h
+    type.cpp
+    type_kind.h
+    type_context.h
+    type_context.cpp
+    type_builtin.h
+    type_builtin.cpp
+    type_printer.h
+    type_printer.cpp
+    type_tests.cpp
+```
+
+Exact filenames may vary slightly, but the conceptual split must
+remain clear.
+
+### Core semantic entities
+
+Implement at least:
+
+- `Type`
+- `TypeKind`
+- `TypeContext`
+- `TypeBuiltin`
+- `TypePointer`
+- `TypeFunction`
+- `TypeNamed`
+- `TypeGenericParam`
+- `TypeStruct`
+- `TypeEnum`
+
+Alias handling may be explicit or represented through named
+declarations, but the layer must be ready for aliases.
+
+## 6. Ownership and allocation
+
+Semantic types should be compiler-owned canonical objects allocated
+from a context-owned arena or equivalent stable storage.
+
+Do not use per-edge `std::unique_ptr` ownership for the type graph.
+
+Do not use a giant `std::variant` for the entire semantic type
+universe.
+
+The intended shape is:
+
+- context-owned semantic objects
+- stable identity
+- canonicalization / interning where appropriate
+
+## 7. Canonicalization
+
+The semantic type layer must canonicalize types.
+
+At minimum, the following must be interned or otherwise canonicalized:
+
+- builtin types
+- pointer types
+- function types
+- named types with generic arguments
+- generic parameter types where identity rules require it
+
+The goal is that canonical semantic equality can rely on stable
+identity for equivalent types.
+
+## 8. Separation from syntax
+
+Parser type syntax must remain separate from semantic types.
+
+The parser produces syntax-level type nodes. Task 7 produces semantic
+types.
+
+Task 7 may introduce the semantic structures only. Lowering from
+syntax `TypeNode` to semantic `Type` may be partially scaffolded, but
+full type-lowering logic belongs with later semantic passes.
+
+## 9. Required foundational builtin set
+
+The initial builtin scalar set is:
+
+- `i8`
+- `i16`
+- `i32`
+- `i64`
+- `u8`
+- `u16`
+- `u32`
+- `u64`
+- `f32`
+- `f64`
+- `bool`
+
+Additionally, `string` is a compiler-known predeclared named type (not
+a builtin scalar) and `void` is a compiler-supported return/internal
+type. See `CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md` §5 for the
+distinction.
+
+## 10. Initial semantic type categories
+
+### 10.1 TypeBuiltin
+
+Represents builtin scalar types.
+
+### 10.2 TypePointer
+
+Represents `*T`.
+
+### 10.3 TypeFunction
+
+Represents function types. Must contain:
+
+- ordered parameter types
+- return type
+
+### 10.4 TypeNamed
+
+Represents a nominal named type reference, optionally with generic
+arguments. Should be declaration-backed or symbol-backed, not just a
+string.
+
+### 10.5 TypeGenericParam
+
+Represents a generic type parameter in semantic form.
+
+### 10.6 TypeStruct
+
+Represents semantic struct declarations or canonical struct type
+identity.
+
+### 10.7 TypeEnum
+
+Represents semantic enum declarations or canonical enum type identity.
+
+## 11. Dependency boundaries
+
+### Allowed dependencies
+
+`types/` may depend on:
+
+- stable basic support utilities
+- resolved declaration identity, if needed
+- AST declaration identity, only if no better resolved identity
+  exists yet
+
+### Forbidden dependencies
+
+`types/` must not depend on:
+
+- `typecheck/`
+- HIR
+- MIR
+- backend
+- tooling-specific code
+
+## 12. Type printing
+
+A type printer must exist for debugging, diagnostics, and tests.
+
+Printing should be stable and deterministic.
+
+Examples of expected readable output:
+
+- `i32`
+- `*i32`
+- `fn(i32, f64): bool`
+- `List[i32]`
+
+The exact function-type print spelling may vary, but it must be
+consistent.
+
+## 13. Equality
+
+Task 7 must provide reliable semantic type equality.
+
+Preferred model:
+
+- canonicalized pointer/handle identity for equal types
+
+If some categories cannot use direct identity initially, the
+implementation must still provide a clear equality API and be designed
+toward full canonicalization.
+
+## 14. Tests
+
+Task 7 is not complete without tests.
+
+Required test coverage:
+
+- builtin type creation
+- pointer type canonicalization
+- function type canonicalization
+- named type representation with zero and non-zero generic arguments
+- type printing stability
+- semantic equality behavior
+
+Examples of required assertions:
+
+- requesting `*i32` twice yields the same canonical semantic type
+- requesting `fn(i32): i32` twice yields the same canonical semantic
+  type
+- `*i32` and `*u32` are distinct
+- `List[i32]` and `List[f64]` are distinct
+
+## 15. Exit criteria
+
+Task 7 is complete when:
+
+- the compiler has a stable `types/` layer
+- semantic builtin, pointer, function, named, generic-param, struct,
+  and enum type categories exist
+- canonicalization is implemented for the foundational categories
+- tests pass
+- the implementation is cleanly separated from both syntax-level
+  `TypeNode` and later `typecheck/`
+
+## 16. Follow-on consumers
+
+Task 7 must leave a clean path for:
+
+- Task 8 type checking
+- HIR type annotation
+- semantic hover / tooling
+- future generic instantiation work
+- future enum/pattern-matching work
+- future conformance/trait-interface work
+
+## 17. Design notes for later work
+
+The Task 7 implementation should anticipate, but not yet solve:
+
+- generic substitution
+- declaration-backed nominal identities
+- alias normalization policy
+- enum variant payload typing
+- constrained generic parameters
+- static-dispatch conformance mechanisms
+
+## 18. Stability rule
+
+If implementation pressure suggests collapsing semantic types into
+syntax nodes, or letting `typecheck/` define the type universe
+implicitly, stop and revisit the architecture before proceeding.


### PR DESCRIPTION
## Summary

Freeze the foundational type-system direction for Dao and add the Task 7 implementation spec. Rename builtin scalar surface from verbose (`int32`, `float64`) to terse (`i32`, `f64`) in contracts per new type system foundations contract.

## Highlights

- **CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md**: nominal + algebraic + parametric stance; builtin scalar set (`i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `bool`); predeclared vs scalar distinction (`string` is not a scalar, `void` is compiler-supported); enum sum-type direction; conformance/trait direction; layer separation rules
- **TASK_7_TYPES.md**: canonical semantic type representation spec — `TypeContext`, `TypeBuiltin`, `TypePointer`, `TypeFunction`, `TypeNamed`, `TypeGenericParam`, `TypeStruct`, `TypeEnum`; canonicalization/interning; arena ownership; type printing; tests; exit criteria
- **CONTRACT_SYNTAX_SURFACE.md**: terse scalar names in all code examples
- **CONTRACT_COMPILER_PHASES.md**: `resolve/` and `types/` promoted to required subroots
- **CONTRACT_REPOSITORY_LAYOUT.md**: `resolve/`, `types/`, `typecheck/` added under `compiler/frontend/`
- **ARCH_INDEX.md**: `types/` entry added

## Test plan

- [x] Docs only — no code changes
- [x] Contracts internally consistent
- [x] Task 7 spec references correct contract sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)