### PR TITLE
refactor(syntax): ♻️ rename scalar builtins to terse form

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -14,7 +14,9 @@ namespace {
 // ---------------------------------------------------------------------------
 
 auto is_builtin_type(std::string_view name) -> bool {
-  // Builtin scalar types and compiler-known predeclared types.
+  // Builtin scalar types only — predeclared named types (string, void)
+  // are classified as type.nominal, not type.builtin.
+  // See CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md §5.
   static constexpr std::string_view builtins[] = {
       "i8",
       "i16",
@@ -27,8 +29,6 @@ auto is_builtin_type(std::string_view name) -> bool {
       "f32",
       "f64",
       "bool",
-      "string",
-      "void",
   };
   for (auto b : builtins) {
     if (name == b) {
@@ -508,6 +508,9 @@ auto resolve_use_category(SymbolKind kind) -> std::string_view {
     return "use.module";
   case SymbolKind::LambdaParam:
     return "use.variable.param"; // reuse param category for lambda params
+  case SymbolKind::Builtin:
+  case SymbolKind::Predeclared:
+    return ""; // type-position symbols — classified by visit_type(), not here
   default:
     return "";
   }

--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -14,18 +14,18 @@ namespace {
 // ---------------------------------------------------------------------------
 
 auto is_builtin_type(std::string_view name) -> bool {
-  // Core numeric and primitive types.
+  // Builtin scalar types and compiler-known predeclared types.
   static constexpr std::string_view builtins[] = {
-      "int8",
-      "int16",
-      "int32",
-      "int64",
-      "uint8",
-      "uint16",
-      "uint32",
-      "uint64",
-      "float32",
-      "float64",
+      "i8",
+      "i16",
+      "i32",
+      "i64",
+      "u8",
+      "u16",
+      "u32",
+      "u64",
+      "f32",
+      "f64",
       "bool",
       "string",
       "void",

--- a/compiler/analysis/semantic_tokens_test.cpp
+++ b/compiler/analysis/semantic_tokens_test.cpp
@@ -93,51 +93,51 @@ auto count_tokens(const std::vector<SemanticToken>& tokens, std::string_view kin
 
 suite keyword_classification = [] {
   "keyword.fn is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    0\n");
     expect(find_token(result.tokens, "keyword.fn") != nullptr);
   };
 
   "keyword.let is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    let x = 1\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    let x = 1\n    0\n");
     expect(find_token(result.tokens, "keyword.let") != nullptr);
   };
 
   "keyword.if is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    if true:\n        0\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    if true:\n        0\n    0\n");
     expect(find_token(result.tokens, "keyword.if") != nullptr);
   };
 
   "keyword.return is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    return 0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    return 0\n");
     expect(find_token(result.tokens, "keyword.return") != nullptr);
   };
 
   "keyword.import is classified"_test = [] {
-    auto result = classify_source("test.dao", "import foo\nfn main(): int32\n    0\n");
+    auto result = classify_source("test.dao", "import foo\nfn main(): i32\n    0\n");
     expect(find_token(result.tokens, "keyword.import") != nullptr);
   };
 
   "keyword.mode is classified"_test = [] {
     auto result =
-        classify_source("test.dao", "fn main(): int32\n    mode unsafe =>\n        0\n    0\n");
+        classify_source("test.dao", "fn main(): i32\n    mode unsafe =>\n        0\n    0\n");
     expect(find_token(result.tokens, "keyword.mode") != nullptr);
   };
 
   "keyword.resource is classified"_test = [] {
     auto result = classify_source(
-        "test.dao", "fn main(): int32\n    resource memory Pool =>\n        0\n    0\n");
+        "test.dao", "fn main(): i32\n    resource memory Pool =>\n        0\n    0\n");
     expect(find_token(result.tokens, "keyword.resource") != nullptr);
   };
 };
 
 suite literal_classification = [] {
   "literal.number for integers"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    42\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    42\n");
     expect(find_token(result.tokens, "literal.number") != nullptr);
   };
 
   "literal.string is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    \"hello\"\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    \"hello\"\n");
     expect(find_token(result.tokens, "literal.string") != nullptr);
   };
 };
@@ -145,51 +145,51 @@ suite literal_classification = [] {
 suite operator_classification = [] {
   "operator.pipe is classified"_test = [] {
     auto result =
-        classify_source("test.dao", "fn f(x: int32): int32 -> x\nfn g(): int32 -> 1 |> f\n");
+        classify_source("test.dao", "fn f(x: i32): i32 -> x\nfn g(): i32 -> 1 |> f\n");
     expect(find_token(result.tokens, "operator.pipe") != nullptr);
   };
 
   "operator.arrow is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn f(): int32 -> 0\n");
+    auto result = classify_source("test.dao", "fn f(): i32 -> 0\n");
     expect(find_token(result.tokens, "operator.arrow") != nullptr);
   };
 
   "operator.assignment is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    let x = 1\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    let x = 1\n    0\n");
     expect(find_token(result.tokens, "operator.assignment") != nullptr);
   };
 };
 
 suite declaration_classification = [] {
   "decl.function on function name"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    0\n");
     expect(find_token(result.tokens, "decl.function") != nullptr);
   };
 
   "decl.type on struct name"_test = [] {
-    auto result = classify_source("test.dao", "struct Point:\n    let x: int32\n");
+    auto result = classify_source("test.dao", "struct Point:\n    let x: i32\n");
     expect(find_token(result.tokens, "decl.type") != nullptr);
   };
 
   "decl.field on struct member"_test = [] {
-    auto result = classify_source("test.dao", "struct Point:\n    let x: int32\n");
+    auto result = classify_source("test.dao", "struct Point:\n    let x: i32\n");
     expect(find_token(result.tokens, "decl.field") != nullptr);
   };
 };
 
 suite type_classification = [] {
-  "type.builtin for int32"_test = [] {
-    auto result = classify_source("test.dao", "fn main(): int32\n    0\n");
+  "type.builtin for i32"_test = [] {
+    auto result = classify_source("test.dao", "fn main(): i32\n    0\n");
     expect(find_token(result.tokens, "type.builtin") != nullptr);
   };
 
   "type.nominal for user types"_test = [] {
-    auto result = classify_source("test.dao", "fn f(g: Graph): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn f(g: Graph): i32\n    0\n");
     expect(find_token(result.tokens, "type.nominal") != nullptr);
   };
 
   "qualified type classifies final segment as type.nominal"_test = [] {
-    auto result = classify_source("test.dao", "fn f(g: net::graph::Graph): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn f(g: net::graph::Graph): i32\n    0\n");
     expect(find_token_at(result, "type.nominal", "Graph") != nullptr)
         << "final segment should be type.nominal";
     expect(find_token_at(result, "use.module", "net") != nullptr)
@@ -201,7 +201,7 @@ suite type_classification = [] {
 
 suite module_classification = [] {
   "use.module on import path segments"_test = [] {
-    auto result = classify_source("test.dao", "import net::http\nfn main(): int32\n    0\n");
+    auto result = classify_source("test.dao", "import net::http\nfn main(): i32\n    0\n");
     expect(find_token_at(result, "use.module", "net") != nullptr)
         << "first import segment should be use.module";
     expect(find_token_at(result, "decl.module", "http") != nullptr)
@@ -213,7 +213,7 @@ suite module_classification = [] {
     // to classify — structural AST classification is not authoritative
     // for expression-position qualified names.
     auto result = classify_source_resolved(
-        "test.dao", "import net::http\nfn main(): int32\n    http::get\n    0\n");
+        "test.dao", "import net::http\nfn main(): i32\n    http::get\n    0\n");
     expect(find_token_at(result, "use.module", "http") != nullptr)
         << "leading segment should be use.module";
   };
@@ -223,18 +223,18 @@ suite variable_classification = [] {
   "param binder is not classified as use.variable.param"_test = [] {
     // Parameter binders are declaration sites. use.variable.param is
     // for references, which require name resolution (Task 6).
-    auto result = classify_source("test.dao", "fn f(x: int32): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn f(x: i32): i32\n    0\n");
     expect(find_token(result.tokens, "use.variable.param") == nullptr);
   };
 
   "let binder is not classified as use.variable.local"_test = [] {
     // Let binders are declaration sites — same reasoning as params.
-    auto result = classify_source("test.dao", "fn main(): int32\n    let x = 1\n    0\n");
+    auto result = classify_source("test.dao", "fn main(): i32\n    let x = 1\n    0\n");
     expect(find_token(result.tokens, "use.variable.local") == nullptr);
   };
 
   "use.field on field access"_test = [] {
-    auto result = classify_source("test.dao", "fn f(p: Point): int32\n    p.x\n");
+    auto result = classify_source("test.dao", "fn f(p: Point): i32\n    p.x\n");
     expect(find_token(result.tokens, "use.field") != nullptr);
   };
 };
@@ -242,19 +242,19 @@ suite variable_classification = [] {
 suite mode_resource_classification = [] {
   "mode.unsafe is classified"_test = [] {
     auto result =
-        classify_source("test.dao", "fn main(): int32\n    mode unsafe =>\n        0\n    0\n");
+        classify_source("test.dao", "fn main(): i32\n    mode unsafe =>\n        0\n    0\n");
     expect(find_token(result.tokens, "mode.unsafe") != nullptr);
   };
 
   "resource.kind.memory is classified"_test = [] {
     auto result = classify_source(
-        "test.dao", "fn main(): int32\n    resource memory Pool =>\n        0\n    0\n");
+        "test.dao", "fn main(): i32\n    resource memory Pool =>\n        0\n    0\n");
     expect(find_token(result.tokens, "resource.kind.memory") != nullptr);
   };
 
   "resource.binding is classified"_test = [] {
     auto result = classify_source(
-        "test.dao", "fn main(): int32\n    resource memory Pool =>\n        0\n    0\n");
+        "test.dao", "fn main(): i32\n    resource memory Pool =>\n        0\n    0\n");
     expect(find_token(result.tokens, "resource.binding") != nullptr);
   };
 };
@@ -262,14 +262,14 @@ suite mode_resource_classification = [] {
 suite lambda_classification = [] {
   "lambda.param is classified"_test = [] {
     auto result =
-        classify_source("test.dao", "fn f(x: int32): int32 -> x\nfn g(): int32 -> 1 |> |x| -> x\n");
+        classify_source("test.dao", "fn f(x: i32): i32 -> x\nfn g(): i32 -> 1 |> |x| -> x\n");
     expect(find_token(result.tokens, "lambda.param") != nullptr);
   };
 };
 
 suite punctuation_classification = [] {
   "punctuation is classified"_test = [] {
-    auto result = classify_source("test.dao", "fn f(x: int32): int32\n    0\n");
+    auto result = classify_source("test.dao", "fn f(x: i32): i32\n    0\n");
     expect(find_token(result.tokens, "punctuation") != nullptr);
   };
 };
@@ -277,7 +277,7 @@ suite punctuation_classification = [] {
 suite sorted_output = [] {
   "tokens are sorted by offset"_test = [] {
     auto result = classify_source("test.dao",
-                                  "fn main(): int32\n"
+                                  "fn main(): i32\n"
                                   "    let x = 1\n"
                                   "    0\n");
     for (size_t i = 1; i < result.tokens.size(); ++i) {
@@ -327,7 +327,7 @@ suite taxonomy_coverage = [] {
       categories.insert(tok.kind);
     }
 
-    // hello.dao has: fn, print("hello, dao"), 0, int32
+    // hello.dao has: fn, print("hello, dao"), 0, i32
     expect(categories.contains("keyword.fn")) << "missing keyword.fn";
     expect(categories.contains("decl.function")) << "missing decl.function";
     expect(categories.contains("literal.number")) << "missing literal.number";

--- a/compiler/frontend/lexer/lexer_test.cpp
+++ b/compiler/frontend/lexer/lexer_test.cpp
@@ -109,7 +109,7 @@ suite operator_tests = [] {
   };
 
   "colon vs coloncolon disambiguation"_test = [] {
-    auto output = lex_string("x: int32\nnet::http::get\n");
+    auto output = lex_string("x: i32\nnet::http::get\n");
     auto kinds = std::vector<TokenKind>{};
     for (const auto& tok : output.result.tokens) {
       if (tok.kind != TokenKind::Newline && tok.kind != TokenKind::Eof &&
@@ -117,11 +117,11 @@ suite operator_tests = [] {
         kinds.push_back(tok.kind);
       }
     }
-    // x : int32 net :: http :: get
+    // x : i32 net :: http :: get
     expect(kinds.size() == 8_u);
     expect(kinds[0] == TokenKind::Identifier); // x
     expect(kinds[1] == TokenKind::Colon);      // :
-    expect(kinds[2] == TokenKind::Identifier); // int32
+    expect(kinds[2] == TokenKind::Identifier); // i32
     expect(kinds[3] == TokenKind::Identifier); // net
     expect(kinds[4] == TokenKind::ColonColon); // ::
     expect(kinds[5] == TokenKind::Identifier); // http
@@ -196,7 +196,7 @@ suite identifier_tests = [] {
 
 suite indentation_tests = [] {
   "simple indent dedent"_test = [] {
-    auto output = lex_string("fn main(): int32\n    0\n");
+    auto output = lex_string("fn main(): i32\n    0\n");
     int indents = count_kind(output.result.tokens, TokenKind::Indent);
     int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
     expect(indents == dedents) << "INDENT/DEDENT must be balanced";
@@ -204,7 +204,7 @@ suite indentation_tests = [] {
   };
 
   "nested indentation"_test = [] {
-    auto output = lex_string("fn f(): int32\n    if true:\n        0\n    1\n");
+    auto output = lex_string("fn f(): i32\n    if true:\n        0\n    1\n");
     int indents = count_kind(output.result.tokens, TokenKind::Indent);
     int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
     expect(indents == dedents) << "INDENT/DEDENT must be balanced";
@@ -212,7 +212,7 @@ suite indentation_tests = [] {
   };
 
   "blank lines do not affect indentation"_test = [] {
-    auto output = lex_string("fn f(): int32\n    let x: int32\n\n    x\n");
+    auto output = lex_string("fn f(): i32\n    let x: i32\n\n    x\n");
     int indents = count_kind(output.result.tokens, TokenKind::Indent);
     int dedents = count_kind(output.result.tokens, TokenKind::Dedent);
     expect(indents == dedents) << "INDENT/DEDENT must be balanced";
@@ -220,7 +220,7 @@ suite indentation_tests = [] {
   };
 
   "tabs rejected"_test = [] {
-    auto output = lex_string("fn f(): int32\n\t0\n");
+    auto output = lex_string("fn f(): i32\n\t0\n");
     expect(!output.result.diagnostics.empty()) << "tabs must produce a diagnostic";
   };
 

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -48,7 +48,7 @@ auto parse_file(const std::filesystem::path& path) -> ParseOutput {
 
 suite function_tests = [] {
   "expression-bodied function"_test = [] {
-    auto output = parse_string("fn add(a: int32, b: int32): int32 -> a + b\n");
+    auto output = parse_string("fn add(a: i32, b: i32): i32 -> a + b\n");
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
     auto* file = output.parse_result.file;
     expect(file != nullptr);
@@ -67,7 +67,7 @@ suite function_tests = [] {
   };
 
   "block-bodied function"_test = [] {
-    auto output = parse_string("fn main(): int32\n    0\n");
+    auto output = parse_string("fn main(): i32\n    0\n");
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
     auto* file = output.parse_result.file;
     expect(file->declarations().size() == 1_u);
@@ -79,7 +79,7 @@ suite function_tests = [] {
   };
 
   "no-param function"_test = [] {
-    auto output = parse_string("fn greet(): int32 -> 0\n");
+    auto output = parse_string("fn greet(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     expect(fn->params().empty());
@@ -88,7 +88,7 @@ suite function_tests = [] {
 
 suite let_tests = [] {
   "let with type and initializer"_test = [] {
-    auto output = parse_string("fn f(): int32\n    let x: int32 = 42\n    x\n");
+    auto output = parse_string("fn f(): i32\n    let x: i32 = 42\n    x\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     expect(fn->body().size() == 2_u);
@@ -101,7 +101,7 @@ suite let_tests = [] {
   };
 
   "let with type only"_test = [] {
-    auto output = parse_string("fn f(): int32\n    let x: int32\n    x\n");
+    auto output = parse_string("fn f(): i32\n    let x: i32\n    x\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
@@ -110,7 +110,7 @@ suite let_tests = [] {
   };
 
   "let with initializer only"_test = [] {
-    auto output = parse_string("fn f(): int32\n    let x = 42\n    x\n");
+    auto output = parse_string("fn f(): i32\n    let x = 42\n    x\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
@@ -121,7 +121,7 @@ suite let_tests = [] {
 
 suite control_flow_tests = [] {
   "if statement"_test = [] {
-    auto output = parse_string("fn f(): int32\n    if true:\n        0\n    1\n");
+    auto output = parse_string("fn f(): i32\n    if true:\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
@@ -132,7 +132,7 @@ suite control_flow_tests = [] {
   };
 
   "if-else statement"_test = [] {
-    auto output = parse_string("fn f(): int32\n    if true:\n        0\n    else:\n        1\n");
+    auto output = parse_string("fn f(): i32\n    if true:\n        0\n    else:\n        1\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
@@ -141,7 +141,7 @@ suite control_flow_tests = [] {
   };
 
   "while statement"_test = [] {
-    auto output = parse_string("fn f(): int32\n    while true:\n        0\n    1\n");
+    auto output = parse_string("fn f(): i32\n    while true:\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* while_stmt = static_cast<WhileStatementNode*>(fn->body()[0]);
@@ -150,7 +150,7 @@ suite control_flow_tests = [] {
   };
 
   "for statement"_test = [] {
-    auto output = parse_string("fn f(): int32\n    for i in items:\n        i\n    0\n");
+    auto output = parse_string("fn f(): i32\n    for i in items:\n        i\n    0\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* for_stmt = static_cast<ForStatementNode*>(fn->body()[0]);
@@ -161,7 +161,7 @@ suite control_flow_tests = [] {
 
 suite expression_tests = [] {
   "binary operators"_test = [] {
-    auto output = parse_string("fn f(): int32 -> 1 + 2 * 3\n");
+    auto output = parse_string("fn f(): i32 -> 1 + 2 * 3\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     // Should be BinaryExpr(+, 1, BinaryExpr(*, 2, 3)) — * binds tighter than +
@@ -175,7 +175,7 @@ suite expression_tests = [] {
   };
 
   "unary operators"_test = [] {
-    auto output = parse_string("fn f(p: *int32): int32 -> *p\n");
+    auto output = parse_string("fn f(p: *i32): i32 -> *p\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* deref = static_cast<UnaryExprNode*>(fn->expr_body());
@@ -184,7 +184,7 @@ suite expression_tests = [] {
   };
 
   "function call"_test = [] {
-    auto output = parse_string("fn f(): int32\n    foo(1, 2)\n");
+    auto output = parse_string("fn f(): i32\n    foo(1, 2)\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -194,7 +194,7 @@ suite expression_tests = [] {
   };
 
   "field access"_test = [] {
-    auto output = parse_string("fn f(): int32\n    x.y.z\n");
+    auto output = parse_string("fn f(): i32\n    x.y.z\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -206,7 +206,7 @@ suite expression_tests = [] {
   };
 
   "index expression"_test = [] {
-    auto output = parse_string("fn f(): int32\n    a[0]\n");
+    auto output = parse_string("fn f(): i32\n    a[0]\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -216,7 +216,7 @@ suite expression_tests = [] {
   };
 
   "multi-arg bracket"_test = [] {
-    auto output = parse_string("fn f(): int32\n    Map[int32, string]()\n");
+    auto output = parse_string("fn f(): i32\n    Map[i32, string]()\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -227,7 +227,7 @@ suite expression_tests = [] {
   };
 
   "comparison operators"_test = [] {
-    auto output = parse_string("fn f(): int32 -> 1 == 2\n");
+    auto output = parse_string("fn f(): i32 -> 1 == 2\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* eq = static_cast<BinaryExprNode*>(fn->expr_body());
@@ -235,7 +235,7 @@ suite expression_tests = [] {
   };
 
   "logical operators"_test = [] {
-    auto output = parse_string("fn f(): int32 -> true and false or true\n");
+    auto output = parse_string("fn f(): i32 -> true and false or true\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     // or binds less tightly than and: or(and(true, false), true)
@@ -248,12 +248,12 @@ suite expression_tests = [] {
 
 suite lambda_tests = [] {
   "simple lambda"_test = [] {
-    auto output = parse_string("fn f(): int32 -> |x| -> x + 1\n");
+    auto output = parse_string("fn f(): i32 -> |x| -> x + 1\n");
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
   };
 
   "lambda in pipe"_test = [] {
-    auto output = parse_string("fn f(): int32\n    xs |> map |x| -> x * x\n");
+    auto output = parse_string("fn f(): i32\n    xs |> map |x| -> x * x\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -263,7 +263,7 @@ suite lambda_tests = [] {
 
 suite pipe_tests = [] {
   "simple pipe"_test = [] {
-    auto output = parse_string("fn f(): int32\n    x |> foo |> bar\n");
+    auto output = parse_string("fn f(): i32\n    x |> foo |> bar\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
@@ -273,7 +273,7 @@ suite pipe_tests = [] {
   };
 
   "multi-line pipe in suite"_test = [] {
-    auto output = parse_string("fn f(): int32\n    xs\n        |> map |x| -> x\n    0\n");
+    auto output = parse_string("fn f(): i32\n    xs\n        |> map |x| -> x\n    0\n");
     expect(output.parse_result.diagnostics.empty()) << "multi-line pipe in suite";
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     expect(fn->body().size() == 2_u) << "pipe expr + trailing 0";
@@ -284,7 +284,7 @@ suite pipe_tests = [] {
 
 suite mode_resource_tests = [] {
   "mode block"_test = [] {
-    auto output = parse_string("fn f(): int32\n    mode unsafe =>\n        0\n    1\n");
+    auto output = parse_string("fn f(): i32\n    mode unsafe =>\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* mode = static_cast<ModeBlockNode*>(fn->body()[0]);
@@ -294,7 +294,7 @@ suite mode_resource_tests = [] {
   };
 
   "resource block"_test = [] {
-    auto output = parse_string("fn f(): int32\n    resource memory Search =>\n        0\n    1\n");
+    auto output = parse_string("fn f(): i32\n    resource memory Search =>\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* res = static_cast<ResourceBlockNode*>(fn->body()[0]);
@@ -307,7 +307,7 @@ suite mode_resource_tests = [] {
 
 suite type_tests = [] {
   "pointer type"_test = [] {
-    auto output = parse_string("fn f(p: *int32): int32 -> 0\n");
+    auto output = parse_string("fn f(p: *i32): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* param_type = fn->params()[0].type;
@@ -315,7 +315,7 @@ suite type_tests = [] {
   };
 
   "parameterized type"_test = [] {
-    auto output = parse_string("fn f(): List[int32] -> []\n");
+    auto output = parse_string("fn f(): List[i32] -> []\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
@@ -326,7 +326,7 @@ suite type_tests = [] {
   };
 
   "multi-param type"_test = [] {
-    auto output = parse_string("fn f(): Map[int32, string] -> []\n");
+    auto output = parse_string("fn f(): Map[i32, string] -> []\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
@@ -336,7 +336,7 @@ suite type_tests = [] {
 
 suite import_tests = [] {
   "simple import"_test = [] {
-    auto output = parse_string("import foo\nfn f(): int32 -> 0\n");
+    auto output = parse_string("import foo\nfn f(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
     expect(output.parse_result.file->imports().size() == 1_u);
     auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
@@ -345,7 +345,7 @@ suite import_tests = [] {
   };
 
   "qualified import"_test = [] {
-    auto output = parse_string("import net::http\nfn f(): int32 -> 0\n");
+    auto output = parse_string("import net::http\nfn f(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
     auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
     expect(imp->path().segments.size() == 2_u);
@@ -356,7 +356,7 @@ suite import_tests = [] {
 
 suite assignment_tests = [] {
   "simple assignment"_test = [] {
-    auto output = parse_string("fn f(): int32\n    x = 42\n");
+    auto output = parse_string("fn f(): i32\n    x = 42\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
@@ -366,7 +366,7 @@ suite assignment_tests = [] {
   };
 
   "field assignment"_test = [] {
-    auto output = parse_string("fn f(): int32\n    x.y = 42\n");
+    auto output = parse_string("fn f(): i32\n    x.y = 42\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
@@ -374,7 +374,7 @@ suite assignment_tests = [] {
   };
 
   "index assignment"_test = [] {
-    auto output = parse_string("fn f(): int32\n    a[0] = 42\n");
+    auto output = parse_string("fn f(): i32\n    a[0] = 42\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
@@ -382,14 +382,14 @@ suite assignment_tests = [] {
   };
 
   "invalid assignment target"_test = [] {
-    auto output = parse_string("fn f(): int32\n    1 = 2\n");
+    auto output = parse_string("fn f(): i32\n    1 = 2\n");
     expect(!output.parse_result.diagnostics.empty()) << "should reject invalid LHS";
   };
 };
 
 suite return_tests = [] {
   "return statement"_test = [] {
-    auto output = parse_string("fn f(): int32\n    return 42\n");
+    auto output = parse_string("fn f(): i32\n    return 42\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* ret = static_cast<ReturnStatementNode*>(fn->body()[0]);
@@ -428,7 +428,7 @@ suite file_tests = [] {
 
 suite qualified_name_tests = [] {
   "qualified name in expression"_test = [] {
-    auto output = parse_string("fn f(): int32\n    Foo::bar()\n");
+    auto output = parse_string("fn f(): i32\n    Foo::bar()\n");
     expect(output.parse_result.diagnostics.empty());
     auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
     auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -21,6 +21,8 @@ auto symbol_kind_name(SymbolKind kind) -> const char* {
     return "Module";
   case SymbolKind::Builtin:
     return "Builtin";
+  case SymbolKind::Predeclared:
+    return "Predeclared";
   case SymbolKind::LambdaParam:
     return "LambdaParam";
   }
@@ -84,7 +86,7 @@ private:
       file_scope_->declare(name, sym);
     }
     for (auto name : kPredeclaredTypes) {
-      auto* sym = ctx_.make_symbol(SymbolKind::Builtin, name, Span{}, nullptr);
+      auto* sym = ctx_.make_symbol(SymbolKind::Predeclared, name, Span{}, nullptr);
       file_scope_->declare(name, sym);
     }
   }

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -34,8 +34,16 @@ namespace {
 // ---------------------------------------------------------------------------
 
 constexpr std::string_view kBuiltinTypes[] = {
-    "int8",  "int16",   "int32",   "int64",   "uint8",  "uint16", "uint32",
-    "uint64", "float32", "float64", "bool",    "string", "void",
+    "i8",  "i16", "i32", "i64", "u8",   "u16",
+    "u32", "u64", "f32", "f64", "bool",
+};
+
+// Predeclared named types — not builtin scalars, but compiler-known
+// so that examples work without imports. See
+// CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md §5.
+constexpr std::string_view kPredeclaredTypes[] = {
+    "string",
+    "void",
 };
 
 // ---------------------------------------------------------------------------
@@ -72,6 +80,10 @@ private:
 
   void populate_builtins() {
     for (auto name : kBuiltinTypes) {
+      auto* sym = ctx_.make_symbol(SymbolKind::Builtin, name, Span{}, nullptr);
+      file_scope_->declare(name, sym);
+    }
+    for (auto name : kPredeclaredTypes) {
       auto* sym = ctx_.make_symbol(SymbolKind::Builtin, name, Span{}, nullptr);
       file_scope_->declare(name, sym);
     }

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -84,7 +84,7 @@ auto find_offset(const ResolvedSource& result, const std::string& text, size_t n
 
 suite resolve_basic = [] {
   "simple identifier resolves to param"_test = [] {
-    auto result = resolve_source("test", "fn foo(x: int32): int32 -> x");
+    auto result = resolve_source("test", "fn foo(x: i32): i32 -> x");
     expect(result.resolve_result.diagnostics.empty());
 
     // 'x' at position of the expression body should resolve to Param
@@ -94,8 +94,8 @@ suite resolve_basic = [] {
 
   "simple identifier resolves to local"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32\n"
-                                 "    let value: int32 = 42\n"
+                                 "fn foo(): i32\n"
+                                 "    let value: i32 = 42\n"
                                  "    value");
     expect(result.resolve_result.diagnostics.empty());
 
@@ -106,15 +106,15 @@ suite resolve_basic = [] {
 
   "unknown identifier produces diagnostic"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32\n"
+                                 "fn foo(): i32\n"
                                  "    unknown_var");
     expect(has_diagnostic_containing(result.resolve_result, "unknown name 'unknown_var'"));
   };
 
   "forward reference to function"_test = [] {
     auto result = resolve_source("test",
-                                 "fn caller(): int32 -> callee()\n"
-                                 "fn callee(): int32 -> 0");
+                                 "fn caller(): i32 -> callee()\n"
+                                 "fn callee(): i32 -> 0");
     expect(result.resolve_result.diagnostics.empty());
 
     auto callee_offset = find_offset(result, "callee", 0); // first occurrence is the call
@@ -123,8 +123,8 @@ suite resolve_basic = [] {
 
   "qualified name rejects non-module leading segment"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32 -> 0\n"
-                                 "fn main(): int32\n"
+                                 "fn foo(): i32 -> 0\n"
+                                 "fn main(): i32\n"
                                  "    foo::bar()");
     expect(has_diagnostic_containing(result.resolve_result, "'foo' is not a module"));
   };
@@ -133,9 +133,9 @@ suite resolve_basic = [] {
 suite resolve_scoping = [] {
   "let binding not visible before declaration"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32\n"
-                                 "    let a: int32 = b\n"
-                                 "    let b: int32 = 0\n"
+                                 "fn foo(): i32\n"
+                                 "    let a: i32 = b\n"
+                                 "    let b: i32 = 0\n"
                                  "    a");
     // 'b' is used before its let declaration — produces unknown name.
     expect(has_diagnostic_containing(result.resolve_result, "unknown name 'b'"));
@@ -146,9 +146,9 @@ suite resolve_scoping = [] {
 
   "if block creates new scope"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(x: int32): int32\n"
+                                 "fn foo(x: i32): i32\n"
                                  "    if x > 0:\n"
-                                 "        let inner: int32 = 1\n"
+                                 "        let inner: i32 = 1\n"
                                  "        inner\n"
                                  "    x");
     // 'inner' should resolve inside the if block, 'x' outside
@@ -157,7 +157,7 @@ suite resolve_scoping = [] {
 
   "for loop variable scoped to body"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(xs: int32): int32\n"
+                                 "fn foo(xs: i32): i32\n"
                                  "    for item in xs:\n"
                                  "        item\n"
                                  "    0");
@@ -170,7 +170,7 @@ suite resolve_scoping = [] {
 
   "lambda param scoped to lambda body"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(x: int32): int32 -> |y| -> y + x");
+                                 "fn foo(x: i32): i32 -> |y| -> y + x");
     expect(result.resolve_result.diagnostics.empty());
 
     // 'y' in the body should resolve to LambdaParam
@@ -180,8 +180,8 @@ suite resolve_scoping = [] {
 
   "nested scopes shadow outer"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(x: int32): int32\n"
-                                 "    let x: int32 = 42\n"
+                                 "fn foo(x: i32): i32\n"
+                                 "    let x: i32 = 42\n"
                                  "    x");
     // The inner 'x' shadows the parameter — no error, resolves to Local
     expect(result.resolve_result.diagnostics.empty());
@@ -193,46 +193,46 @@ suite resolve_scoping = [] {
 suite resolve_duplicates = [] {
   "duplicate top-level functions"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32 -> 0\n"
-                                 "fn foo(): int32 -> 1");
+                                 "fn foo(): i32 -> 0\n"
+                                 "fn foo(): i32 -> 1");
     expect(has_diagnostic_containing(result.resolve_result, "duplicate top-level declaration 'foo'"));
   };
 
   "duplicate parameters"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(x: int32, x: int32): int32 -> x");
+                                 "fn foo(x: i32, x: i32): i32 -> x");
     expect(has_diagnostic_containing(result.resolve_result, "duplicate parameter 'x'"));
   };
 
   "duplicate let in same scope"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32\n"
-                                 "    let a: int32 = 1\n"
-                                 "    let a: int32 = 2\n"
+                                 "fn foo(): i32\n"
+                                 "    let a: i32 = 1\n"
+                                 "    let a: i32 = 2\n"
                                  "    a");
     expect(has_diagnostic_containing(result.resolve_result, "duplicate declaration 'a'"));
   };
 
   "duplicate lambda parameters"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32 -> |x, x| -> x");
+                                 "fn foo(): i32 -> |x, x| -> x");
     expect(has_diagnostic_containing(result.resolve_result, "duplicate parameter 'x'"));
   };
 };
 
 suite resolve_types = [] {
   "builtin type resolves"_test = [] {
-    auto result = resolve_source("test", "fn foo(x: int32): int32 -> x");
+    auto result = resolve_source("test", "fn foo(x: i32): i32 -> x");
     expect(result.resolve_result.diagnostics.empty());
 
-    // int32 in param type should resolve to Builtin
-    // The first 'int32' in "x: int32" — find its offset
-    auto int32_offset = find_offset(result, "int32", 0);
+    // i32 in param type should resolve to Builtin
+    // The first 'i32' in "x: i32" — find its offset
+    auto int32_offset = find_offset(result, "i32", 0);
     expect(use_resolves_to(result, int32_offset, SymbolKind::Builtin));
   };
 
   "unknown nominal type does NOT produce diagnostic"_test = [] {
-    auto result = resolve_source("test", "fn foo(x: NodeId): int32 -> 0");
+    auto result = resolve_source("test", "fn foo(x: NodeId): i32 -> 0");
     // NodeId is unknown but type-position references are not diagnosed
     expect(result.resolve_result.diagnostics.empty());
   };
@@ -240,9 +240,9 @@ suite resolve_types = [] {
   "user-declared type resolves"_test = [] {
     auto result = resolve_source("test",
                                  "struct Point:\n"
-                                 "    let x: int32\n"
-                                 "    let y: int32\n"
-                                 "fn foo(p: Point): int32 -> 0");
+                                 "    let x: i32\n"
+                                 "    let y: i32\n"
+                                 "fn foo(p: Point): i32 -> 0");
     expect(result.resolve_result.diagnostics.empty());
 
     auto point_offset = find_offset(result, "Point", 1); // second 'Point' is the type use
@@ -254,7 +254,7 @@ suite resolve_imports = [] {
   "import binds last segment"_test = [] {
     auto result = resolve_source("test",
                                  "import net::http\n"
-                                 "fn foo(): int32 -> 0");
+                                 "fn foo(): i32 -> 0");
     expect(result.resolve_result.diagnostics.empty());
 
     // 'http' should be declared as a Module symbol
@@ -265,7 +265,7 @@ suite resolve_imports = [] {
   "qualified name first segment resolves to module"_test = [] {
     auto result = resolve_source("test",
                                  "import net::http\n"
-                                 "fn foo(): int32\n"
+                                 "fn foo(): i32\n"
                                  "    http::get()");
     expect(result.resolve_result.diagnostics.empty());
 
@@ -276,7 +276,7 @@ suite resolve_imports = [] {
 
   "unresolved first segment of qualified name produces diagnostic"_test = [] {
     auto result = resolve_source("test",
-                                 "fn foo(): int32\n"
+                                 "fn foo(): i32\n"
                                  "    unknown::get()");
     expect(has_diagnostic_containing(result.resolve_result, "unknown name 'unknown'"));
   };
@@ -286,16 +286,16 @@ suite resolve_struct = [] {
   "struct fields declared"_test = [] {
     auto result = resolve_source("test",
                                  "struct Point:\n"
-                                 "    let x: int32\n"
-                                 "    let y: int32");
+                                 "    let x: i32\n"
+                                 "    let y: i32");
     expect(result.resolve_result.diagnostics.empty());
   };
 
   "duplicate struct field"_test = [] {
     auto result = resolve_source("test",
                                  "struct Point:\n"
-                                 "    let x: int32\n"
-                                 "    let x: int32");
+                                 "    let x: i32\n"
+                                 "    let x: i32");
     expect(has_diagnostic_containing(result.resolve_result, "duplicate declaration 'x'"));
   };
 };

--- a/compiler/frontend/resolve/symbol.h
+++ b/compiler/frontend/resolve/symbol.h
@@ -16,8 +16,9 @@ enum class SymbolKind : std::uint8_t {
   Local,       // let binding or for-loop variable
   Field,       // struct member
   Module,      // import binding
-  Builtin,     // built-in type (i32, f64, etc.)
-  LambdaParam, // lambda |x| parameter
+  Builtin,      // built-in scalar type (i32, f64, bool)
+  Predeclared,  // compiler-known predeclared named type (string, void)
+  LambdaParam,  // lambda |x| parameter
 };
 
 auto symbol_kind_name(SymbolKind kind) -> const char*;

--- a/compiler/frontend/resolve/symbol.h
+++ b/compiler/frontend/resolve/symbol.h
@@ -16,7 +16,7 @@ enum class SymbolKind : std::uint8_t {
   Local,       // let binding or for-loop variable
   Field,       // struct member
   Module,      // import binding
-  Builtin,     // built-in type (int32, float64, etc.)
+  Builtin,     // built-in type (i32, f64, etc.)
   LambdaParam, // lambda |x| parameter
 };
 

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -16,8 +16,8 @@ Defines the currently frozen syntax surface for Dao's early design phase.
 ### Block-bodied form
 
 ```dao
-fn read(ptr: *int32): int32
-    let value: int32
+fn read(ptr: *i32): i32
+    let value: i32
     value
 ```
 
@@ -28,7 +28,7 @@ Rules:
 ### Expression-bodied form
 
 ```dao
-fn add(a: int32, b: int32): int32 -> a + b
+fn add(a: i32, b: i32): i32 -> a + b
 ```
 
 Rules:
@@ -59,9 +59,9 @@ Rules:
 ## Let Bindings
 
 ```dao
-let x: int32 = 42
+let x: i32 = 42
 let y = compute()
-let value: int32
+let value: i32
 ```
 
 Rules:

--- a/examples/astar.dao
+++ b/examples/astar.dao
@@ -1,16 +1,16 @@
-type NodeId = int32
-type Graph = int32
-type List = int32
-type PriorityQueue = int32
-type Map = int32
+type NodeId = i32
+type Graph = i32
+type List = i32
+type PriorityQueue = i32
+type Map = i32
 
-fn reconstruct_path(came_from: int32, start: int32, goal: int32): int32 -> 0
+fn reconstruct_path(came_from: i32, start: i32, goal: i32): i32 -> 0
 
-fn heuristic(a: NodeId, b: NodeId): float64 -> 0.0
+fn heuristic(a: NodeId, b: NodeId): f64 -> 0.0
 
 fn a_star(g: Graph, start: NodeId, goal: NodeId): List[NodeId]
     resource memory Search =>
-        let open = PriorityQueue[NodeId, float64]()
+        let open = PriorityQueue[NodeId, f64]()
         let came_from = Map[NodeId, NodeId]()
 
         while open.not_empty:

--- a/examples/hello.dao
+++ b/examples/hello.dao
@@ -1,6 +1,6 @@
 fn print(msg: string): void
     0
 
-fn main(): int32
+fn main(): i32
     print("hello, dao")
     0

--- a/examples/pipelines.dao
+++ b/examples/pipelines.dao
@@ -1,8 +1,8 @@
-type List = int32
+type List = i32
 
-fn filter(pred: int32): int32 -> 0
-fn map(f: int32): int32 -> 0
+fn filter(pred: i32): i32 -> 0
+fn map(f: i32): i32 -> 0
 
-fn positive_squares(xs: List[int32]): List[int32] -> xs
+fn positive_squares(xs: List[i32]): List[i32] -> xs
     |> filter |x| -> x > 0
     |> map |x| -> x * x

--- a/examples/unsafe.dao
+++ b/examples/unsafe.dao
@@ -1,5 +1,5 @@
-fn read(ptr: *int32): int32
-    let value: int32
+fn read(ptr: *i32): i32
+    let value: i32
 
     mode unsafe =>
         value = *ptr

--- a/spec/syntax_probes/astar.dao
+++ b/spec/syntax_probes/astar.dao
@@ -1,16 +1,16 @@
-type NodeId = int32
-type Graph = int32
-type List = int32
-type PriorityQueue = int32
-type Map = int32
+type NodeId = i32
+type Graph = i32
+type List = i32
+type PriorityQueue = i32
+type Map = i32
 
-fn reconstruct_path(came_from: int32, start: int32, goal: int32): int32 -> 0
+fn reconstruct_path(came_from: i32, start: i32, goal: i32): i32 -> 0
 
-fn heuristic(a: NodeId, b: NodeId): float64 -> 0.0
+fn heuristic(a: NodeId, b: NodeId): f64 -> 0.0
 
 fn a_star(g: Graph, start: NodeId, goal: NodeId): List[NodeId]
     resource memory Search =>
-        let open = PriorityQueue[NodeId, float64]()
+        let open = PriorityQueue[NodeId, f64]()
         let came_from = Map[NodeId, NodeId]()
 
         while open.not_empty:

--- a/spec/syntax_probes/functions.dao
+++ b/spec/syntax_probes/functions.dao
@@ -1,7 +1,7 @@
-fn add(a: int32, b: int32): int32 -> a + b
+fn add(a: i32, b: i32): i32 -> a + b
 
-fn read(ptr: *int32): int32
-    let value: int32 = 0
+fn read(ptr: *i32): i32
+    let value: i32 = 0
 
     mode unsafe =>
         value = *ptr

--- a/spec/syntax_probes/modes_and_resources.dao
+++ b/spec/syntax_probes/modes_and_resources.dao
@@ -1,6 +1,6 @@
-type NodeId = int32
-type List = int32
-type PriorityQueue = int32
+type NodeId = i32
+type List = i32
+type PriorityQueue = i32
 
 fn search(start: NodeId, goal: NodeId): List[NodeId]
     resource memory Search =>

--- a/spec/syntax_probes/pipelines.dao
+++ b/spec/syntax_probes/pipelines.dao
@@ -1,9 +1,9 @@
-type List = int32
+type List = i32
 
-fn filter(pred: int32): int32 -> 0
-fn map(f: int32): int32 -> 0
+fn filter(pred: i32): i32 -> 0
+fn map(f: i32): i32 -> 0
 
-fn positive_squares(xs: List[int32]): List[int32]
+fn positive_squares(xs: List[i32]): List[i32]
     xs
     |> filter |x| -> x > 0
     |> map |x| -> x * x

--- a/testdata/ast/examples_astar.ast
+++ b/testdata/ast/examples_astar.ast
@@ -1,20 +1,20 @@
 File
-  AliasDecl NodeId = int32
-  AliasDecl Graph = int32
-  AliasDecl List = int32
-  AliasDecl PriorityQueue = int32
-  AliasDecl Map = int32
+  AliasDecl NodeId = i32
+  AliasDecl Graph = i32
+  AliasDecl List = i32
+  AliasDecl PriorityQueue = i32
+  AliasDecl Map = i32
   FunctionDecl reconstruct_path
-    Param came_from: int32
-    Param start: int32
-    Param goal: int32
-    ReturnType: int32
+    Param came_from: i32
+    Param start: i32
+    Param goal: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl heuristic
     Param a: NodeId
     Param b: NodeId
-    ReturnType: float64
+    ReturnType: f64
     ExprBody
       FloatLiteral 0.0
   FunctionDecl a_star
@@ -30,7 +30,7 @@ File
               Identifier PriorityQueue
               Indices
                 Identifier NodeId
-                Identifier float64
+                Identifier f64
       LetStatement came_from
         CallExpr
           Callee

--- a/testdata/ast/examples_hello.ast
+++ b/testdata/ast/examples_hello.ast
@@ -5,7 +5,7 @@ File
     ExpressionStatement
       IntLiteral 0
   FunctionDecl main
-    ReturnType: int32
+    ReturnType: i32
     ExpressionStatement
       CallExpr
         Callee

--- a/testdata/ast/examples_pipelines.ast
+++ b/testdata/ast/examples_pipelines.ast
@@ -1,18 +1,18 @@
 File
-  AliasDecl List = int32
+  AliasDecl List = i32
   FunctionDecl filter
-    Param pred: int32
-    ReturnType: int32
+    Param pred: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl map
-    Param f: int32
-    ReturnType: int32
+    Param f: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl positive_squares
-    Param xs: List[int32]
-    ReturnType: List[int32]
+    Param xs: List[i32]
+    ReturnType: List[i32]
     ExprBody
       PipeExpr
         Identifier xs

--- a/testdata/ast/examples_unsafe.ast
+++ b/testdata/ast/examples_unsafe.ast
@@ -1,8 +1,8 @@
 File
   FunctionDecl read
-    Param ptr: *int32
-    ReturnType: int32
-    LetStatement value: int32
+    Param ptr: *i32
+    ReturnType: i32
+    LetStatement value: i32
     ModeBlock unsafe
       Assignment
         Target

--- a/testdata/ast/probes_astar.ast
+++ b/testdata/ast/probes_astar.ast
@@ -1,20 +1,20 @@
 File
-  AliasDecl NodeId = int32
-  AliasDecl Graph = int32
-  AliasDecl List = int32
-  AliasDecl PriorityQueue = int32
-  AliasDecl Map = int32
+  AliasDecl NodeId = i32
+  AliasDecl Graph = i32
+  AliasDecl List = i32
+  AliasDecl PriorityQueue = i32
+  AliasDecl Map = i32
   FunctionDecl reconstruct_path
-    Param came_from: int32
-    Param start: int32
-    Param goal: int32
-    ReturnType: int32
+    Param came_from: i32
+    Param start: i32
+    Param goal: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl heuristic
     Param a: NodeId
     Param b: NodeId
-    ReturnType: float64
+    ReturnType: f64
     ExprBody
       FloatLiteral 0.0
   FunctionDecl a_star
@@ -30,7 +30,7 @@ File
               Identifier PriorityQueue
               Indices
                 Identifier NodeId
-                Identifier float64
+                Identifier f64
       LetStatement came_from
         CallExpr
           Callee

--- a/testdata/ast/probes_functions.ast
+++ b/testdata/ast/probes_functions.ast
@@ -1,16 +1,16 @@
 File
   FunctionDecl add
-    Param a: int32
-    Param b: int32
-    ReturnType: int32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
     ExprBody
       BinaryExpr +
         Identifier a
         Identifier b
   FunctionDecl read
-    Param ptr: *int32
-    ReturnType: int32
-    LetStatement value: int32
+    Param ptr: *i32
+    ReturnType: i32
+    LetStatement value: i32
       IntLiteral 0
     ModeBlock unsafe
       Assignment

--- a/testdata/ast/probes_modes_and_resources.ast
+++ b/testdata/ast/probes_modes_and_resources.ast
@@ -1,7 +1,7 @@
 File
-  AliasDecl NodeId = int32
-  AliasDecl List = int32
-  AliasDecl PriorityQueue = int32
+  AliasDecl NodeId = i32
+  AliasDecl List = i32
+  AliasDecl PriorityQueue = i32
   FunctionDecl search
     Param start: NodeId
     Param goal: NodeId

--- a/testdata/ast/probes_pipelines.ast
+++ b/testdata/ast/probes_pipelines.ast
@@ -1,18 +1,18 @@
 File
-  AliasDecl List = int32
+  AliasDecl List = i32
   FunctionDecl filter
-    Param pred: int32
-    ReturnType: int32
+    Param pred: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl map
-    Param f: int32
-    ReturnType: int32
+    Param f: i32
+    ReturnType: i32
     ExprBody
       IntLiteral 0
   FunctionDecl positive_squares
-    Param xs: List[int32]
-    ReturnType: List[int32]
+    Param xs: List[i32]
+    ReturnType: List[i32]
     ExpressionStatement
       PipeExpr
         Identifier xs

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -86,7 +86,7 @@ const tokenHighlighter = ViewPlugin.fromClass(
 // Editor setup
 // ---------------------------------------------------------------------------
 
-const defaultSource = `fn main(): int32
+const defaultSource = `fn main(): i32
     print("hello, dao")
     0
 `;


### PR DESCRIPTION
## Summary

Rename all builtin scalar type names from verbose (`int32`, `float64`) to terse (`i32`, `f64`) across the entire repository, per the direction frozen in `CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md`.

## Highlights

- **Resolver**: split builtins into scalar set (`i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `bool`) and predeclared named types (`string`, `void`) per contract §5
- **Semantic tokens**: update `is_builtin_type()` name list
- **All `.dao` files**: examples and syntax probes updated
- **All C++ test files**: inline Dao source strings updated
- **CONTRACT_SYNTAX_SURFACE.md**: code examples updated atomically with corpus
- **Playground**: default source updated
- **Golden files**: AST expectations regenerated

## Test plan

- [x] All 5 test suites pass (lexer, parser, ast_printer, resolve, semantic_tokens)
- [x] `daoc resolve` shows terse builtin names
- [x] No old scalar names remain outside historical docs (TASK_6_RESOLVE.md)
- [x] `grep -r '\bint32\b' compiler/ examples/ spec/ testdata/ tools/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)