### PR TITLE
feat(types): ✨ add canonical semantic type representation

### DIFF
--- a/compiler/frontend/CMakeLists.txt
+++ b/compiler/frontend/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(dao_frontend STATIC
   lexer/lexer.cpp
   parser/parser.cpp
   resolve/resolve.cpp
+  types/type.cpp
+  types/type_context.cpp
+  types/type_printer.cpp
 )
 
 target_include_directories(dao_frontend PUBLIC
@@ -53,8 +56,19 @@ target_compile_definitions(resolve_test PRIVATE
   DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
+add_executable(type_test
+  types/type_test.cpp
+)
+
+target_link_libraries(type_test PRIVATE dao_frontend Boost::ut)
+
+target_compile_definitions(type_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
 include(CTest)
 add_test(NAME lexer_test COMMAND lexer_test)
 add_test(NAME parser_test COMMAND parser_test)
 add_test(NAME ast_printer_test COMMAND ast_printer_test)
 add_test(NAME resolve_test COMMAND resolve_test)
+add_test(NAME type_test COMMAND type_test)

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -2,12 +2,10 @@
 #define DAO_FRONTEND_AST_AST_H
 
 #include "frontend/diagnostics/source.h"
+#include "support/arena.h"
 
 #include <cassert>
 #include <cstdint>
-#include <functional>
-#include <memory>
-#include <ranges>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -15,89 +13,25 @@
 namespace dao {
 
 // ---------------------------------------------------------------------------
-// Arena allocator — owns all AST nodes for a compilation unit.
+// AstContext — owns all AST nodes for a compilation unit.
 // ---------------------------------------------------------------------------
 
 class AstContext {
 public:
   AstContext() = default;
-  ~AstContext() {
-    // Destruct in reverse allocation order.
-    for (auto& dtor : std::ranges::reverse_view(dtors_)) {
-      dtor();
-    }
-    for (auto* block : blocks_) {
-      ::operator delete(block);
-    }
-  }
+  ~AstContext() = default;
 
   AstContext(const AstContext&) = delete;
   auto operator=(const AstContext&) -> AstContext& = delete;
-
-  AstContext(AstContext&& other) noexcept
-      : blocks_(std::move(other.blocks_)), offset_(other.offset_), dtors_(std::move(other.dtors_)) {
-    other.blocks_.clear();
-    other.offset_ = kBlockSize;
-    other.dtors_.clear();
-  }
-
-  auto operator=(AstContext&& other) noexcept -> AstContext& {
-    if (this != &other) {
-      // Destroy current contents first.
-      for (auto& dtor : std::ranges::reverse_view(dtors_)) {
-        dtor();
-      }
-      for (auto* block : blocks_) {
-        ::operator delete(block);
-      }
-      blocks_ = std::move(other.blocks_);
-      offset_ = other.offset_;
-      dtors_ = std::move(other.dtors_);
-      other.blocks_.clear();
-      other.offset_ = kBlockSize;
-      other.dtors_.clear();
-    }
-    return *this;
-  }
+  AstContext(AstContext&&) noexcept = default;
+  auto operator=(AstContext&&) noexcept -> AstContext& = default;
 
   template <typename T, typename... Args> auto alloc(Args&&... args) -> T* {
-    void* mem = allocate(sizeof(T), alignof(T));
-    auto* ptr = new (mem) T(std::forward<Args>(args)...);
-    if constexpr (!std::is_trivially_destructible_v<T>) {
-      dtors_.push_back([ptr]() { ptr->~T(); }); // NOLINT(modernize-use-trailing-return-type)
-    }
-    return ptr;
+    return arena_.alloc<T>(std::forward<Args>(args)...);
   }
 
 private:
-  static constexpr size_t kBlockSize = 4096;
-
-  struct Block {
-    char data[kBlockSize]; // NOLINT(modernize-avoid-c-arrays)
-  };
-
-  std::vector<Block*> blocks_;
-  size_t offset_ = kBlockSize; // Force first allocation to create a block.
-  std::vector<std::function<void()>> dtors_;
-
-  auto allocate(size_t size, size_t align) -> void* {
-    // Align up.
-    offset_ = (offset_ + align - 1) & ~(align - 1);
-    if (offset_ + size > kBlockSize) {
-      if (size > kBlockSize) {
-        // Oversized allocation — give it its own block.
-        auto* mem = ::operator new(size);
-        blocks_.push_back(static_cast<Block*>(mem));
-        return mem;
-      }
-      blocks_.push_back(new Block);
-      offset_ = 0;
-    }
-    void* ptr =
-        blocks_.back()->data + offset_; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    offset_ += size;
-    return ptr;
-  }
+  Arena arena_;
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/types/type.cpp
+++ b/compiler/frontend/types/type.cpp
@@ -1,0 +1,74 @@
+#include "frontend/types/type_builtin.h"
+#include "frontend/types/type_kind.h"
+
+#include <string_view>
+
+namespace dao {
+
+auto type_kind_name(TypeKind kind) -> const char* {
+  switch (kind) {
+  case TypeKind::Builtin:
+    return "Builtin";
+  case TypeKind::Pointer:
+    return "Pointer";
+  case TypeKind::Function:
+    return "Function";
+  case TypeKind::Named:
+    return "Named";
+  case TypeKind::GenericParam:
+    return "GenericParam";
+  case TypeKind::Struct:
+    return "Struct";
+  case TypeKind::Enum:
+    return "Enum";
+  }
+  return "Unknown";
+}
+
+auto builtin_kind_name(BuiltinKind kind) -> const char* {
+  switch (kind) {
+  case BuiltinKind::I8:
+    return "i8";
+  case BuiltinKind::I16:
+    return "i16";
+  case BuiltinKind::I32:
+    return "i32";
+  case BuiltinKind::I64:
+    return "i64";
+  case BuiltinKind::U8:
+    return "u8";
+  case BuiltinKind::U16:
+    return "u16";
+  case BuiltinKind::U32:
+    return "u32";
+  case BuiltinKind::U64:
+    return "u64";
+  case BuiltinKind::F32:
+    return "f32";
+  case BuiltinKind::F64:
+    return "f64";
+  case BuiltinKind::Bool:
+    return "bool";
+  case BuiltinKind::Void:
+    return "void";
+  }
+  return "unknown";
+}
+
+auto builtin_kind_from_name(std::string_view name) -> std::optional<BuiltinKind> {
+  if (name == "i8") return BuiltinKind::I8;
+  if (name == "i16") return BuiltinKind::I16;
+  if (name == "i32") return BuiltinKind::I32;
+  if (name == "i64") return BuiltinKind::I64;
+  if (name == "u8") return BuiltinKind::U8;
+  if (name == "u16") return BuiltinKind::U16;
+  if (name == "u32") return BuiltinKind::U32;
+  if (name == "u64") return BuiltinKind::U64;
+  if (name == "f32") return BuiltinKind::F32;
+  if (name == "f64") return BuiltinKind::F64;
+  if (name == "bool") return BuiltinKind::Bool;
+  if (name == "void") return BuiltinKind::Void;
+  return std::nullopt;
+}
+
+} // namespace dao

--- a/compiler/frontend/types/type.cpp
+++ b/compiler/frontend/types/type.cpp
@@ -9,6 +9,8 @@ auto type_kind_name(TypeKind kind) -> const char* {
   switch (kind) {
   case TypeKind::Builtin:
     return "Builtin";
+  case TypeKind::Void:
+    return "Void";
   case TypeKind::Pointer:
     return "Pointer";
   case TypeKind::Function:
@@ -49,8 +51,6 @@ auto builtin_kind_name(BuiltinKind kind) -> const char* {
     return "f64";
   case BuiltinKind::Bool:
     return "bool";
-  case BuiltinKind::Void:
-    return "void";
   }
   return "unknown";
 }
@@ -67,7 +67,6 @@ auto builtin_kind_from_name(std::string_view name) -> std::optional<BuiltinKind>
   if (name == "f32") return BuiltinKind::F32;
   if (name == "f64") return BuiltinKind::F64;
   if (name == "bool") return BuiltinKind::Bool;
-  if (name == "void") return BuiltinKind::Void;
   return std::nullopt;
 }
 

--- a/compiler/frontend/types/type.h
+++ b/compiler/frontend/types/type.h
@@ -1,0 +1,185 @@
+#ifndef DAO_FRONTEND_TYPES_TYPE_H
+#define DAO_FRONTEND_TYPES_TYPE_H
+
+#include "frontend/types/type_builtin.h"
+#include "frontend/types/type_kind.h"
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Base class — all semantic types derive from this.
+// ---------------------------------------------------------------------------
+
+class Type {
+public:
+  explicit Type(TypeKind kind) : kind_(kind) {}
+  virtual ~Type() = default;
+
+  Type(const Type&) = delete;
+  auto operator=(const Type&) -> Type& = delete;
+  Type(Type&&) = delete;
+  auto operator=(Type&&) -> Type& = delete;
+
+  [[nodiscard]] auto kind() const -> TypeKind { return kind_; }
+
+private:
+  TypeKind kind_;
+};
+
+// ---------------------------------------------------------------------------
+// Concrete semantic types
+// ---------------------------------------------------------------------------
+
+class TypeBuiltin : public Type {
+public:
+  explicit TypeBuiltin(BuiltinKind builtin)
+      : Type(TypeKind::Builtin), builtin_(builtin) {}
+
+  [[nodiscard]] auto builtin() const -> BuiltinKind { return builtin_; }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Builtin;
+  }
+
+private:
+  BuiltinKind builtin_;
+};
+
+class TypePointer : public Type {
+public:
+  explicit TypePointer(const Type* pointee)
+      : Type(TypeKind::Pointer), pointee_(pointee) {}
+
+  [[nodiscard]] auto pointee() const -> const Type* { return pointee_; }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Pointer;
+  }
+
+private:
+  const Type* pointee_;
+};
+
+class TypeFunction : public Type {
+public:
+  TypeFunction(std::vector<const Type*> param_types, const Type* return_type)
+      : Type(TypeKind::Function), param_types_(std::move(param_types)),
+        return_type_(return_type) {}
+
+  [[nodiscard]] auto param_types() const -> const std::vector<const Type*>& {
+    return param_types_;
+  }
+  [[nodiscard]] auto return_type() const -> const Type* { return return_type_; }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Function;
+  }
+
+private:
+  std::vector<const Type*> param_types_;
+  const Type* return_type_;
+};
+
+class TypeNamed : public Type {
+public:
+  TypeNamed(const void* decl_id, std::string_view name,
+            std::vector<const Type*> type_args)
+      : Type(TypeKind::Named), decl_id_(decl_id), name_(name),
+        type_args_(std::move(type_args)) {}
+
+  [[nodiscard]] auto decl_id() const -> const void* { return decl_id_; }
+  [[nodiscard]] auto name() const -> std::string_view { return name_; }
+  [[nodiscard]] auto type_args() const -> const std::vector<const Type*>& {
+    return type_args_;
+  }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Named;
+  }
+
+private:
+  const void* decl_id_;
+  std::string_view name_;
+  std::vector<const Type*> type_args_;
+};
+
+class TypeGenericParam : public Type {
+public:
+  TypeGenericParam(std::string_view name, uint32_t index)
+      : Type(TypeKind::GenericParam), name_(name), index_(index) {}
+
+  [[nodiscard]] auto name() const -> std::string_view { return name_; }
+  [[nodiscard]] auto index() const -> uint32_t { return index_; }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::GenericParam;
+  }
+
+private:
+  std::string_view name_;
+  uint32_t index_;
+};
+
+struct StructField {
+  std::string_view name;
+  const Type* type;
+};
+
+class TypeStruct : public Type {
+public:
+  TypeStruct(const void* decl_id, std::string_view name,
+             std::vector<StructField> fields)
+      : Type(TypeKind::Struct), decl_id_(decl_id), name_(name),
+        fields_(std::move(fields)) {}
+
+  [[nodiscard]] auto decl_id() const -> const void* { return decl_id_; }
+  [[nodiscard]] auto name() const -> std::string_view { return name_; }
+  [[nodiscard]] auto fields() const -> const std::vector<StructField>& {
+    return fields_;
+  }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Struct;
+  }
+
+private:
+  const void* decl_id_;
+  std::string_view name_;
+  std::vector<StructField> fields_;
+};
+
+struct EnumVariant {
+  std::string_view name;
+  std::vector<const Type*> payload_types; // empty for C-style variants
+};
+
+class TypeEnum : public Type {
+public:
+  TypeEnum(const void* decl_id, std::string_view name,
+           std::vector<EnumVariant> variants)
+      : Type(TypeKind::Enum), decl_id_(decl_id), name_(name),
+        variants_(std::move(variants)) {}
+
+  [[nodiscard]] auto decl_id() const -> const void* { return decl_id_; }
+  [[nodiscard]] auto name() const -> std::string_view { return name_; }
+  [[nodiscard]] auto variants() const -> const std::vector<EnumVariant>& {
+    return variants_;
+  }
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Enum;
+  }
+
+private:
+  const void* decl_id_;
+  std::string_view name_;
+  std::vector<EnumVariant> variants_;
+};
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_TYPES_TYPE_H

--- a/compiler/frontend/types/type.h
+++ b/compiler/frontend/types/type.h
@@ -49,6 +49,17 @@ private:
   BuiltinKind builtin_;
 };
 
+// Void — compiler-internal return type. Not a builtin scalar.
+// See CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md §5.
+class TypeVoid : public Type {
+public:
+  TypeVoid() : Type(TypeKind::Void) {}
+
+  static auto classof(const Type* t) -> bool {
+    return t->kind() == TypeKind::Void;
+  }
+};
+
 class TypePointer : public Type {
 public:
   explicit TypePointer(const Type* pointee)

--- a/compiler/frontend/types/type_builtin.h
+++ b/compiler/frontend/types/type_builtin.h
@@ -1,0 +1,32 @@
+#ifndef DAO_FRONTEND_TYPES_TYPE_BUILTIN_H
+#define DAO_FRONTEND_TYPES_TYPE_BUILTIN_H
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace dao {
+
+enum class BuiltinKind : std::uint8_t {
+  I8,
+  I16,
+  I32,
+  I64,
+  U8,
+  U16,
+  U32,
+  U64,
+  F32,
+  F64,
+  Bool,
+  Void, // compiler-internal return type, not a user-facing scalar
+};
+
+inline constexpr std::uint8_t kBuiltinKindCount = 12;
+
+auto builtin_kind_name(BuiltinKind kind) -> const char*;
+auto builtin_kind_from_name(std::string_view name) -> std::optional<BuiltinKind>;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_TYPES_TYPE_BUILTIN_H

--- a/compiler/frontend/types/type_builtin.h
+++ b/compiler/frontend/types/type_builtin.h
@@ -19,10 +19,9 @@ enum class BuiltinKind : std::uint8_t {
   F32,
   F64,
   Bool,
-  Void, // compiler-internal return type, not a user-facing scalar
 };
 
-inline constexpr std::uint8_t kBuiltinKindCount = 12;
+inline constexpr std::uint8_t kBuiltinKindCount = 11;
 
 auto builtin_kind_name(BuiltinKind kind) -> const char*;
 auto builtin_kind_from_name(std::string_view name) -> std::optional<BuiltinKind>;

--- a/compiler/frontend/types/type_context.cpp
+++ b/compiler/frontend/types/type_context.cpp
@@ -2,42 +2,8 @@
 
 #include <cstdint>
 #include <functional>
-#include <ranges>
 
 namespace dao {
-
-// ---------------------------------------------------------------------------
-// Arena helpers
-// ---------------------------------------------------------------------------
-
-auto TypeContext::allocate(size_t size, size_t align) -> void* {
-  offset_ = (offset_ + align - 1) & ~(align - 1);
-  if (offset_ + size > kBlockSize) {
-    if (size > kBlockSize) {
-      auto* mem = ::operator new(size);
-      blocks_.push_back(static_cast<Block*>(mem));
-      return mem;
-    }
-    blocks_.push_back(new Block);
-    offset_ = 0;
-  }
-  void* ptr =
-      blocks_.back()->data + offset_; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-  offset_ += size;
-  return ptr;
-}
-
-void TypeContext::destroy() {
-  for (auto& dtor : std::ranges::reverse_view(dtors_)) {
-    dtor();
-  }
-  for (auto* block : blocks_) {
-    ::operator delete(block);
-  }
-  blocks_.clear();
-  offset_ = kBlockSize;
-  dtors_.clear();
-}
 
 // ---------------------------------------------------------------------------
 // Hash helpers
@@ -83,46 +49,19 @@ auto TypeContext::GenericParamKeyHash::operator()(const GenericParamKey& key) co
 // ---------------------------------------------------------------------------
 
 TypeContext::TypeContext() {
-  // Pre-populate all builtin types.
+  // Pre-populate all builtin scalar types.
   for (uint8_t i = 0; i < kBuiltinKindCount; ++i) {
     auto kind = static_cast<BuiltinKind>(i);
-    builtins_[i] = alloc<TypeBuiltin>(kind);
+    builtins_[i] = arena_.alloc<TypeBuiltin>(kind);
   }
+  // Void is a compiler-internal singleton, not a builtin scalar.
+  void_ = arena_.alloc<TypeVoid>();
 }
 
-TypeContext::~TypeContext() { destroy(); }
+TypeContext::~TypeContext() = default;
 
-TypeContext::TypeContext(TypeContext&& other) noexcept
-    : blocks_(std::move(other.blocks_)), offset_(other.offset_),
-      dtors_(std::move(other.dtors_)), builtins_(other.builtins_),
-      pointer_map_(std::move(other.pointer_map_)),
-      function_map_(std::move(other.function_map_)),
-      named_map_(std::move(other.named_map_)),
-      generic_param_map_(std::move(other.generic_param_map_)) {
-  other.blocks_.clear();
-  other.offset_ = kBlockSize;
-  other.dtors_.clear();
-  other.builtins_ = {};
-}
-
-auto TypeContext::operator=(TypeContext&& other) noexcept -> TypeContext& {
-  if (this != &other) {
-    destroy();
-    blocks_ = std::move(other.blocks_);
-    offset_ = other.offset_;
-    dtors_ = std::move(other.dtors_);
-    builtins_ = other.builtins_;
-    pointer_map_ = std::move(other.pointer_map_);
-    function_map_ = std::move(other.function_map_);
-    named_map_ = std::move(other.named_map_);
-    generic_param_map_ = std::move(other.generic_param_map_);
-    other.blocks_.clear();
-    other.offset_ = kBlockSize;
-    other.dtors_.clear();
-    other.builtins_ = {};
-  }
-  return *this;
-}
+TypeContext::TypeContext(TypeContext&&) noexcept = default;
+auto TypeContext::operator=(TypeContext&&) noexcept -> TypeContext& = default;
 
 // ---------------------------------------------------------------------------
 // Builtin access
@@ -132,6 +71,10 @@ auto TypeContext::builtin(BuiltinKind kind) -> const TypeBuiltin* {
   return builtins_[static_cast<uint8_t>(kind)];
 }
 
+auto TypeContext::void_type() -> const TypeVoid* {
+  return void_;
+}
+
 // ---------------------------------------------------------------------------
 // Interned constructors
 // ---------------------------------------------------------------------------
@@ -139,7 +82,7 @@ auto TypeContext::builtin(BuiltinKind kind) -> const TypeBuiltin* {
 auto TypeContext::pointer_to(const Type* pointee) -> const TypePointer* {
   auto [it, inserted] = pointer_map_.try_emplace(pointee, nullptr);
   if (inserted) {
-    it->second = alloc<TypePointer>(pointee);
+    it->second = arena_.alloc<TypePointer>(pointee);
   }
   return it->second;
 }
@@ -149,7 +92,7 @@ auto TypeContext::function_type(std::vector<const Type*> params,
   FnKey key{params, ret};
   auto [it, inserted] = function_map_.try_emplace(key, nullptr);
   if (inserted) {
-    it->second = alloc<TypeFunction>(std::move(params), ret);
+    it->second = arena_.alloc<TypeFunction>(std::move(params), ret);
   }
   return it->second;
 }
@@ -160,7 +103,7 @@ auto TypeContext::named_type(const void* decl_id, std::string_view name,
   NamedKey key{decl_id, type_args};
   auto [it, inserted] = named_map_.try_emplace(key, nullptr);
   if (inserted) {
-    it->second = alloc<TypeNamed>(decl_id, name, std::move(type_args));
+    it->second = arena_.alloc<TypeNamed>(decl_id, name, std::move(type_args));
   }
   return it->second;
 }
@@ -170,7 +113,7 @@ auto TypeContext::generic_param(std::string_view name, uint32_t index)
   GenericParamKey key{name, index};
   auto [it, inserted] = generic_param_map_.try_emplace(key, nullptr);
   if (inserted) {
-    it->second = alloc<TypeGenericParam>(name, index);
+    it->second = arena_.alloc<TypeGenericParam>(name, index);
   }
   return it->second;
 }
@@ -182,13 +125,13 @@ auto TypeContext::generic_param(std::string_view name, uint32_t index)
 auto TypeContext::make_struct(const void* decl_id, std::string_view name,
                               std::vector<StructField> fields)
     -> const TypeStruct* {
-  return alloc<TypeStruct>(decl_id, name, std::move(fields));
+  return arena_.alloc<TypeStruct>(decl_id, name, std::move(fields));
 }
 
 auto TypeContext::make_enum(const void* decl_id, std::string_view name,
                              std::vector<EnumVariant> variants)
     -> const TypeEnum* {
-  return alloc<TypeEnum>(decl_id, name, std::move(variants));
+  return arena_.alloc<TypeEnum>(decl_id, name, std::move(variants));
 }
 
 } // namespace dao

--- a/compiler/frontend/types/type_context.cpp
+++ b/compiler/frontend/types/type_context.cpp
@@ -1,0 +1,194 @@
+#include "frontend/types/type_context.h"
+
+#include <cstdint>
+#include <functional>
+#include <ranges>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Arena helpers
+// ---------------------------------------------------------------------------
+
+auto TypeContext::allocate(size_t size, size_t align) -> void* {
+  offset_ = (offset_ + align - 1) & ~(align - 1);
+  if (offset_ + size > kBlockSize) {
+    if (size > kBlockSize) {
+      auto* mem = ::operator new(size);
+      blocks_.push_back(static_cast<Block*>(mem));
+      return mem;
+    }
+    blocks_.push_back(new Block);
+    offset_ = 0;
+  }
+  void* ptr =
+      blocks_.back()->data + offset_; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  offset_ += size;
+  return ptr;
+}
+
+void TypeContext::destroy() {
+  for (auto& dtor : std::ranges::reverse_view(dtors_)) {
+    dtor();
+  }
+  for (auto* block : blocks_) {
+    ::operator delete(block);
+  }
+  blocks_.clear();
+  offset_ = kBlockSize;
+  dtors_.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Hash helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+auto hash_combine(size_t seed, size_t value) -> size_t {
+  // Boost-style hash combine.
+  return seed ^ (value + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+auto hash_type_ptr(const Type* t) -> size_t {
+  return std::hash<const void*>{}(t);
+}
+
+} // namespace
+
+auto TypeContext::FnKeyHash::operator()(const FnKey& key) const -> size_t {
+  size_t h = hash_type_ptr(key.ret);
+  for (const auto* p : key.params) {
+    h = hash_combine(h, hash_type_ptr(p));
+  }
+  return h;
+}
+
+auto TypeContext::NamedKeyHash::operator()(const NamedKey& key) const -> size_t {
+  size_t h = std::hash<const void*>{}(key.decl_id);
+  for (const auto* a : key.type_args) {
+    h = hash_combine(h, hash_type_ptr(a));
+  }
+  return h;
+}
+
+auto TypeContext::GenericParamKeyHash::operator()(const GenericParamKey& key) const
+    -> size_t {
+  size_t h = std::hash<std::string_view>{}(key.name);
+  return hash_combine(h, std::hash<uint32_t>{}(key.index));
+}
+
+// ---------------------------------------------------------------------------
+// Construction / destruction
+// ---------------------------------------------------------------------------
+
+TypeContext::TypeContext() {
+  // Pre-populate all builtin types.
+  for (uint8_t i = 0; i < kBuiltinKindCount; ++i) {
+    auto kind = static_cast<BuiltinKind>(i);
+    builtins_[i] = alloc<TypeBuiltin>(kind);
+  }
+}
+
+TypeContext::~TypeContext() { destroy(); }
+
+TypeContext::TypeContext(TypeContext&& other) noexcept
+    : blocks_(std::move(other.blocks_)), offset_(other.offset_),
+      dtors_(std::move(other.dtors_)), builtins_(other.builtins_),
+      pointer_map_(std::move(other.pointer_map_)),
+      function_map_(std::move(other.function_map_)),
+      named_map_(std::move(other.named_map_)),
+      generic_param_map_(std::move(other.generic_param_map_)) {
+  other.blocks_.clear();
+  other.offset_ = kBlockSize;
+  other.dtors_.clear();
+  other.builtins_ = {};
+}
+
+auto TypeContext::operator=(TypeContext&& other) noexcept -> TypeContext& {
+  if (this != &other) {
+    destroy();
+    blocks_ = std::move(other.blocks_);
+    offset_ = other.offset_;
+    dtors_ = std::move(other.dtors_);
+    builtins_ = other.builtins_;
+    pointer_map_ = std::move(other.pointer_map_);
+    function_map_ = std::move(other.function_map_);
+    named_map_ = std::move(other.named_map_);
+    generic_param_map_ = std::move(other.generic_param_map_);
+    other.blocks_.clear();
+    other.offset_ = kBlockSize;
+    other.dtors_.clear();
+    other.builtins_ = {};
+  }
+  return *this;
+}
+
+// ---------------------------------------------------------------------------
+// Builtin access
+// ---------------------------------------------------------------------------
+
+auto TypeContext::builtin(BuiltinKind kind) -> const TypeBuiltin* {
+  return builtins_[static_cast<uint8_t>(kind)];
+}
+
+// ---------------------------------------------------------------------------
+// Interned constructors
+// ---------------------------------------------------------------------------
+
+auto TypeContext::pointer_to(const Type* pointee) -> const TypePointer* {
+  auto [it, inserted] = pointer_map_.try_emplace(pointee, nullptr);
+  if (inserted) {
+    it->second = alloc<TypePointer>(pointee);
+  }
+  return it->second;
+}
+
+auto TypeContext::function_type(std::vector<const Type*> params,
+                                const Type* ret) -> const TypeFunction* {
+  FnKey key{params, ret};
+  auto [it, inserted] = function_map_.try_emplace(key, nullptr);
+  if (inserted) {
+    it->second = alloc<TypeFunction>(std::move(params), ret);
+  }
+  return it->second;
+}
+
+auto TypeContext::named_type(const void* decl_id, std::string_view name,
+                             std::vector<const Type*> type_args)
+    -> const TypeNamed* {
+  NamedKey key{decl_id, type_args};
+  auto [it, inserted] = named_map_.try_emplace(key, nullptr);
+  if (inserted) {
+    it->second = alloc<TypeNamed>(decl_id, name, std::move(type_args));
+  }
+  return it->second;
+}
+
+auto TypeContext::generic_param(std::string_view name, uint32_t index)
+    -> const TypeGenericParam* {
+  GenericParamKey key{name, index};
+  auto [it, inserted] = generic_param_map_.try_emplace(key, nullptr);
+  if (inserted) {
+    it->second = alloc<TypeGenericParam>(name, index);
+  }
+  return it->second;
+}
+
+// ---------------------------------------------------------------------------
+// Nominal constructors
+// ---------------------------------------------------------------------------
+
+auto TypeContext::make_struct(const void* decl_id, std::string_view name,
+                              std::vector<StructField> fields)
+    -> const TypeStruct* {
+  return alloc<TypeStruct>(decl_id, name, std::move(fields));
+}
+
+auto TypeContext::make_enum(const void* decl_id, std::string_view name,
+                             std::vector<EnumVariant> variants)
+    -> const TypeEnum* {
+  return alloc<TypeEnum>(decl_id, name, std::move(variants));
+}
+
+} // namespace dao

--- a/compiler/frontend/types/type_context.h
+++ b/compiler/frontend/types/type_context.h
@@ -1,0 +1,146 @@
+#ifndef DAO_FRONTEND_TYPES_TYPE_CONTEXT_H
+#define DAO_FRONTEND_TYPES_TYPE_CONTEXT_H
+
+#include "frontend/types/type.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <ranges>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// TypeContext — arena owner and interning hub for semantic types.
+// ---------------------------------------------------------------------------
+
+class TypeContext {
+public:
+  TypeContext();
+  ~TypeContext();
+
+  TypeContext(const TypeContext&) = delete;
+  auto operator=(const TypeContext&) -> TypeContext& = delete;
+  TypeContext(TypeContext&&) noexcept;
+  auto operator=(TypeContext&&) noexcept -> TypeContext&;
+
+  // --- Builtin access (pre-populated, never null) ---
+
+  auto builtin(BuiltinKind kind) -> const TypeBuiltin*;
+
+  auto i8() -> const TypeBuiltin* { return builtin(BuiltinKind::I8); }
+  auto i16() -> const TypeBuiltin* { return builtin(BuiltinKind::I16); }
+  auto i32() -> const TypeBuiltin* { return builtin(BuiltinKind::I32); }
+  auto i64() -> const TypeBuiltin* { return builtin(BuiltinKind::I64); }
+  auto u8() -> const TypeBuiltin* { return builtin(BuiltinKind::U8); }
+  auto u16() -> const TypeBuiltin* { return builtin(BuiltinKind::U16); }
+  auto u32() -> const TypeBuiltin* { return builtin(BuiltinKind::U32); }
+  auto u64() -> const TypeBuiltin* { return builtin(BuiltinKind::U64); }
+  auto f32() -> const TypeBuiltin* { return builtin(BuiltinKind::F32); }
+  auto f64() -> const TypeBuiltin* { return builtin(BuiltinKind::F64); }
+  auto bool_type() -> const TypeBuiltin* { return builtin(BuiltinKind::Bool); }
+  auto void_type() -> const TypeBuiltin* { return builtin(BuiltinKind::Void); }
+
+  // --- Interned constructors (return canonical pointer) ---
+
+  auto pointer_to(const Type* pointee) -> const TypePointer*;
+
+  auto function_type(std::vector<const Type*> params, const Type* ret)
+      -> const TypeFunction*;
+
+  auto named_type(const void* decl_id, std::string_view name,
+                  std::vector<const Type*> type_args) -> const TypeNamed*;
+
+  auto generic_param(std::string_view name, uint32_t index)
+      -> const TypeGenericParam*;
+
+  // --- Nominal constructors (not interned — each call allocates) ---
+
+  auto make_struct(const void* decl_id, std::string_view name,
+                   std::vector<StructField> fields) -> const TypeStruct*;
+
+  auto make_enum(const void* decl_id, std::string_view name,
+                 std::vector<EnumVariant> variants) -> const TypeEnum*;
+
+private:
+  // --- Arena allocator ---
+
+  static constexpr size_t kBlockSize = 4096;
+
+  struct Block {
+    char data[kBlockSize]; // NOLINT(modernize-avoid-c-arrays)
+  };
+
+  std::vector<Block*> blocks_;
+  size_t offset_ = kBlockSize;
+  std::vector<std::function<void()>> dtors_;
+
+  auto allocate(size_t size, size_t align) -> void*;
+
+  template <typename T, typename... Args> auto alloc(Args&&... args) -> T* {
+    void* mem = allocate(sizeof(T), alignof(T));
+    auto* ptr = new (mem) T(std::forward<Args>(args)...);
+    if constexpr (!std::is_trivially_destructible_v<T>) {
+      dtors_.push_back([ptr]() { ptr->~T(); }); // NOLINT(modernize-use-trailing-return-type)
+    }
+    return ptr;
+  }
+
+  void destroy();
+
+  // --- Interning maps ---
+
+  std::array<const TypeBuiltin*, kBuiltinKindCount> builtins_{};
+
+  std::unordered_map<const Type*, const TypePointer*> pointer_map_;
+
+  // Function type key: hash of (param types..., return type).
+  struct FnKey {
+    std::vector<const Type*> params;
+    const Type* ret;
+
+    auto operator==(const FnKey& other) const -> bool = default;
+  };
+
+  struct FnKeyHash {
+    auto operator()(const FnKey& key) const -> size_t;
+  };
+
+  std::unordered_map<FnKey, const TypeFunction*, FnKeyHash> function_map_;
+
+  // Named type key: (decl_id, type_args...).
+  struct NamedKey {
+    const void* decl_id;
+    std::vector<const Type*> type_args;
+
+    auto operator==(const NamedKey& other) const -> bool = default;
+  };
+
+  struct NamedKeyHash {
+    auto operator()(const NamedKey& key) const -> size_t;
+  };
+
+  std::unordered_map<NamedKey, const TypeNamed*, NamedKeyHash> named_map_;
+
+  // Generic param key: (name, index).
+  struct GenericParamKey {
+    std::string_view name;
+    uint32_t index;
+
+    auto operator==(const GenericParamKey& other) const -> bool = default;
+  };
+
+  struct GenericParamKeyHash {
+    auto operator()(const GenericParamKey& key) const -> size_t;
+  };
+
+  std::unordered_map<GenericParamKey, const TypeGenericParam*, GenericParamKeyHash>
+      generic_param_map_;
+};
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_TYPES_TYPE_CONTEXT_H

--- a/compiler/frontend/types/type_context.h
+++ b/compiler/frontend/types/type_context.h
@@ -2,11 +2,10 @@
 #define DAO_FRONTEND_TYPES_TYPE_CONTEXT_H
 
 #include "frontend/types/type.h"
+#include "support/arena.h"
 
 #include <array>
 #include <cstdint>
-#include <functional>
-#include <ranges>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -42,7 +41,10 @@ public:
   auto f32() -> const TypeBuiltin* { return builtin(BuiltinKind::F32); }
   auto f64() -> const TypeBuiltin* { return builtin(BuiltinKind::F64); }
   auto bool_type() -> const TypeBuiltin* { return builtin(BuiltinKind::Bool); }
-  auto void_type() -> const TypeBuiltin* { return builtin(BuiltinKind::Void); }
+
+  // Void is a compiler-internal return type, not a builtin scalar.
+  // See CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md §5.
+  auto void_type() -> const TypeVoid*;
 
   // --- Interned constructors (return canonical pointer) ---
 
@@ -66,34 +68,12 @@ public:
                  std::vector<EnumVariant> variants) -> const TypeEnum*;
 
 private:
-  // --- Arena allocator ---
-
-  static constexpr size_t kBlockSize = 4096;
-
-  struct Block {
-    char data[kBlockSize]; // NOLINT(modernize-avoid-c-arrays)
-  };
-
-  std::vector<Block*> blocks_;
-  size_t offset_ = kBlockSize;
-  std::vector<std::function<void()>> dtors_;
-
-  auto allocate(size_t size, size_t align) -> void*;
-
-  template <typename T, typename... Args> auto alloc(Args&&... args) -> T* {
-    void* mem = allocate(sizeof(T), alignof(T));
-    auto* ptr = new (mem) T(std::forward<Args>(args)...);
-    if constexpr (!std::is_trivially_destructible_v<T>) {
-      dtors_.push_back([ptr]() { ptr->~T(); }); // NOLINT(modernize-use-trailing-return-type)
-    }
-    return ptr;
-  }
-
-  void destroy();
+  Arena arena_;
 
   // --- Interning maps ---
 
   std::array<const TypeBuiltin*, kBuiltinKindCount> builtins_{};
+  const TypeVoid* void_ = nullptr;
 
   std::unordered_map<const Type*, const TypePointer*> pointer_map_;
 

--- a/compiler/frontend/types/type_kind.h
+++ b/compiler/frontend/types/type_kind.h
@@ -1,0 +1,22 @@
+#ifndef DAO_FRONTEND_TYPES_TYPE_KIND_H
+#define DAO_FRONTEND_TYPES_TYPE_KIND_H
+
+#include <cstdint>
+
+namespace dao {
+
+enum class TypeKind : std::uint8_t {
+  Builtin,
+  Pointer,
+  Function,
+  Named,
+  GenericParam,
+  Struct,
+  Enum,
+};
+
+auto type_kind_name(TypeKind kind) -> const char*;
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_TYPES_TYPE_KIND_H

--- a/compiler/frontend/types/type_kind.h
+++ b/compiler/frontend/types/type_kind.h
@@ -7,6 +7,7 @@ namespace dao {
 
 enum class TypeKind : std::uint8_t {
   Builtin,
+  Void, // compiler-internal return type, not a builtin scalar
   Pointer,
   Function,
   Named,

--- a/compiler/frontend/types/type_printer.cpp
+++ b/compiler/frontend/types/type_printer.cpp
@@ -18,6 +18,9 @@ void print_type(std::ostream& out, const Type* type) {
     out << builtin_kind_name(b->builtin());
     break;
   }
+  case TypeKind::Void:
+    out << "void";
+    break;
   case TypeKind::Pointer: {
     const auto* p = static_cast<const TypePointer*>(type);
     out << '*';

--- a/compiler/frontend/types/type_printer.cpp
+++ b/compiler/frontend/types/type_printer.cpp
@@ -1,0 +1,79 @@
+#include "frontend/types/type_printer.h"
+
+#include "frontend/types/type.h"
+
+#include <sstream>
+
+namespace dao {
+
+void print_type(std::ostream& out, const Type* type) {
+  if (type == nullptr) {
+    out << "<null>";
+    return;
+  }
+
+  switch (type->kind()) {
+  case TypeKind::Builtin: {
+    const auto* b = static_cast<const TypeBuiltin*>(type);
+    out << builtin_kind_name(b->builtin());
+    break;
+  }
+  case TypeKind::Pointer: {
+    const auto* p = static_cast<const TypePointer*>(type);
+    out << '*';
+    print_type(out, p->pointee());
+    break;
+  }
+  case TypeKind::Function: {
+    const auto* f = static_cast<const TypeFunction*>(type);
+    out << "fn(";
+    bool first = true;
+    for (const auto* param : f->param_types()) {
+      if (!first) out << ", ";
+      first = false;
+      print_type(out, param);
+    }
+    out << "): ";
+    print_type(out, f->return_type());
+    break;
+  }
+  case TypeKind::Named: {
+    const auto* n = static_cast<const TypeNamed*>(type);
+    out << n->name();
+    if (!n->type_args().empty()) {
+      out << '[';
+      bool first = true;
+      for (const auto* arg : n->type_args()) {
+        if (!first) out << ", ";
+        first = false;
+        print_type(out, arg);
+      }
+      out << ']';
+    }
+    break;
+  }
+  case TypeKind::GenericParam: {
+    const auto* g = static_cast<const TypeGenericParam*>(type);
+    out << g->name();
+    break;
+  }
+  case TypeKind::Struct: {
+    const auto* s = static_cast<const TypeStruct*>(type);
+    out << s->name();
+    break;
+  }
+  case TypeKind::Enum: {
+    const auto* e = static_cast<const TypeEnum*>(type);
+    out << e->name();
+    break;
+  }
+  }
+}
+
+auto print_type(const Type* type) -> std::string {
+  std::ostringstream out;
+  print_type(out, type);
+  return out.str();
+}
+
+} // namespace dao

--- a/compiler/frontend/types/type_printer.h
+++ b/compiler/frontend/types/type_printer.h
@@ -1,0 +1,16 @@
+#ifndef DAO_FRONTEND_TYPES_TYPE_PRINTER_H
+#define DAO_FRONTEND_TYPES_TYPE_PRINTER_H
+
+#include <ostream>
+#include <string>
+
+namespace dao {
+
+class Type;
+
+auto print_type(const Type* type) -> std::string;
+void print_type(std::ostream& out, const Type* type);
+
+} // namespace dao
+
+#endif // DAO_FRONTEND_TYPES_TYPE_PRINTER_H

--- a/compiler/frontend/types/type_test.cpp
+++ b/compiler/frontend/types/type_test.cpp
@@ -1,0 +1,327 @@
+#include "frontend/types/type.h"
+#include "frontend/types/type_context.h"
+#include "frontend/types/type_printer.h"
+
+#include <boost/ut.hpp>
+
+using namespace boost::ut;
+using namespace dao;
+
+namespace {
+
+// Sentinel declaration identities for testing.
+const int kDeclA = 1;
+const int kDeclB = 2;
+
+} // namespace
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+// ---------------------------------------------------------------------------
+// Builtin types
+// ---------------------------------------------------------------------------
+
+suite type_builtin = [] {
+  "builtin types are non-null and have correct kind"_test = [] {
+    TypeContext ctx;
+
+    for (uint8_t i = 0; i < kBuiltinKindCount; ++i) {
+      auto kind = static_cast<BuiltinKind>(i);
+      auto* t = ctx.builtin(kind);
+      expect(t != nullptr);
+      expect(t->kind() == TypeKind::Builtin);
+      expect(t->builtin() == kind);
+    }
+  };
+
+  "requesting same builtin twice yields same pointer"_test = [] {
+    TypeContext ctx;
+    expect(ctx.i32() == ctx.i32());
+    expect(ctx.f64() == ctx.f64());
+    expect(ctx.bool_type() == ctx.bool_type());
+    expect(ctx.void_type() == ctx.void_type());
+  };
+
+  "different builtins are distinct"_test = [] {
+    TypeContext ctx;
+    expect(ctx.i32() != ctx.f64());
+    expect(ctx.i32() != ctx.u32());
+    expect(ctx.bool_type() != ctx.void_type());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Pointer types
+// ---------------------------------------------------------------------------
+
+suite type_pointer = [] {
+  "pointer_to canonicalizes"_test = [] {
+    TypeContext ctx;
+    auto* pi32a = ctx.pointer_to(ctx.i32());
+    auto* pi32b = ctx.pointer_to(ctx.i32());
+    expect(pi32a == pi32b) << "*i32 twice should yield same pointer";
+  };
+
+  "pointer_to different pointees are distinct"_test = [] {
+    TypeContext ctx;
+    auto* pi32 = ctx.pointer_to(ctx.i32());
+    auto* pu32 = ctx.pointer_to(ctx.u32());
+    expect(pi32 != pu32);
+  };
+
+  "nested pointer types"_test = [] {
+    TypeContext ctx;
+    auto* pi32 = ctx.pointer_to(ctx.i32());
+    auto* ppi32 = ctx.pointer_to(pi32);
+    expect(ppi32 != pi32);
+    expect(ppi32->pointee() == pi32);
+    expect(pi32->pointee() == ctx.i32());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Function types
+// ---------------------------------------------------------------------------
+
+suite type_function = [] {
+  "function type canonicalizes"_test = [] {
+    TypeContext ctx;
+    auto* fn1 = ctx.function_type({ctx.i32()}, ctx.i32());
+    auto* fn2 = ctx.function_type({ctx.i32()}, ctx.i32());
+    expect(fn1 == fn2) << "fn(i32): i32 twice should yield same pointer";
+  };
+
+  "function types with different return are distinct"_test = [] {
+    TypeContext ctx;
+    auto* fn1 = ctx.function_type({ctx.i32()}, ctx.i32());
+    auto* fn2 = ctx.function_type({ctx.i32()}, ctx.f64());
+    expect(fn1 != fn2);
+  };
+
+  "function types with different param count are distinct"_test = [] {
+    TypeContext ctx;
+    auto* fn1 = ctx.function_type({ctx.i32()}, ctx.bool_type());
+    auto* fn2 = ctx.function_type({ctx.i32(), ctx.f64()}, ctx.bool_type());
+    expect(fn1 != fn2);
+  };
+
+  "empty params function type"_test = [] {
+    TypeContext ctx;
+    auto* fn1 = ctx.function_type({}, ctx.void_type());
+    auto* fn2 = ctx.function_type({}, ctx.void_type());
+    expect(fn1 == fn2);
+    expect(fn1->param_types().empty());
+    expect(fn1->return_type() == ctx.void_type());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Named types
+// ---------------------------------------------------------------------------
+
+suite type_named = [] {
+  "named type with zero args"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.named_type(&kDeclA, "Point", {});
+    auto* t2 = ctx.named_type(&kDeclA, "Point", {});
+    expect(t1 == t2);
+    expect(t1->name() == "Point");
+    expect(t1->type_args().empty());
+  };
+
+  "named type with args canonicalizes"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.named_type(&kDeclA, "List", {ctx.i32()});
+    auto* t2 = ctx.named_type(&kDeclA, "List", {ctx.i32()});
+    expect(t1 == t2) << "List[i32] twice should yield same pointer";
+  };
+
+  "named types with different args are distinct"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.named_type(&kDeclA, "List", {ctx.i32()});
+    auto* t2 = ctx.named_type(&kDeclA, "List", {ctx.f64()});
+    expect(t1 != t2) << "List[i32] and List[f64] should be distinct";
+  };
+
+  "different decl_id with same name yields distinct types"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.named_type(&kDeclA, "Foo", {});
+    auto* t2 = ctx.named_type(&kDeclB, "Foo", {});
+    expect(t1 != t2) << "nominal identity is declaration-backed";
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Generic parameters
+// ---------------------------------------------------------------------------
+
+suite type_generic_param = [] {
+  "generic param creation"_test = [] {
+    TypeContext ctx;
+    auto* t = ctx.generic_param("T", 0);
+    expect(t != nullptr);
+    expect(t->name() == "T");
+    expect(t->index() == 0u);
+  };
+
+  "same generic param canonicalizes"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.generic_param("T", 0);
+    auto* t2 = ctx.generic_param("T", 0);
+    expect(t1 == t2);
+  };
+
+  "different generic params are distinct"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.generic_param("T", 0);
+    auto* t2 = ctx.generic_param("U", 1);
+    expect(t1 != t2);
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Struct and enum types (nominal — not interned)
+// ---------------------------------------------------------------------------
+
+suite type_struct_enum = [] {
+  "struct creation with fields"_test = [] {
+    TypeContext ctx;
+    auto* s = ctx.make_struct(&kDeclA, "Point",
+                              {{"x", ctx.f64()}, {"y", ctx.f64()}});
+    expect(s != nullptr);
+    expect(s->kind() == TypeKind::Struct);
+    expect(s->name() == "Point");
+    expect(s->fields().size() == 2u);
+    expect(s->fields()[0].name == "x");
+    expect(s->fields()[0].type == ctx.f64());
+  };
+
+  "each make_struct call produces distinct object"_test = [] {
+    TypeContext ctx;
+    auto* s1 = ctx.make_struct(&kDeclA, "Point", {{"x", ctx.f64()}});
+    auto* s2 = ctx.make_struct(&kDeclA, "Point", {{"x", ctx.f64()}});
+    expect(s1 != s2) << "nominal types are not interned";
+  };
+
+  "enum creation with variants"_test = [] {
+    TypeContext ctx;
+    auto* e = ctx.make_enum(&kDeclA, "Option",
+                            {{"None", {}}, {"Some", {ctx.i32()}}});
+    expect(e != nullptr);
+    expect(e->kind() == TypeKind::Enum);
+    expect(e->name() == "Option");
+    expect(e->variants().size() == 2u);
+    expect(e->variants()[0].name == "None");
+    expect(e->variants()[0].payload_types.empty());
+    expect(e->variants()[1].name == "Some");
+    expect(e->variants()[1].payload_types.size() == 1u);
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Type printer
+// ---------------------------------------------------------------------------
+
+suite type_printer = [] {
+  "print builtin"_test = [] {
+    TypeContext ctx;
+    expect(print_type(ctx.i32()) == "i32");
+    expect(print_type(ctx.f64()) == "f64");
+    expect(print_type(ctx.bool_type()) == "bool");
+    expect(print_type(ctx.void_type()) == "void");
+  };
+
+  "print pointer"_test = [] {
+    TypeContext ctx;
+    expect(print_type(ctx.pointer_to(ctx.i32())) == "*i32");
+  };
+
+  "print function"_test = [] {
+    TypeContext ctx;
+    auto* fn = ctx.function_type({ctx.i32(), ctx.f64()}, ctx.bool_type());
+    expect(print_type(fn) == "fn(i32, f64): bool");
+  };
+
+  "print empty-params function"_test = [] {
+    TypeContext ctx;
+    auto* fn = ctx.function_type({}, ctx.void_type());
+    expect(print_type(fn) == "fn(): void");
+  };
+
+  "print named type without args"_test = [] {
+    TypeContext ctx;
+    auto* t = ctx.named_type(&kDeclA, "Point", {});
+    expect(print_type(t) == "Point");
+  };
+
+  "print named type with args"_test = [] {
+    TypeContext ctx;
+    auto* t = ctx.named_type(&kDeclA, "List", {ctx.i32()});
+    expect(print_type(t) == "List[i32]");
+  };
+
+  "print generic param"_test = [] {
+    TypeContext ctx;
+    auto* t = ctx.generic_param("T", 0);
+    expect(print_type(t) == "T");
+  };
+
+  "print struct"_test = [] {
+    TypeContext ctx;
+    auto* s = ctx.make_struct(&kDeclA, "Point", {{"x", ctx.f64()}});
+    expect(print_type(s) == "Point");
+  };
+
+  "print enum"_test = [] {
+    TypeContext ctx;
+    auto* e = ctx.make_enum(&kDeclA, "Color", {{"Red", {}}, {"Blue", {}}});
+    expect(print_type(e) == "Color");
+  };
+
+  "print nested: pointer to function returning pointer"_test = [] {
+    TypeContext ctx;
+    auto* inner = ctx.function_type({ctx.i32()}, ctx.pointer_to(ctx.f64()));
+    auto* outer = ctx.pointer_to(inner);
+    expect(print_type(outer) == "*fn(i32): *f64");
+  };
+
+  "print null type"_test = [] {
+    expect(print_type(nullptr) == "<null>");
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Type kind name and builtin_kind_from_name
+// ---------------------------------------------------------------------------
+
+suite type_utilities = [] {
+  "type_kind_name covers all kinds"_test = [] {
+    expect(std::string_view(type_kind_name(TypeKind::Builtin)) == "Builtin");
+    expect(std::string_view(type_kind_name(TypeKind::Pointer)) == "Pointer");
+    expect(std::string_view(type_kind_name(TypeKind::Function)) == "Function");
+    expect(std::string_view(type_kind_name(TypeKind::Named)) == "Named");
+    expect(std::string_view(type_kind_name(TypeKind::GenericParam)) == "GenericParam");
+    expect(std::string_view(type_kind_name(TypeKind::Struct)) == "Struct");
+    expect(std::string_view(type_kind_name(TypeKind::Enum)) == "Enum");
+  };
+
+  "builtin_kind_from_name round-trips"_test = [] {
+    for (uint8_t i = 0; i < kBuiltinKindCount; ++i) {
+      auto kind = static_cast<BuiltinKind>(i);
+      auto name = builtin_kind_name(kind);
+      auto result = builtin_kind_from_name(name);
+      expect(result.has_value()) << "should find " << name;
+      expect(*result == kind);
+    }
+  };
+
+  "builtin_kind_from_name returns nullopt for unknown"_test = [] {
+    expect(!builtin_kind_from_name("string").has_value());
+    expect(!builtin_kind_from_name("int").has_value());
+    expect(!builtin_kind_from_name("").has_value());
+  };
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/types/type_test.cpp
+++ b/compiler/frontend/types/type_test.cpp
@@ -39,14 +39,41 @@ suite type_builtin = [] {
     expect(ctx.i32() == ctx.i32());
     expect(ctx.f64() == ctx.f64());
     expect(ctx.bool_type() == ctx.bool_type());
-    expect(ctx.void_type() == ctx.void_type());
   };
 
   "different builtins are distinct"_test = [] {
     TypeContext ctx;
     expect(ctx.i32() != ctx.f64());
     expect(ctx.i32() != ctx.u32());
-    expect(ctx.bool_type() != ctx.void_type());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Void type (not a builtin scalar)
+// ---------------------------------------------------------------------------
+
+suite type_void = [] {
+  "void_type is non-null and has Void kind"_test = [] {
+    TypeContext ctx;
+    auto* v = ctx.void_type();
+    expect(v != nullptr);
+    expect(v->kind() == TypeKind::Void);
+  };
+
+  "void_type is a singleton"_test = [] {
+    TypeContext ctx;
+    expect(ctx.void_type() == ctx.void_type());
+  };
+
+  "void is distinct from builtins"_test = [] {
+    TypeContext ctx;
+    // void_type() returns const TypeVoid*, builtins return const TypeBuiltin*.
+    // Compare as const Type* to verify distinct identity.
+    const Type* v = ctx.void_type();
+    const Type* i = ctx.i32();
+    const Type* b = ctx.bool_type();
+    expect(v != i);
+    expect(v != b);
   };
 };
 
@@ -297,6 +324,7 @@ suite type_printer = [] {
 suite type_utilities = [] {
   "type_kind_name covers all kinds"_test = [] {
     expect(std::string_view(type_kind_name(TypeKind::Builtin)) == "Builtin");
+    expect(std::string_view(type_kind_name(TypeKind::Void)) == "Void");
     expect(std::string_view(type_kind_name(TypeKind::Pointer)) == "Pointer");
     expect(std::string_view(type_kind_name(TypeKind::Function)) == "Function");
     expect(std::string_view(type_kind_name(TypeKind::Named)) == "Named");
@@ -317,6 +345,7 @@ suite type_utilities = [] {
 
   "builtin_kind_from_name returns nullopt for unknown"_test = [] {
     expect(!builtin_kind_from_name("string").has_value());
+    expect(!builtin_kind_from_name("void").has_value()) << "void is not a builtin scalar";
     expect(!builtin_kind_from_name("int").has_value());
     expect(!builtin_kind_from_name("").has_value());
   };

--- a/compiler/support/arena.h
+++ b/compiler/support/arena.h
@@ -1,0 +1,114 @@
+#ifndef DAO_SUPPORT_ARENA_H
+#define DAO_SUPPORT_ARENA_H
+
+#include <cstddef>
+#include <functional>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Arena — bump allocator with destructor tracking.
+//
+// Owns all objects allocated through it. Non-trivially-destructible
+// objects are destroyed in reverse allocation order when the arena is
+// destroyed or reset. Pointers into the arena are stable for its
+// lifetime.
+//
+// Intended for compiler-owned object graphs (AST nodes, semantic types,
+// etc.) where individual deallocation is unnecessary.
+// ---------------------------------------------------------------------------
+
+class Arena {
+public:
+  Arena() = default;
+
+  ~Arena() { destroy(); }
+
+  Arena(const Arena&) = delete;
+  auto operator=(const Arena&) -> Arena& = delete;
+
+  Arena(Arena&& other) noexcept
+      : blocks_(std::move(other.blocks_)), offset_(other.offset_),
+        dtors_(std::move(other.dtors_)) {
+    other.blocks_.clear();
+    other.offset_ = kBlockSize;
+    other.dtors_.clear();
+  }
+
+  auto operator=(Arena&& other) noexcept -> Arena& {
+    if (this != &other) {
+      destroy();
+      blocks_ = std::move(other.blocks_);
+      offset_ = other.offset_;
+      dtors_ = std::move(other.dtors_);
+      other.blocks_.clear();
+      other.offset_ = kBlockSize;
+      other.dtors_.clear();
+    }
+    return *this;
+  }
+
+  // Construct a T in arena-owned memory. The returned pointer is stable
+  // for the lifetime of the arena. If T is non-trivially destructible,
+  // its destructor is called (in reverse allocation order) when the
+  // arena is destroyed.
+  template <typename T, typename... Args>
+  auto alloc(Args&&... args) -> T* {
+    void* mem = allocate(sizeof(T), alignof(T));
+    auto* ptr = new (mem) T(std::forward<Args>(args)...);
+    if constexpr (!std::is_trivially_destructible_v<T>) {
+      dtors_.push_back([ptr]() { ptr->~T(); }); // NOLINT(modernize-use-trailing-return-type)
+    }
+    return ptr;
+  }
+
+private:
+  static constexpr size_t kBlockSize = 4096;
+
+  struct Block {
+    char data[kBlockSize]; // NOLINT(modernize-avoid-c-arrays)
+  };
+
+  std::vector<Block*> blocks_;
+  size_t offset_ = kBlockSize; // Force first allocation to create a block.
+  std::vector<std::function<void()>> dtors_;
+
+  auto allocate(size_t size, size_t align) -> void* {
+    // Align up.
+    offset_ = (offset_ + align - 1) & ~(align - 1);
+    if (offset_ + size > kBlockSize) {
+      if (size > kBlockSize) {
+        // Oversized allocation — give it its own block.
+        auto* mem = ::operator new(size);
+        blocks_.push_back(static_cast<Block*>(mem));
+        return mem;
+      }
+      blocks_.push_back(new Block);
+      offset_ = 0;
+    }
+    void* ptr =
+        blocks_.back()->data + offset_; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    offset_ += size;
+    return ptr;
+  }
+
+  void destroy() {
+    for (auto& dtor : std::ranges::reverse_view(dtors_)) {
+      dtor();
+    }
+    for (auto* block : blocks_) {
+      ::operator delete(block);
+    }
+    blocks_.clear();
+    offset_ = kBlockSize;
+    dtors_.clear();
+  }
+};
+
+} // namespace dao
+
+#endif // DAO_SUPPORT_ARENA_H

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -43,6 +43,12 @@ Reference language material.
 
 Compiler implementation roots only.
 
+### `compiler/support/`
+
+Shared low-level utilities used across compiler subsystems.
+
+- `arena.h` — bump allocator with destructor tracking for compiler-owned object graphs
+
 ### `compiler/frontend/`
 
 Source-facing compiler pipeline.

--- a/docs/contracts/CONTRACT_COMPILER_PHASES.md
+++ b/docs/contracts/CONTRACT_COMPILER_PHASES.md
@@ -32,10 +32,10 @@ Required subroots:
 - `compiler/frontend/ast/`
 - `compiler/frontend/resolve/` — name resolution and scope analysis
 - `compiler/frontend/diagnostics/`
-
-Expected next frontend subroots once implementation begins:
 - `compiler/frontend/types/` — canonical semantic type universe
   (types, interning, comparison, printing)
+
+Expected next frontend subroots once implementation begins:
 - `compiler/frontend/typecheck/` — semantic type-checking pass
 - `compiler/frontend/lower/`
 

--- a/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
+++ b/docs/contracts/CONTRACT_REPOSITORY_LAYOUT.md
@@ -30,9 +30,9 @@ Defines the allowed top-level ontology and major subroots for Dao.
 - `ast/`
 - `resolve/`
 - `diagnostics/`
+- `types/`
 
 Expected next subroots once implementation begins:
-- `types/`
 - `typecheck/`
 - `lower/`
 


### PR DESCRIPTION
## Summary

Implement the Task 7 canonical semantic type layer under `compiler/frontend/types/` and extract a shared `Arena` into `compiler/support/`. This establishes the compiler-owned type universe used by later type checking, HIR annotation, and semantic tooling.

## Highlights

- **Shared Arena** (`compiler/support/arena.h`): reusable bump allocator with destructor tracking, composed by both `AstContext` and `TypeContext`
- **Type hierarchy**: `Type` base with `TypeBuiltin`, `TypeVoid`, `TypePointer`, `TypeFunction`, `TypeNamed`, `TypeGenericParam`, `TypeStruct`, `TypeEnum`
- **TypeContext**: arena-owning context with hash-based interning for builtin, pointer, function, named, and generic param types
- **Void separation**: `void` is `TypeKind::Void` (compiler-internal singleton), not a builtin scalar — per CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md §5
- **BuiltinKind**: 11 terse scalars (i8–i64, u8–u64, f32, f64, bool); `string` and `void` excluded
- **Type printer**: stable deterministic output (`i32`, `*i32`, `fn(i32, f64): bool`, `List[i32]`)
- **37 tests** across 9 suites covering creation, canonicalization, distinctness, void identity, printing, and utilities
- **Contract updates**: `types/` promoted to required in CONTRACT_REPOSITORY_LAYOUT.md and CONTRACT_COMPILER_PHASES.md

## Test plan

- [x] All 37 type tests pass (128 assertions)
- [x] All existing tests pass (lexer, parser, AST printer, resolve, semantic tokens)
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)