### PR TITLE
docs(ir-backend): 📝 add HIR, MIR, and LLVM backend specs and contracts

### DIFF
--- a/docs/contracts/CONTRACT_HIR_BOUNDARY.md
+++ b/docs/contracts/CONTRACT_HIR_BOUNDARY.md
@@ -1,0 +1,58 @@
+# CONTRACT_HIR_BOUNDARY
+
+Status: normative
+Scope: Dao HIR boundary
+Authority: compiler architecture boundary
+
+## 1. Purpose
+
+This contract freezes the role of HIR in the Dao compiler.
+
+HIR is the typed, target-agnostic semantic IR between frontend checking
+and lower operational IR.
+
+## 2. HIR must be
+
+- typed
+- target-agnostic
+- symbol-linked
+- simpler than AST
+- expressive enough to preserve Dao semantic constructs
+
+## 3. HIR must preserve as first-class constructs
+
+- pipe expressions
+- lambda expressions
+- mode regions
+- resource regions
+
+These may be lowered later, but not erased at the HIR boundary.
+
+## 4. HIR must not contain
+
+- parser-only syntax structures with no semantic meaning
+- unresolved names
+- AST syntax-level type nodes
+- backend-specific details
+- LLVM-specific constructs
+
+## 5. HIR expressions
+
+HIR expressions must carry semantic types.
+
+## 6. HIR identity
+
+HIR should reference resolved semantic identities rather than raw source
+names wherever practical.
+
+## 7. Boundary rule
+
+AST + resolve + types + typecheck feed HIR.
+
+HIR feeds MIR.
+
+HIR must not redo:
+
+- parsing
+- name resolution
+- type checking

--- a/docs/contracts/CONTRACT_LLVM_BACKEND_BOUNDARY.md
+++ b/docs/contracts/CONTRACT_LLVM_BACKEND_BOUNDARY.md
@@ -1,0 +1,52 @@
+# CONTRACT_LLVM_BACKEND_BOUNDARY
+
+Status: normative
+Scope: Dao LLVM backend boundary
+Authority: compiler architecture boundary
+
+## 1. Purpose
+
+This contract freezes the role of the LLVM backend in the Dao compiler.
+
+The LLVM backend lowers MIR into LLVM IR.
+It is the first target-specific backend boundary.
+
+## 2. LLVM backend must be
+
+- MIR-driven
+- type-lowering-centric
+- target-specific only at the backend layer
+- cleanly separated from frontend and MIR design
+
+## 3. LLVM backend must not consume
+
+- AST directly
+- HIR directly
+- unresolved names
+- syntax-level type nodes
+
+## 4. LLVM backend responsibilities
+
+The backend is responsible for:
+
+- semantic/MIR type lowering to LLVM types
+- function lowering
+- basic block lowering
+- instruction/value lowering
+- textual LLVM IR emission
+
+## 5. Boundary rule
+
+MIR feeds the LLVM backend.
+
+The LLVM backend must not redo:
+
+- parsing
+- resolution
+- type checking
+- HIR/MIR construction
+
+## 6. Unsupported semantics
+
+If a Dao semantic construct has not yet been correctly lowered, the
+backend must fail explicitly rather than silently erase it.

--- a/docs/contracts/CONTRACT_MIR_BOUNDARY.md
+++ b/docs/contracts/CONTRACT_MIR_BOUNDARY.md
@@ -1,0 +1,64 @@
+# CONTRACT_MIR_BOUNDARY
+
+Status: normative
+Scope: Dao MIR boundary
+Authority: compiler architecture boundary
+
+## 1. Purpose
+
+This contract freezes the role of MIR in the Dao compiler.
+
+MIR is the typed, target-independent operational IR between HIR and
+backend lowering.
+
+## 2. MIR must be
+
+- typed
+- target-independent
+- operational
+- explicit in control flow
+- explicit in evaluation order
+
+## 3. MIR must include
+
+- functions
+- basic blocks
+- terminators
+- typed values/instructions
+
+## 4. MIR must preserve Dao-relevant execution semantics
+
+MIR must preserve, by explicit construct or annotation, the semantics
+of:
+
+- mode regions
+- resource regions
+
+These must not disappear before backend lowering decisions are made.
+
+## 5. MIR lowering policy
+
+MIR may lower:
+
+- pipe expressions into explicit operational form
+- structured control flow into branches and blocks
+- nested expressions into explicit temporaries
+
+## 6. MIR must not contain
+
+- parser-only syntax structure
+- unresolved names
+- AST syntax types
+- LLVM-specific values or types
+- target ABI details
+
+## 7. Boundary rule
+
+HIR feeds MIR.
+MIR feeds backend lowering.
+
+MIR must not redo:
+
+- parsing
+- resolution
+- type checking

--- a/docs/task_specs/TASK_10_MIR.md
+++ b/docs/task_specs/TASK_10_MIR.md
@@ -361,11 +361,12 @@ Lower to:
 * initializer evaluation if present
 * store/init into that slot if needed
 
-If uninitialized-but-typed locals are currently legal via zero/default
-initialization semantics, MIR should represent that explicitly:
-
-* either via default-init instruction
-* or via guaranteed local initialization lowering
+If a `let x: T` without initializer reaches MIR, represent the local
+declaration explicitly but do not commit to a runtime value model
+(zero-init, default-init, poison, etc.). Initialization semantics for
+uninitialized typed locals are not yet frozen in the syntax contract.
+MIR should preserve the construct faithfully and defer the runtime
+behavior decision to a future contract update.
 
 ### 17.3 Assignment
 
@@ -502,7 +503,8 @@ Required coverage:
 ### Data flow
 
 * let with initializer
-* let with explicit type and no initializer
+* let with explicit type and no initializer (structural representation
+  only — do not assert initialization value semantics until frozen)
 * assignment
 * arithmetic expressions
 * call argument evaluation

--- a/docs/task_specs/TASK_10_MIR.md
+++ b/docs/task_specs/TASK_10_MIR.md
@@ -1,0 +1,562 @@
+# TASK_10_MIR
+
+Status: implementation spec
+Phase: Mid-level IR
+Scope: `compiler/ir/mir/`
+
+## 1. Objective
+
+Implement the first Mid-Level Intermediate Representation (MIR) for Dao.
+
+Task 10 consumes:
+
+- HIR
+- semantic types
+- resolved symbol identities
+
+and produces:
+
+- a typed, target-independent operational IR
+- explicit control flow
+- explicit evaluation order
+- explicit storage and assignment forms
+- a representation suitable for LLVM lowering in later tasks
+
+MIR is where Dao moves from source-semantic structure to executable
+program structure.
+
+## 2. Non-goals
+
+Task 10 must not implement:
+
+- LLVM lowering
+- register allocation
+- machine ABI lowering
+- monomorphization
+- optimization pipelines
+- borrow/lifetime systems
+- full closure conversion if lambda capture is not yet frozen
+- backend-specific GPU codegen
+- runtime implementation details
+
+MIR should be lower than HIR, but still machine-independent.
+
+## 3. MIR role
+
+MIR should:
+
+- make control flow explicit
+- make temporary values explicit
+- make evaluation order explicit
+- lower high-level constructs into operational forms
+- preserve enough source span information for diagnostics/debugging
+- remain target-agnostic
+
+MIR should not be:
+
+- a source-like tree
+- a backend IR
+- an LLVM-shaped mirror
+
+## 4. Directory
+
+Implementation must live under:
+
+```text
+compiler/ir/mir/
+```
+
+Suggested shape:
+
+```text
+compiler/ir/mir/
+    mir.h
+    mir.cpp
+    mir_kind.h
+    mir_context.h
+    mir_context.cpp
+    mir_module.h
+    mir_function.h
+    mir_block.h
+    mir_inst.h
+    mir_value.h
+    mir_builder.h
+    mir_builder.cpp
+    mir_printer.h
+    mir_printer.cpp
+    mir_tests.cpp
+```
+
+## 5. Inputs
+
+Task 10 consumes:
+
+* HIR nodes
+* semantic `Type*`
+* symbol identities
+* source spans
+
+HIR is authoritative for source-semantic structure.
+MIR construction must not redo parsing, resolution, or type checking.
+
+## 6. Outputs
+
+Task 10 must produce:
+
+* MIR module/unit representation
+* MIR functions
+* basic blocks
+* typed MIR values and instructions
+* explicit control flow edges
+* stable MIR printer/debug dump support
+
+## 7. Core design principles
+
+### 7.1 Explicit control flow
+
+MIR must represent control flow with basic blocks and terminators.
+
+### 7.2 Explicit values
+
+MIR must make intermediate values explicit rather than relying on nested
+expression trees for everything.
+
+### 7.3 Still typed
+
+MIR values must carry semantic types or reference typed value
+definitions.
+
+### 7.4 Target-independent
+
+No LLVM types, no SSA values from LLVM, no backend handles.
+
+### 7.5 Source traceability
+
+Instructions and major values should retain spans where practical.
+
+## 8. MIR structural model
+
+Recommended top-level shape:
+
+* `MirModule`
+  * `MirFunction`
+    * `MirBlock`
+      * `MirInst`
+      * `MirValue`
+
+### 8.1 Functions
+
+A MIR function contains:
+
+* function identity/symbol
+* parameter list
+* local storage declarations as needed
+* ordered basic blocks
+* entry block
+
+### 8.2 Basic blocks
+
+A MIR block contains:
+
+* ordered instruction list
+* exactly one terminator instruction at end
+
+### 8.3 Instructions vs values
+
+A clean first design is:
+
+* some instructions define values
+* terminators do not
+* locals/storage are distinct from SSA-like temporaries
+
+Do not overcomplicate this into a perfect SSA design yet if it slows
+progress.
+
+## 9. Recommended MIR semantic stance
+
+MIR should be hybrid operational IR:
+
+* expression trees lowered into temporaries/instructions
+* block control flow explicit
+* locals/storage explicit
+* not necessarily full SSA in Task 10
+* ready for later SSA conversion or direct lowering strategy
+
+This is the safest first MIR.
+
+## 10. What must be lowered from HIR
+
+Task 10 should lower:
+
+* structured expressions into instruction/value form
+* `if` into conditional branching between blocks
+* `while` into loop blocks and explicit back-edges
+* `for` into explicit lowered loop structure according to current
+  iteration semantics
+* `return` into function terminators
+* calls into explicit call instructions
+* field/index access into explicit operational instructions
+* assignments into explicit store/assign instructions
+* temporary evaluation order for nested expressions
+
+## 11. What must remain semantically visible in MIR
+
+Some Dao constructs should still remain visible in MIR, even if
+operationalized.
+
+### 11.1 Mode regions
+
+`mode unsafe`, `mode gpu`, `mode parallel` must not be erased into
+nothing.
+
+MIR should preserve them either as:
+
+* region markers
+* block annotations
+* dedicated mode-enter/mode-exit instructions
+* function/block attributes where semantically appropriate
+
+Do not discard this information before backend strategy is decided.
+
+### 11.2 Resource regions
+
+`resource memory X =>` must remain visible in MIR.
+
+At minimum MIR should preserve:
+
+* resource kind
+* resource instance identifier
+* region boundaries
+
+This is critical for later allocation/runtime lowering.
+
+### 11.3 Pipe semantics
+
+Pipe expressions need not remain expression-tree nodes in MIR, but
+their evaluation and call-target semantics must lower in a way that
+preserves Dao behavior and debugging intelligibility.
+
+It is acceptable for Task 10 to lower `HirPipe` into explicit call-like
+instruction sequences, provided source span traceability remains
+reasonable.
+
+### 11.4 Lambdas
+
+Lambdas may remain as MIR-level function/lambda objects or lower into
+function-like nested entities plus environment scaffolding, but Task 10
+should avoid full, final closure conversion unless absolutely necessary.
+
+If lambda capture semantics are still narrow, keep MIR lambda handling
+correspondingly narrow and explicit.
+
+## 12. MIR control-flow form
+
+Task 10 must introduce explicit basic blocks and terminators.
+
+Minimum terminator set:
+
+* `Br` (unconditional branch)
+* `CondBr` (conditional branch)
+* `Return`
+
+Optional later:
+
+* `Unreachable`
+
+Every block must end in exactly one terminator.
+
+## 13. MIR value/instruction categories
+
+A good initial instruction/value set includes:
+
+### Constants / literals
+
+* integer constant
+* float constant
+* bool constant
+* string constant reference
+
+### Value-producing instructions
+
+* unary op
+* binary op
+* call
+* load
+* address-of
+* dereference/load-indirect if modeled separately
+* field access
+* index access
+* cast/conversion later, if needed
+* aggregate/list construction only if current surface requires it
+
+### Storage / state instructions
+
+* local alloc or local binding declaration
+* store / assign
+* resource region start/end or equivalent annotation mechanism
+
+### Control instructions
+
+* branch
+* conditional branch
+* return
+
+## 14. Storage model
+
+Task 10 should make local storage explicit.
+
+Recommended model:
+
+* locals are declared in MIR
+* assignments become explicit stores to locals or addressable places
+* pure expression temporaries are separate MIR values
+
+Do not keep assignment as a vague high-level source construct.
+
+## 15. Place vs value distinction
+
+MIR should begin distinguishing:
+
+* **places**: assignable/addressable storage locations
+* **values**: computed results
+
+This distinction is important for:
+
+* assignment
+* address-of
+* dereference
+* field assignment
+* index assignment
+
+The first MIR version does not need a sophisticated place system, but it
+should not pretend everything is just an expression value.
+
+## 16. Type policy
+
+MIR remains typed.
+
+Every MIR value-producing instruction must have a semantic `Type*`.
+
+Locals/places should also carry semantic type information.
+
+MIR must consume the semantic type universe from `frontend/types`.
+It must not invent backend-specific type models.
+
+## 17. Lowering policy for specific constructs
+
+### 17.1 Functions
+
+Lower HIR functions to MIR functions with:
+
+* explicit entry block
+* explicit parameter values/storage
+* explicit body blocks
+* explicit returns
+
+### 17.2 Let bindings
+
+Lower to:
+
+* local declaration/storage slot
+* initializer evaluation if present
+* store/init into that slot if needed
+
+If uninitialized-but-typed locals are currently legal via zero/default
+initialization semantics, MIR should represent that explicitly:
+
+* either via default-init instruction
+* or via guaranteed local initialization lowering
+
+### 17.3 Assignment
+
+Lower to explicit store/assign instructions against valid places.
+
+### 17.4 If
+
+Lower into:
+
+* condition eval
+* conditional branch
+* then block
+* else block if present
+* continuation block as needed
+
+### 17.5 While
+
+Lower into canonical loop form, e.g.:
+
+* entry → condition block
+* condition true → body
+* body → condition
+* condition false → exit
+
+### 17.6 For
+
+Lower according to the currently supported iteration model.
+If iteration semantics remain narrow, MIR lowering may be
+correspondingly narrow.
+
+### 17.7 Return
+
+Lower to explicit terminator with optional return value.
+
+### 17.8 Calls
+
+Lower call evaluation order explicitly.
+
+### 17.9 Pipe
+
+Lower pipe into explicit target evaluation/call sequence.
+Do not preserve pipe as a dedicated MIR node unless it clearly improves
+the operational model; MIR is a reasonable place to operationalize it.
+
+### 17.10 Lambda
+
+Keep lambda lowering conservative.
+If needed, MIR may represent lambdas as nested function-like entities
+with explicit capture placeholders, but do not overbuild full closure
+conversion unless the language slice requires it.
+
+### 17.11 Mode/resource
+
+Preserve region semantics explicitly through MIR constructs or
+annotations.
+These are part of Dao's core semantic identity.
+
+## 18. Builder responsibilities
+
+`MirBuilder` should:
+
+* walk HIR
+* construct MIR functions/blocks/instructions
+* create temporaries as needed
+* manage block construction and terminators
+* preserve semantic type/spans
+* validate major lowering invariants
+
+It must not:
+
+* redo type checking
+* redo resolution
+* introduce backend-only concepts
+
+## 19. Suggested implementation shape
+
+A good first builder strategy is:
+
+* one `MirBuilder` per function
+* helper routines:
+  * `lower_stmt`
+  * `lower_expr_value`
+  * `lower_expr_place`
+  * `lower_cond`
+  * `lower_block_region`
+
+This helps maintain the place/value distinction cleanly.
+
+## 20. MIR printer
+
+Task 10 must include a stable MIR printer.
+
+Suggested CLI:
+
+```text
+daoc mir file.dao
+```
+
+The dump should reveal:
+
+* function boundaries
+* block labels
+* instruction order
+* value definitions
+* terminators
+* mode/resource region info
+
+Example direction:
+
+```text
+fn positive_squares
+block %entry:
+  %0 = local xs : List[i32]
+  %1 = call filter(%0, <lambda>)
+  %2 = call map(%1, <lambda>)
+  return %2
+```
+
+Exact formatting may vary, but it must be operationally legible.
+
+## 21. Tests
+
+Task 10 is not complete without MIR golden tests.
+
+Required coverage:
+
+### Control flow
+
+* if
+* while
+* return
+* block continuation shape
+
+### Data flow
+
+* let with initializer
+* let with explicit type and no initializer
+* assignment
+* arithmetic expressions
+* call argument evaluation
+
+### Dao-specific semantics
+
+* pipe lowering
+* mode region preservation
+* resource region preservation
+* pointer address/deref if supported
+* lambda presence/lowering in current supported slice
+
+### Structural invariants
+
+* every block ends in terminator
+* no dangling blocks
+* values/instructions carry types
+* source spans preserved where required
+
+## 22. Exit criteria
+
+Task 10 is complete when:
+
+* HIR lowers into a stable MIR form
+* MIR has explicit basic blocks and terminators
+* MIR is typed and target-independent
+* Dao-specific semantic regions remain representable
+* MIR printer and tests exist
+* the result is ready to feed LLVM lowering
+
+## 23. Boundary rules
+
+MIR may depend on:
+
+* HIR
+* semantic types
+* symbols
+* support utilities
+* source spans
+
+MIR must not depend on:
+
+* LLVM APIs
+* `backend/llvm`
+* playground/LSP-specific tooling logic
+* parser or resolver internals beyond consumed semantic results
+
+## 24. Stability rules
+
+If implementation pressure suggests any of the following, stop and
+revisit before proceeding:
+
+* making MIR just another tree-shaped AST clone
+* pulling LLVM concepts into MIR
+* erasing mode/resource semantics entirely
+* keeping evaluation order implicit
+* avoiding the place/value distinction where addressability matters

--- a/docs/task_specs/TASK_11_LLVM_BACKEND.md
+++ b/docs/task_specs/TASK_11_LLVM_BACKEND.md
@@ -312,7 +312,9 @@ Recommended initial strategy:
 * materialize a runtime-compatible handle/pointer value at use sites
 
 The exact runtime-facing string ABI may remain narrow for now, but it
-must be explicit and consistent.
+must be explicit and consistent. Per CONTRACT_BOOTSTRAP_AND_INTEROP.md,
+the initial foreign interop target is the C ABI. String lowering and
+any runtime-facing seams must use C-compatible calling conventions.
 
 ## 15. Runtime hooks
 
@@ -330,6 +332,9 @@ If runtime hooks are needed:
 
 * define them explicitly
 * isolate them behind `llvm_runtime_hooks.*`
+* use the C ABI for all runtime-facing call boundaries, per
+  CONTRACT_BOOTSTRAP_AND_INTEROP.md
+* keep the runtime call surface narrow and documented
 * do not scatter ad hoc intrinsic-like calls throughout lowering code
 
 ## 16. Lowering of Dao-specific execution semantics

--- a/docs/task_specs/TASK_11_LLVM_BACKEND.md
+++ b/docs/task_specs/TASK_11_LLVM_BACKEND.md
@@ -1,0 +1,500 @@
+# TASK_11_LLVM_BACKEND
+
+Status: implementation spec
+Phase: Backend
+Scope: `compiler/backend/llvm/`
+
+## 1. Objective
+
+Implement the first LLVM backend for Dao.
+
+Task 11 consumes:
+
+- MIR
+- semantic types
+- function/module identity
+- preserved execution/resource annotations from MIR
+
+and produces:
+
+- LLVM IR modules
+- LLVM IR functions
+- target-independent LLVM lowering output suitable for JIT or object
+  generation later
+
+Task 11 is the first backend realization of Dao programs.
+
+## 2. Non-goals
+
+Task 11 must not implement:
+
+- a full optimizer pipeline strategy
+- platform ABI perfection across all targets
+- cross-platform runtime packaging
+- final GPU backend lowering
+- final resource-region runtime semantics beyond the current supported
+  slice
+- debug info completeness
+- linker driver behavior
+- object/executable packaging for every platform
+- advanced exception handling
+- generics monomorphization if not already solved upstream
+
+The goal is a correct and disciplined first LLVM lowering, not backend
+completeness.
+
+## 3. Backend role
+
+The LLVM backend should:
+
+- consume MIR as the operational source of truth
+- map Dao semantic types to LLVM types
+- lower MIR control flow to LLVM basic blocks
+- lower MIR values/instructions to LLVM IR
+- preserve enough source correlation for debugging and diagnostics where
+  practical
+- remain cleanly separated from frontend and MIR construction concerns
+
+The LLVM backend should not:
+
+- reinterpret source syntax
+- redo semantic analysis
+- become a second MIR
+
+## 4. Directory
+
+Implementation must live under:
+
+```text
+compiler/backend/llvm/
+```
+
+Suggested shape:
+
+```text
+compiler/backend/llvm/
+    llvm_backend.h
+    llvm_backend.cpp
+    llvm_context.h
+    llvm_context.cpp
+    llvm_module_builder.h
+    llvm_module_builder.cpp
+    llvm_function_builder.h
+    llvm_function_builder.cpp
+    llvm_type_lowering.h
+    llvm_type_lowering.cpp
+    llvm_value_lowering.h
+    llvm_value_lowering.cpp
+    llvm_runtime_hooks.h
+    llvm_runtime_hooks.cpp
+    llvm_printer.h
+    llvm_printer.cpp
+    llvm_tests.cpp
+```
+
+Exact filenames may vary, but the conceptual split should remain clear.
+
+## 5. Inputs
+
+Task 11 consumes:
+
+* MIR module/function/block/instruction structure
+* semantic `Type*`
+* MIR type information
+* MIR source spans where available
+* backend configuration/target triple information as needed
+
+MIR is authoritative for backend lowering.
+The LLVM backend must not consume AST or HIR directly.
+
+## 6. Outputs
+
+Task 11 must produce:
+
+* an LLVM Module
+* lowered LLVM Functions
+* lowered LLVM BasicBlocks
+* LLVM values/instructions corresponding to MIR
+* textual LLVM IR dump support
+* a stable CLI surface for IR emission
+
+Optional later outputs:
+
+* object files
+* assembly
+* executable linking
+
+These are not required for the initial Task 11 slice unless explicitly
+added.
+
+## 7. Core design principles
+
+### 7.1 MIR is the backend input boundary
+
+LLVM lowering starts from MIR, not from AST or HIR.
+
+### 7.2 Semantic type lowering is centralized
+
+Semantic/MIR type to LLVM type mapping must live in a dedicated
+type-lowering layer.
+
+### 7.3 Control flow remains explicit
+
+MIR basic blocks and terminators should lower directly to LLVM control
+flow.
+
+### 7.4 Backend details stay in backend
+
+Do not leak LLVM types or APIs back upward into MIR, HIR, or frontend
+layers.
+
+### 7.5 Start narrow, correct, and inspectable
+
+The first backend should favor correctness and readable IR over
+premature sophistication.
+
+## 8. LLVM backend responsibilities
+
+Task 11 must implement:
+
+* module creation
+* function signature lowering
+* local value/lifetime mapping
+* basic block creation
+* instruction lowering
+* terminator lowering
+* semantic type lowering
+* string constant/materialization support for the current language slice
+* CLI/debug printing support
+
+## 9. Type lowering
+
+Task 11 must introduce a dedicated LLVM type lowering layer.
+
+### Required initial mappings
+
+#### Scalars
+
+* `i8` → LLVM `i8`
+* `i16` → LLVM `i16`
+* `i32` → LLVM `i32`
+* `i64` → LLVM `i64`
+* `u8` → LLVM `i8`
+* `u16` → LLVM `i16`
+* `u32` → LLVM `i32`
+* `u64` → LLVM `i64`
+* `bool` → LLVM `i1`
+* `f32` → LLVM `float`
+* `f64` → LLVM `double`
+
+#### Pointer types
+
+* `*T` → LLVM pointer to lowered `T`
+
+#### Void
+
+* compiler-supported `void` → LLVM `void` in function returns where
+  applicable
+
+#### Predeclared string
+
+For the first backend slice, choose and document a narrow
+representation.
+
+Recommended initial representation:
+
+* pointer-like runtime string handle, or
+* simple pointer-to-bytes convention if that is already the chosen
+  runtime boundary
+
+Do not leave this implicit.
+
+#### Structs / enums
+
+If semantic structs/enums are already part of the supported slice, lower
+them conservatively and explicitly.
+If not fully ready yet, keep the initial backend slice scoped
+accordingly.
+
+## 10. Function lowering
+
+Each MIR function lowers to one LLVM function.
+
+Task 11 must lower:
+
+* function name / symbol identity
+* parameter types
+* return type
+* entry block
+* all MIR basic blocks
+* terminators
+
+Recommended first policy:
+
+* use straightforward LLVM function creation
+* map MIR locals and temporaries cleanly
+* avoid clever ABI shaping in the first pass
+
+## 11. Local storage and values
+
+The backend must define a clear strategy for lowering:
+
+* MIR locals / places
+* MIR temporaries / values
+* loads and stores
+
+Recommended first strategy:
+
+* lower MIR locals to LLVM allocas in the entry block
+* lower MIR temporaries directly to LLVM SSA values where possible
+* lower explicit MIR store/load operations faithfully
+
+This is simple, conventional, and easy to inspect.
+
+## 12. Control-flow lowering
+
+Task 11 must lower MIR terminators into LLVM terminators.
+
+### Required baseline
+
+* `Br` → unconditional branch
+* `CondBr` → conditional branch
+* `Return` → return instruction
+
+LLVM block structure should closely mirror MIR block structure.
+
+Do not invent extra backend-only control flow unless required.
+
+## 13. Instruction lowering
+
+Task 11 must lower, at minimum, the currently supported MIR
+instruction/value categories.
+
+### Constants
+
+* integer constants
+* float constants
+* bool constants
+* string constants
+
+### Arithmetic and logical ops
+
+* add/sub/mul/div for the supported numeric types
+* comparisons
+* boolean logic
+
+### Memory-ish operations
+
+* local declaration / alloca lowering
+* load
+* store
+* address-of lowering as appropriate
+* dereference/load-indirect lowering as appropriate
+
+### Calls
+
+* direct function calls
+* runtime hook calls where needed
+
+### Field/index access
+
+Only if these are already fully represented in MIR for the current
+supported slice.
+
+## 14. String handling
+
+Task 11 must choose an explicit first lowering strategy for string
+literals and `string`.
+
+Recommended initial strategy:
+
+* lower string literals as LLVM global constants
+* materialize a runtime-compatible handle/pointer value at use sites
+
+The exact runtime-facing string ABI may remain narrow for now, but it
+must be explicit and consistent.
+
+## 15. Runtime hooks
+
+The backend may need a small, explicit set of runtime hooks for the
+current language slice.
+
+Examples might include:
+
+* printing
+* allocation helpers
+* string helpers
+* resource-region entry/exit helpers later
+
+If runtime hooks are needed:
+
+* define them explicitly
+* isolate them behind `llvm_runtime_hooks.*`
+* do not scatter ad hoc intrinsic-like calls throughout lowering code
+
+## 16. Lowering of Dao-specific execution semantics
+
+### 16.1 Mode regions
+
+#### `mode unsafe`
+
+This may have no direct LLVM manifestation beyond permitting the MIR
+operations that reached backend lowering.
+Do not invent unnecessary IR markers for pure permission contexts.
+
+#### `mode parallel`
+
+If parallel execution semantics are not yet fully implemented, preserve
+enough structure to diagnose unsupported lowering cleanly rather than
+silently erasing semantics.
+
+#### `mode gpu`
+
+For the first LLVM backend slice, it is acceptable to:
+
+* reject unsupported GPU mode lowering clearly, or
+* preserve it as unsupported backend territory
+
+Do not fake GPU support through ordinary CPU lowering unless explicitly
+intended.
+
+### 16.2 Resource regions
+
+`resource memory X =>` and future resource constructs must not be
+forgotten casually.
+
+For the first backend slice, acceptable strategies include:
+
+* explicit no-op region markers in backend bookkeeping if runtime
+  behavior is not yet implemented
+* lowering to narrow runtime hook boundaries
+* lowering only the currently implemented memory semantics
+
+But the backend must remain honest about what is and is not implemented.
+
+## 17. Error policy for unsupported lowering
+
+Task 11 should fail clearly for MIR constructs not yet supported.
+
+Examples:
+
+* unimplemented enum lowering
+* unsupported lambda capture strategy
+* unsupported GPU region lowering
+* unsupported advanced resource behavior
+
+Do not emit half-correct LLVM IR.
+
+## 18. Builder structure
+
+A good implementation split is:
+
+* `LlvmBackend` — top-level orchestration
+* `LlvmModuleBuilder` — module-wide lowering
+* `LlvmFunctionBuilder` — per-function lowering
+* `LlvmTypeLowering` — semantic/MIR type to LLVM type mapping
+* `LlvmValueLowering` — MIR instruction/value lowering helpers
+
+This keeps responsibilities clean.
+
+## 19. Value mapping
+
+Task 11 must maintain a clear mapping from MIR entities to LLVM values.
+
+Recommended structures:
+
+* MIR local/place → LLVM alloca/value handle
+* MIR SSA-like temporary/value → LLVM `Value*`
+* MIR block → LLVM `BasicBlock*`
+
+This mapping should be explicit and owned by the function builder.
+
+## 20. Debug / printing surface
+
+Task 11 must support emitting textual LLVM IR.
+
+Suggested CLI surfaces:
+
+```text
+daoc llvm-ir file.dao
+```
+
+One stable textual IR surface is enough initially.
+
+The output should be useful for:
+
+* backend debugging
+* golden tests
+* validating MIR lowering decisions
+
+## 21. Tests
+
+Task 11 is not complete without backend golden tests.
+
+### Required coverage
+
+#### Positive backend coverage
+
+* arithmetic function lowering
+* bool conditions and branches
+* while loop lowering
+* local bindings and assignment
+* function call lowering
+* return lowering
+* pointer address/deref where supported
+* string literal lowering
+* print/runtime-hook lowering if part of the current slice
+
+#### Structural backend coverage
+
+* valid LLVM module emission
+* valid function signatures
+* valid basic block/terminator structure
+* deterministic IR output where practical
+
+#### Failure coverage
+
+* unsupported construct diagnostics/errors for:
+  * unsupported GPU lowering
+  * unsupported advanced lambda lowering
+  * unsupported resource semantics beyond the implemented slice
+
+## 22. Exit criteria
+
+Task 11 is complete when:
+
+* MIR lowers to valid LLVM IR for the supported language slice
+* textual LLVM IR can be emitted through the CLI
+* type lowering is centralized and clean
+* control flow lowering mirrors MIR structure correctly
+* tests cover supported lowering and intentional unsupported cases
+* the backend boundary remains cleanly separated from frontend/MIR
+  concerns
+
+## 23. Boundary rules
+
+The LLVM backend may depend on:
+
+* MIR
+* semantic types
+* backend support utilities
+* LLVM APIs
+
+The LLVM backend must not depend on:
+
+* AST
+* HIR
+* resolver internals
+* type checker internals beyond consumed typed MIR facts
+* playground/LSP-specific logic
+
+## 24. Stability rules
+
+If implementation pressure suggests any of the following, stop and
+revisit before proceeding:
+
+* lowering directly from HIR or AST
+* leaking LLVM types into MIR
+* making string/resource behavior implicit or magical
+* silently erasing unsupported mode/resource semantics
+* scattering type lowering logic throughout random instruction builders

--- a/docs/task_specs/TASK_9_HIR.md
+++ b/docs/task_specs/TASK_9_HIR.md
@@ -1,0 +1,528 @@
+# TASK_9_HIR
+
+Status: implementation spec
+Phase: Semantic Frontend + HIR
+Scope: `compiler/ir/hir/`
+
+## 1. Objective
+
+Implement the first High-Level Intermediate Representation (HIR) for Dao.
+
+Task 9 consumes:
+
+- parsed AST
+- resolution results
+- semantic types
+- typed expression side tables
+
+and produces:
+
+- a typed, target-agnostic HIR
+- explicit semantic structure suitable for later lowering to MIR
+- a form easier to analyze than AST while still preserving Dao-level
+  constructs
+
+HIR is the semantic bridge between source-facing frontend structures and
+lower operational IR.
+
+## 2. Non-goals
+
+Task 9 must not implement:
+
+- MIR construction
+- control-flow graph normalization
+- LLVM lowering
+- backend-specific calling convention details
+- borrow/lifetime systems
+- full closure conversion
+- generic monomorphization
+- trait/interface conformance solving
+- optimization passes
+
+HIR should remain high-level and target-agnostic.
+
+## 3. HIR role
+
+HIR should:
+
+- be simpler and more explicit than AST
+- retain semantic constructs that matter to Dao
+- rely on resolved symbols and semantic types
+- remove parser-only syntax noise
+- still preserve source-correlated structure for diagnostics and tooling
+
+HIR should not be a glorified AST clone.
+HIR should not be a low-level CFG form.
+
+## 4. Directory
+
+Implementation must live under:
+
+```text
+compiler/ir/hir/
+```
+
+Suggested shape:
+
+```text
+compiler/ir/hir/
+    hir.h
+    hir.cpp
+    hir_kind.h
+    hir_context.h
+    hir_context.cpp
+    hir_module.h
+    hir_decl.h
+    hir_stmt.h
+    hir_expr.h
+    hir_builder.h
+    hir_builder.cpp
+    hir_printer.h
+    hir_printer.cpp
+    hir_tests.cpp
+```
+
+Exact filenames may vary, but the conceptual split should remain clear.
+
+## 5. Inputs
+
+Task 9 consumes:
+
+* AST
+* resolver bindings
+* semantic types from `frontend/types`
+* typed results from `frontend/typecheck`
+
+Resolution and type checking are authoritative. HIR construction must
+not redo those passes.
+
+## 6. Outputs
+
+Task 9 must produce:
+
+* a compiler-owned HIR module/unit representation
+* typed HIR expressions
+* typed HIR statements/declarations
+* explicit HIR nodes for Dao-specific semantics
+* stable printer/debug dump support
+
+## 7. Core design principles
+
+### 7.1 Typed by construction
+
+Every HIR expression node must carry a semantic `Type*`.
+
+HIR should not require re-deriving expression types from scratch.
+
+### 7.2 Symbol-linked, not name-string-based
+
+HIR should reference resolved semantic identities, not raw source names
+wherever practical.
+
+### 7.3 Preserve Dao semantics
+
+HIR must preserve the constructs that are semantically important to Dao:
+
+* pipes
+* lambdas
+* mode regions
+* resource regions
+
+Do not erase these too early.
+
+### 7.4 Remove syntax-only noise
+
+HIR should not preserve parser-only grouping constructs unless needed
+for source fidelity.
+
+Examples:
+
+* parenthesized expressions should usually disappear
+* syntax-only type nodes should not survive
+* punctuation distinctions that have no semantic meaning should not
+  survive
+
+### 7.5 Target-agnostic
+
+HIR must not contain LLVM types, backend handles, ABI lowering
+artifacts, or machine details.
+
+## 8. What HIR should preserve vs lower
+
+### 8.1 Preserve in HIR
+
+Preserve as first-class HIR nodes:
+
+* function declarations
+* parameters
+* local bindings
+* assignments
+* if / while / for
+* return
+* call
+* field access
+* indexing
+* pipe expressions
+* lambdas
+* mode blocks
+* resource blocks
+* literals
+* identifiers / symbol refs
+
+### 8.2 Lower away before or during HIR construction
+
+Lower or discard:
+
+* syntax-only `TypeNode`
+* parenthesized expressions
+* purely lexical grouping with no semantic meaning
+* unresolved names
+
+## 9. HIR ownership and allocation
+
+HIR should use compiler-owned arena/context allocation, consistent with
+AST and semantic types.
+
+Recommended model:
+
+* `HirContext` owns all HIR nodes
+* HIR nodes have stable identity
+* node categories use class hierarchy + kind tags, not giant
+  `std::variant`
+
+## 10. HIR layers and major node categories
+
+Suggested hierarchy:
+
+* `HirNode`
+  * `HirDecl`
+  * `HirStmt`
+  * `HirExpr`
+
+All HIR expressions must carry semantic `Type*`.
+
+### 10.1 Declaration categories
+
+At minimum:
+
+* `HirFunction`
+* `HirStructDecl` if current syntax already supports structs
+* `HirAliasDecl` if aliases are in current surface
+
+### 10.2 Statement categories
+
+At minimum:
+
+* `HirLet`
+* `HirAssign`
+* `HirIf`
+* `HirWhile`
+* `HirFor`
+* `HirReturn`
+* `HirExprStmt`
+* `HirMode`
+* `HirResource`
+
+### 10.3 Expression categories
+
+At minimum:
+
+* `HirLiteral`
+* `HirSymbolRef`
+* `HirUnary`
+* `HirBinary`
+* `HirCall`
+* `HirField`
+* `HirIndex`
+* `HirPipe`
+* `HirLambda`
+
+## 11. Treatment of specific language features
+
+### 11.1 Functions
+
+HIR function nodes should contain:
+
+* symbol identity
+* parameter list with semantic types
+* declared return type
+* body form
+
+Block-bodied functions should become explicit HIR bodies.
+Expression-bodied functions may either:
+
+* remain as a compact expression form in HIR, or
+* normalize to an explicit return/body form
+
+Recommended:
+
+normalize expression-bodied functions to a standard body shape for
+uniformity.
+
+### 11.2 Let statements
+
+HIR let bindings should contain:
+
+* bound symbol
+* semantic declared or inferred type
+* optional initializer
+
+If the source allowed `let x: T` without initializer, preserve that
+explicitly.
+
+### 11.3 Assignment
+
+HIR assignments should have explicit assignable target categories.
+
+Do not keep arbitrary AST expression as a left-hand side without
+classifying it.
+
+Recommended target categories:
+
+* local/symbol assignment
+* field assignment
+* index assignment
+
+If only symbol assignment is supported yet, keep it narrow and explicit.
+
+### 11.4 Pipes
+
+HIR must preserve pipe expressions as first-class nodes.
+
+Do not desugar pipes into generic nested calls in Task 9.
+
+Reasons:
+
+* source-faithful diagnostics
+* tooling / semantic visualization
+* Dao-specific semantics
+* later MIR lowering can choose the operational lowering
+
+A `HirPipe` node should link:
+
+* left input expression
+* right pipeline target expression/form
+
+### 11.5 Lambdas
+
+HIR must preserve lambdas as first-class expressions.
+
+Do not perform full closure conversion in Task 9.
+
+HIR lambda should include:
+
+* parameter semantic identities/types
+* return/result semantic type if available
+* body expression or normalized body form
+
+If lambda bodies are expression-only in source, they may remain
+expression-bodied in HIR.
+
+### 11.6 Modes
+
+HIR must preserve mode regions as explicit nodes.
+
+At minimum:
+
+* unsafe
+* gpu
+* parallel
+
+A `HirMode` node should encode:
+
+* mode kind
+* enclosed statement/body region
+
+Do not flatten mode information away into booleans.
+
+### 11.7 Resources
+
+HIR must preserve resource regions as explicit nodes.
+
+A `HirResource` node should encode:
+
+* resource kind
+* resource instance name/symbol
+* enclosed statement/body region
+
+This is important for later lowering into allocation / execution
+regions.
+
+### 11.8 Literals
+
+Literals in HIR must carry resolved semantic types.
+
+Integer/float literal typing chosen by Task 8 should already be
+reflected.
+
+### 11.9 Symbol references
+
+Identifier expressions should become symbol references, not raw names.
+
+Use:
+
+* `Symbol*`
+* declaration id
+* or equivalent stable semantic handle
+
+Do not keep unresolved textual references in HIR.
+
+## 12. Builder responsibilities
+
+Task 9 should implement a dedicated HIR builder pass.
+
+`HirBuilder` should:
+
+* walk checked AST
+* consume resolution + typed results
+* allocate HIR nodes
+* validate required semantic prerequisites exist
+* report internal construction errors cleanly if invariants are broken
+
+It must not:
+
+* redo parsing
+* redo resolution
+* redo type inference
+
+## 13. Structural normalization policy
+
+HIR should apply modest normalization, not aggressive lowering.
+
+Recommended normalizations:
+
+* remove parentheses
+* normalize expression-bodied function declarations into standard
+  function bodies
+* normalize identifier uses into symbol refs
+* normalize AST type syntax away into semantic types
+* preserve semantic constructs like pipe/mode/resource/lambda
+
+Do not:
+
+* flatten structured control flow into labels/gotos/CFG
+* desugar pipe away
+* closure-convert lambdas
+* erase mode/resource boundaries
+
+Those belong later.
+
+## 14. Source locations
+
+HIR nodes should retain source span information sufficient for:
+
+* diagnostics
+* printers/debug dumps
+* playground/IDE inspection
+* traceability back to source constructs
+
+Every major HIR node should have a span.
+
+## 15. HIR printing and debug surface
+
+Task 9 must include a stable HIR printer.
+
+Suggested CLI surface:
+
+```text
+daoc hir file.dao
+```
+
+The printer should show semantic structure, not just AST syntax.
+
+Example direction:
+
+```text
+Function positive_squares : fn(List[i32]) -> List[i32]
+  Body
+    Pipe : List[i32]
+      SymbolRef xs : List[i32]
+      CallTarget filter ...
+```
+
+Exact formatting may vary, but the dump must be useful.
+
+## 16. Tests
+
+Task 9 is not complete without HIR golden tests.
+
+Required coverage:
+
+### Positive coverage
+
+* expression-bodied function normalized to HIR
+* block-bodied function
+* let with inferred type
+* let with explicit type and no initializer
+* assignment
+* if / while / for
+* return
+* pipe expression
+* lambda expression
+* mode block
+* resource block
+* function call
+* pointer operations if currently supported
+* string / bool / integer / float literals
+
+### Semantic preservation coverage
+
+* typed expression nodes have semantic `Type*`
+* symbol references point to resolved semantic identities
+* mode/resource nodes remain explicit
+* pipe remains explicit
+
+### Golden output
+
+Include golden HIR dumps for selected examples and syntax probes.
+
+## 17. Exit criteria
+
+Task 9 is complete when:
+
+* typed AST can be lowered into a stable HIR form
+* HIR is clearly simpler than AST but preserves Dao semantic constructs
+* HIR printer exists
+* tests cover the supported language slice
+* HIR is ready to feed Task 10 MIR lowering
+
+## 18. Boundary rules
+
+HIR may depend on:
+
+* semantic types
+* resolution results
+* typed expression side tables
+* source spans
+* stable compiler support utilities
+
+HIR must not depend on:
+
+* LLVM
+* backend code
+* MIR
+* tooling-specific parsers or semantic duplication
+
+## 19. Stability rules
+
+If implementation pressure suggests any of the following, stop and
+revisit before proceeding:
+
+* making HIR a near-copy of AST
+* erasing pipe/lambda/mode/resource semantics too early
+* introducing backend-specific details
+* redoing type checking inside HIR construction
+* depending on raw source names instead of resolved semantic identity
+
+## 20. Recommended next seam
+
+Task 9 should leave a very clear path for Task 10 MIR lowering.
+
+MIR will be the place to decide:
+
+* call normalization
+* explicit control flow form
+* operational lowering of pipes
+* operational lowering of mode/resource regions
+* closure strategy
+* target-independent execution details


### PR DESCRIPTION
## Summary

Spec-first documentation for the next three compiler phases (Tasks 9–11), establishing architectural boundaries before implementation begins.

## Highlights

- **TASK_9_HIR.md** — typed semantic tree with modest normalization; pipes, lambdas, modes, and resources preserved as first-class HIR constructs; expression-bodied functions normalized to standard body shape
- **TASK_10_MIR.md** — explicit control flow with basic blocks and terminators; place/value distinction; pipe operationalized into call sequences; mode/resource regions preserved as annotations
- **TASK_11_LLVM_BACKEND.md** — MIR-driven lowering; centralized type mapping (including unsigned→LLVM signed integer mapping); string/runtime hook strategy; explicit failure for unsupported constructs
- **CONTRACT_HIR_BOUNDARY.md** — HIR is typed, target-agnostic, symbol-linked; must preserve pipe/lambda/mode/resource
- **CONTRACT_MIR_BOUNDARY.md** — MIR is typed, target-independent, operational; must preserve mode/resource semantics
- **CONTRACT_LLVM_BACKEND_BOUNDARY.md** — backend consumes MIR only; must fail explicitly for unsupported semantics

## Test plan

- [ ] Specs are internally consistent with existing contracts
- [ ] Boundary contracts do not conflict with CONTRACT_COMPILER_PHASES.md
- [ ] Task specs reference correct directory paths per ARCH_INDEX.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)