### PR TITLE
feat(hir): ✨ implement typed HIR with builder, printer, and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 enable_testing()
 
 add_subdirectory(compiler/frontend)
+add_subdirectory(compiler/ir)
 add_subdirectory(compiler/analysis)
 add_subdirectory(compiler/driver)
 add_subdirectory(tools/playground)

--- a/compiler/driver/CMakeLists.txt
+++ b/compiler/driver/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(daoc main.cpp)
-target_link_libraries(daoc PRIVATE dao_analysis dao_frontend)
+target_link_libraries(daoc PRIVATE dao_analysis dao_ir dao_frontend)

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -5,6 +5,9 @@
 #include "frontend/resolve/resolve.h"
 #include "frontend/typecheck/type_checker.h"
 #include "frontend/types/type_context.h"
+#include "ir/hir/hir_builder.h"
+#include "ir/hir/hir_context.h"
+#include "ir/hir/hir_printer.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -217,6 +220,57 @@ void cmd_check(const std::filesystem::path& path) {
   std::cout << "ok\n";
 }
 
+// Build and print HIR. Output is deterministic.
+void cmd_hir(const std::filesystem::path& path) {
+  auto result = lex_and_parse(path);
+  if (result.parse_result.file == nullptr) {
+    return;
+  }
+
+  auto resolve_result = dao::resolve(*result.parse_result.file);
+
+  // Print resolve diagnostics.
+  for (const auto& diag : resolve_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+  }
+
+  dao::TypeContext types;
+  auto check_result =
+      dao::typecheck(*result.parse_result.file, resolve_result, types);
+
+  bool has_errors = !resolve_result.diagnostics.empty();
+
+  for (const auto& diag : check_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    auto severity = diag.severity == dao::Severity::Error ? "error" : "warning";
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": " << severity << ": " << diag.message << "\n";
+    if (diag.severity == dao::Severity::Error) {
+      has_errors = true;
+    }
+  }
+
+  if (has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  dao::HirContext hir_ctx;
+  auto hir_result = dao::build_hir(*result.parse_result.file, resolve_result,
+                                   check_result, hir_ctx);
+
+  for (const auto& diag : hir_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+  }
+
+  if (hir_result.module != nullptr) {
+    dao::print_hir(std::cout, *hir_result.module);
+  }
+}
+
 // Pretty-print AST. Output is deterministic and suitable for golden-file testing.
 void cmd_ast(const std::filesystem::path& path) {
   auto result = lex_and_parse(path);
@@ -230,7 +284,7 @@ void cmd_ast(const std::filesystem::path& path) {
 auto main(int argc, char* argv[]) -> int {
   if (argc < 2) {
     std::cerr << "usage: daoc <command> <file>\n";
-    std::cerr << "commands: lex, parse, ast, tokens, resolve, check\n";
+    std::cerr << "commands: lex, parse, ast, tokens, resolve, check, hir\n";
     return EXIT_FAILURE;
   }
 
@@ -308,6 +362,21 @@ auto main(int argc, char* argv[]) -> int {
       return EXIT_FAILURE;
     }
     cmd_check(check_path);
+    return EXIT_SUCCESS;
+  }
+
+  // daoc hir <file>
+  if (arg1 == "hir") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc hir <file>\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path hir_path(argv[2]);
+    if (!std::filesystem::exists(hir_path)) {
+      std::cerr << "error: file not found: " << hir_path << "\n";
+      return EXIT_FAILURE;
+    }
+    cmd_hir(hir_path);
     return EXIT_SUCCESS;
   }
 

--- a/compiler/ir/CMakeLists.txt
+++ b/compiler/ir/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(dao_ir STATIC
+  hir/hir.cpp
+  hir/hir_builder.cpp
+  hir/hir_printer.cpp
+)
+
+target_include_directories(dao_ir PUBLIC
+  ${CMAKE_SOURCE_DIR}/compiler
+)
+
+target_link_libraries(dao_ir PUBLIC dao_frontend)
+
+# Tests
+find_package(ut REQUIRED)
+
+add_executable(hir_test
+  hir/hir_test.cpp
+)
+
+target_link_libraries(hir_test PRIVATE dao_ir Boost::ut)
+
+target_compile_definitions(hir_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
+include(CTest)
+add_test(NAME hir_test COMMAND hir_test)

--- a/compiler/ir/hir/hir.cpp
+++ b/compiler/ir/hir/hir.cpp
@@ -1,0 +1,53 @@
+#include "ir/hir/hir.h"
+#include "ir/hir/hir_kind.h"
+
+namespace dao {
+
+auto hir_kind_name(HirKind kind) -> const char* {
+  switch (kind) {
+  case HirKind::Module:        return "Module";
+  case HirKind::Function:      return "Function";
+  case HirKind::StructDecl:    return "StructDecl";
+  case HirKind::Let:           return "Let";
+  case HirKind::Assign:        return "Assign";
+  case HirKind::If:            return "If";
+  case HirKind::While:         return "While";
+  case HirKind::For:           return "For";
+  case HirKind::Return:        return "Return";
+  case HirKind::ExprStmt:      return "ExprStmt";
+  case HirKind::Mode:          return "Mode";
+  case HirKind::Resource:      return "Resource";
+  case HirKind::IntLiteral:    return "IntLiteral";
+  case HirKind::FloatLiteral:  return "FloatLiteral";
+  case HirKind::StringLiteral: return "StringLiteral";
+  case HirKind::BoolLiteral:   return "BoolLiteral";
+  case HirKind::SymbolRef:     return "SymbolRef";
+  case HirKind::Unary:         return "Unary";
+  case HirKind::Binary:        return "Binary";
+  case HirKind::Call:          return "Call";
+  case HirKind::Field:         return "Field";
+  case HirKind::Index:         return "Index";
+  case HirKind::Pipe:          return "Pipe";
+  case HirKind::Lambda:        return "Lambda";
+  }
+  return "<unknown>";
+}
+
+auto hir_mode_kind_from_name(std::string_view name) -> HirModeKind {
+  if (name == "unsafe") return HirModeKind::Unsafe;
+  if (name == "gpu") return HirModeKind::Gpu;
+  if (name == "parallel") return HirModeKind::Parallel;
+  return HirModeKind::Other;
+}
+
+auto hir_mode_kind_name(HirModeKind kind) -> const char* {
+  switch (kind) {
+  case HirModeKind::Unsafe:   return "unsafe";
+  case HirModeKind::Gpu:      return "gpu";
+  case HirModeKind::Parallel: return "parallel";
+  case HirModeKind::Other:    return "other";
+  }
+  return "<unknown>";
+}
+
+} // namespace dao

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -1,0 +1,470 @@
+#ifndef DAO_IR_HIR_HIR_H
+#define DAO_IR_HIR_HIR_H
+
+#include "frontend/ast/ast.h"
+#include "frontend/diagnostics/source.h"
+#include "frontend/resolve/symbol.h"
+#include "frontend/types/type.h"
+#include "ir/hir/hir_kind.h"
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Base classes
+// ---------------------------------------------------------------------------
+
+class HirNode {
+public:
+  explicit HirNode(HirKind kind, Span span) : kind_(kind), span_(span) {}
+  virtual ~HirNode() = default;
+
+  HirNode(const HirNode&) = delete;
+  auto operator=(const HirNode&) -> HirNode& = delete;
+  HirNode(HirNode&&) = delete;
+  auto operator=(HirNode&&) -> HirNode& = delete;
+
+  [[nodiscard]] auto kind() const -> HirKind { return kind_; }
+  [[nodiscard]] auto span() const -> Span { return span_; }
+
+private:
+  HirKind kind_;
+  Span span_;
+};
+
+class HirDecl : public HirNode {
+public:
+  using HirNode::HirNode;
+};
+
+class HirStmt : public HirNode {
+public:
+  using HirNode::HirNode;
+};
+
+class HirExpr : public HirNode {
+public:
+  HirExpr(HirKind kind, Span span, const Type* type)
+      : HirNode(kind, span), type_(type) {}
+
+  [[nodiscard]] auto type() const -> const Type* { return type_; }
+
+private:
+  const Type* type_;
+};
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+class HirModule : public HirNode {
+public:
+  explicit HirModule(Span span, std::vector<HirDecl*> declarations)
+      : HirNode(HirKind::Module, span),
+        declarations_(std::move(declarations)) {}
+
+  [[nodiscard]] auto declarations() const -> const std::vector<HirDecl*>& {
+    return declarations_;
+  }
+
+private:
+  std::vector<HirDecl*> declarations_;
+};
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+struct HirParam {
+  const Symbol* symbol;
+  const Type* type;
+  Span span;
+};
+
+class HirFunction : public HirDecl {
+public:
+  HirFunction(Span span, const Symbol* symbol, std::vector<HirParam> params,
+              const Type* return_type, std::vector<HirStmt*> body)
+      : HirDecl(HirKind::Function, span), symbol_(symbol),
+        params_(std::move(params)), return_type_(return_type),
+        body_(std::move(body)) {}
+
+  [[nodiscard]] auto symbol() const -> const Symbol* { return symbol_; }
+  [[nodiscard]] auto params() const -> const std::vector<HirParam>& {
+    return params_;
+  }
+  [[nodiscard]] auto return_type() const -> const Type* {
+    return return_type_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<HirStmt*>& {
+    return body_;
+  }
+
+private:
+  const Symbol* symbol_;
+  std::vector<HirParam> params_;
+  const Type* return_type_;
+  std::vector<HirStmt*> body_;
+};
+
+class HirStructDecl : public HirDecl {
+public:
+  HirStructDecl(Span span, const Symbol* symbol, const TypeStruct* type)
+      : HirDecl(HirKind::StructDecl, span), symbol_(symbol), type_(type) {}
+
+  [[nodiscard]] auto symbol() const -> const Symbol* { return symbol_; }
+  [[nodiscard]] auto struct_type() const -> const TypeStruct* {
+    return type_;
+  }
+
+private:
+  const Symbol* symbol_;
+  const TypeStruct* type_;
+};
+
+// ---------------------------------------------------------------------------
+// Statements
+// ---------------------------------------------------------------------------
+
+class HirLet : public HirStmt {
+public:
+  HirLet(Span span, const Symbol* symbol, const Type* type,
+         HirExpr* initializer)
+      : HirStmt(HirKind::Let, span), symbol_(symbol), type_(type),
+        initializer_(initializer) {}
+
+  [[nodiscard]] auto symbol() const -> const Symbol* { return symbol_; }
+  [[nodiscard]] auto type() const -> const Type* { return type_; }
+  [[nodiscard]] auto initializer() const -> HirExpr* { return initializer_; }
+
+private:
+  const Symbol* symbol_;
+  const Type* type_;
+  HirExpr* initializer_; // nullable
+};
+
+class HirAssign : public HirStmt {
+public:
+  HirAssign(Span span, HirExpr* target, HirExpr* value)
+      : HirStmt(HirKind::Assign, span), target_(target), value_(value) {}
+
+  [[nodiscard]] auto target() const -> HirExpr* { return target_; }
+  [[nodiscard]] auto value() const -> HirExpr* { return value_; }
+
+private:
+  HirExpr* target_;
+  HirExpr* value_;
+};
+
+class HirIf : public HirStmt {
+public:
+  HirIf(Span span, HirExpr* condition, std::vector<HirStmt*> then_body,
+        std::vector<HirStmt*> else_body)
+      : HirStmt(HirKind::If, span), condition_(condition),
+        then_body_(std::move(then_body)),
+        else_body_(std::move(else_body)) {}
+
+  [[nodiscard]] auto condition() const -> HirExpr* { return condition_; }
+  [[nodiscard]] auto then_body() const -> const std::vector<HirStmt*>& {
+    return then_body_;
+  }
+  [[nodiscard]] auto else_body() const -> const std::vector<HirStmt*>& {
+    return else_body_;
+  }
+
+private:
+  HirExpr* condition_;
+  std::vector<HirStmt*> then_body_;
+  std::vector<HirStmt*> else_body_;
+};
+
+class HirWhile : public HirStmt {
+public:
+  HirWhile(Span span, HirExpr* condition, std::vector<HirStmt*> body)
+      : HirStmt(HirKind::While, span), condition_(condition),
+        body_(std::move(body)) {}
+
+  [[nodiscard]] auto condition() const -> HirExpr* { return condition_; }
+  [[nodiscard]] auto body() const -> const std::vector<HirStmt*>& {
+    return body_;
+  }
+
+private:
+  HirExpr* condition_;
+  std::vector<HirStmt*> body_;
+};
+
+class HirFor : public HirStmt {
+public:
+  HirFor(Span span, const Symbol* var_symbol, HirExpr* iterable,
+         std::vector<HirStmt*> body)
+      : HirStmt(HirKind::For, span), var_symbol_(var_symbol),
+        iterable_(iterable), body_(std::move(body)) {}
+
+  [[nodiscard]] auto var_symbol() const -> const Symbol* {
+    return var_symbol_;
+  }
+  [[nodiscard]] auto iterable() const -> HirExpr* { return iterable_; }
+  [[nodiscard]] auto body() const -> const std::vector<HirStmt*>& {
+    return body_;
+  }
+
+private:
+  const Symbol* var_symbol_;
+  HirExpr* iterable_;
+  std::vector<HirStmt*> body_;
+};
+
+class HirReturn : public HirStmt {
+public:
+  HirReturn(Span span, HirExpr* value)
+      : HirStmt(HirKind::Return, span), value_(value) {}
+
+  [[nodiscard]] auto value() const -> HirExpr* { return value_; }
+
+private:
+  HirExpr* value_; // nullable for bare return
+};
+
+class HirExprStmt : public HirStmt {
+public:
+  HirExprStmt(Span span, HirExpr* expr)
+      : HirStmt(HirKind::ExprStmt, span), expr_(expr) {}
+
+  [[nodiscard]] auto expr() const -> HirExpr* { return expr_; }
+
+private:
+  HirExpr* expr_;
+};
+
+enum class HirModeKind : std::uint8_t {
+  Unsafe,
+  Gpu,
+  Parallel,
+  Other,
+};
+
+auto hir_mode_kind_from_name(std::string_view name) -> HirModeKind;
+auto hir_mode_kind_name(HirModeKind kind) -> const char*;
+
+class HirMode : public HirStmt {
+public:
+  HirMode(Span span, HirModeKind mode, std::string_view mode_name,
+          std::vector<HirStmt*> body)
+      : HirStmt(HirKind::Mode, span), mode_(mode),
+        mode_name_(mode_name), body_(std::move(body)) {}
+
+  [[nodiscard]] auto mode() const -> HirModeKind { return mode_; }
+  [[nodiscard]] auto mode_name() const -> std::string_view {
+    return mode_name_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<HirStmt*>& {
+    return body_;
+  }
+
+private:
+  HirModeKind mode_;
+  std::string_view mode_name_;
+  std::vector<HirStmt*> body_;
+};
+
+class HirResource : public HirStmt {
+public:
+  HirResource(Span span, std::string_view resource_kind,
+              std::string_view resource_name, std::vector<HirStmt*> body)
+      : HirStmt(HirKind::Resource, span), resource_kind_(resource_kind),
+        resource_name_(resource_name), body_(std::move(body)) {}
+
+  [[nodiscard]] auto resource_kind() const -> std::string_view {
+    return resource_kind_;
+  }
+  [[nodiscard]] auto resource_name() const -> std::string_view {
+    return resource_name_;
+  }
+  [[nodiscard]] auto body() const -> const std::vector<HirStmt*>& {
+    return body_;
+  }
+
+private:
+  std::string_view resource_kind_;
+  std::string_view resource_name_;
+  std::vector<HirStmt*> body_;
+};
+
+// ---------------------------------------------------------------------------
+// Expressions — all carry semantic Type*
+// ---------------------------------------------------------------------------
+
+class HirIntLiteral : public HirExpr {
+public:
+  HirIntLiteral(Span span, const Type* type, int64_t value)
+      : HirExpr(HirKind::IntLiteral, span, type), value_(value) {}
+
+  [[nodiscard]] auto value() const -> int64_t { return value_; }
+
+private:
+  int64_t value_;
+};
+
+class HirFloatLiteral : public HirExpr {
+public:
+  HirFloatLiteral(Span span, const Type* type, double value)
+      : HirExpr(HirKind::FloatLiteral, span, type), value_(value) {}
+
+  [[nodiscard]] auto value() const -> double { return value_; }
+
+private:
+  double value_;
+};
+
+class HirStringLiteral : public HirExpr {
+public:
+  HirStringLiteral(Span span, const Type* type, std::string_view value)
+      : HirExpr(HirKind::StringLiteral, span, type), value_(value) {}
+
+  [[nodiscard]] auto value() const -> std::string_view { return value_; }
+
+private:
+  std::string_view value_;
+};
+
+class HirBoolLiteral : public HirExpr {
+public:
+  HirBoolLiteral(Span span, const Type* type, bool value)
+      : HirExpr(HirKind::BoolLiteral, span, type), value_(value) {}
+
+  [[nodiscard]] auto value() const -> bool { return value_; }
+
+private:
+  bool value_;
+};
+
+class HirSymbolRef : public HirExpr {
+public:
+  HirSymbolRef(Span span, const Type* type, const Symbol* symbol)
+      : HirExpr(HirKind::SymbolRef, span, type), symbol_(symbol) {}
+
+  [[nodiscard]] auto symbol() const -> const Symbol* { return symbol_; }
+
+private:
+  const Symbol* symbol_;
+};
+
+class HirUnary : public HirExpr {
+public:
+  HirUnary(Span span, const Type* type, UnaryOp op, HirExpr* operand)
+      : HirExpr(HirKind::Unary, span, type), op_(op), operand_(operand) {}
+
+  [[nodiscard]] auto op() const -> UnaryOp { return op_; }
+  [[nodiscard]] auto operand() const -> HirExpr* { return operand_; }
+
+private:
+  UnaryOp op_;
+  HirExpr* operand_;
+};
+
+class HirBinary : public HirExpr {
+public:
+  HirBinary(Span span, const Type* type, BinaryOp op, HirExpr* left,
+            HirExpr* right)
+      : HirExpr(HirKind::Binary, span, type), op_(op), left_(left),
+        right_(right) {}
+
+  [[nodiscard]] auto op() const -> BinaryOp { return op_; }
+  [[nodiscard]] auto left() const -> HirExpr* { return left_; }
+  [[nodiscard]] auto right() const -> HirExpr* { return right_; }
+
+private:
+  BinaryOp op_;
+  HirExpr* left_;
+  HirExpr* right_;
+};
+
+class HirCall : public HirExpr {
+public:
+  HirCall(Span span, const Type* type, HirExpr* callee,
+          std::vector<HirExpr*> args)
+      : HirExpr(HirKind::Call, span, type), callee_(callee),
+        args_(std::move(args)) {}
+
+  [[nodiscard]] auto callee() const -> HirExpr* { return callee_; }
+  [[nodiscard]] auto args() const -> const std::vector<HirExpr*>& {
+    return args_;
+  }
+
+private:
+  HirExpr* callee_;
+  std::vector<HirExpr*> args_;
+};
+
+class HirField : public HirExpr {
+public:
+  HirField(Span span, const Type* type, HirExpr* object,
+           std::string_view field_name)
+      : HirExpr(HirKind::Field, span, type), object_(object),
+        field_name_(field_name) {}
+
+  [[nodiscard]] auto object() const -> HirExpr* { return object_; }
+  [[nodiscard]] auto field_name() const -> std::string_view {
+    return field_name_;
+  }
+
+private:
+  HirExpr* object_;
+  std::string_view field_name_;
+};
+
+class HirIndex : public HirExpr {
+public:
+  HirIndex(Span span, const Type* type, HirExpr* object,
+           std::vector<HirExpr*> indices)
+      : HirExpr(HirKind::Index, span, type), object_(object),
+        indices_(std::move(indices)) {}
+
+  [[nodiscard]] auto object() const -> HirExpr* { return object_; }
+  [[nodiscard]] auto indices() const -> const std::vector<HirExpr*>& {
+    return indices_;
+  }
+
+private:
+  HirExpr* object_;
+  std::vector<HirExpr*> indices_;
+};
+
+class HirPipe : public HirExpr {
+public:
+  HirPipe(Span span, const Type* type, HirExpr* left, HirExpr* right)
+      : HirExpr(HirKind::Pipe, span, type), left_(left), right_(right) {}
+
+  [[nodiscard]] auto left() const -> HirExpr* { return left_; }
+  [[nodiscard]] auto right() const -> HirExpr* { return right_; }
+
+private:
+  HirExpr* left_;
+  HirExpr* right_;
+};
+
+class HirLambda : public HirExpr {
+public:
+  HirLambda(Span span, const Type* type,
+            std::vector<HirParam> params, HirExpr* body)
+      : HirExpr(HirKind::Lambda, span, type), params_(std::move(params)),
+        body_(body) {}
+
+  [[nodiscard]] auto params() const -> const std::vector<HirParam>& {
+    return params_;
+  }
+  [[nodiscard]] auto body() const -> HirExpr* { return body_; }
+
+private:
+  std::vector<HirParam> params_;
+  HirExpr* body_;
+};
+
+} // namespace dao
+
+#endif // DAO_IR_HIR_HIR_H

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -325,7 +325,7 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
     }
     for (size_t i = 0; i < lam->params().size(); ++i) {
       const auto& [name, span] = lam->params()[i];
-      const auto* param_sym = find_symbol_at_use(span.offset);
+      const auto* param_sym = find_symbol_at_decl(span.offset);
       const Type* param_type = nullptr;
       if (fn_type != nullptr && i < fn_type->param_types().size()) {
         param_type = fn_type->param_types()[i];

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -1,0 +1,379 @@
+#include "ir/hir/hir_builder.h"
+
+#include "frontend/types/type_printer.h"
+
+#include <charconv>
+#include <cstdlib>
+#include <string>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+HirBuilder::HirBuilder(HirContext& ctx, const ResolveResult& resolve,
+                       const TypeCheckResult& typed)
+    : ctx_(ctx), resolve_(resolve), typed_(typed) {
+  for (const auto& sym : resolve_.context.symbols()) {
+    if (sym->decl_span.length > 0) {
+      decl_symbols_[sym->decl_span.offset] = sym.get();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+auto HirBuilder::build(const FileNode& file) -> HirBuildResult {
+  std::vector<HirDecl*> decls;
+  for (const auto* decl : file.declarations()) {
+    auto* hir_decl = lower_decl(decl);
+    if (hir_decl != nullptr) {
+      decls.push_back(hir_decl);
+    }
+  }
+
+  auto* mod = ctx_.alloc<HirModule>(file.span(), std::move(decls));
+  return {.module = mod, .diagnostics = std::move(diagnostics_)};
+}
+
+// ---------------------------------------------------------------------------
+// Declaration lowering
+// ---------------------------------------------------------------------------
+
+auto HirBuilder::lower_decl(const Decl* decl) -> HirDecl* {
+  switch (decl->kind()) {
+  case NodeKind::FunctionDecl:
+    return lower_function(static_cast<const FunctionDeclNode*>(decl));
+  case NodeKind::StructDecl:
+    return lower_struct(static_cast<const StructDeclNode*>(decl));
+  default:
+    return nullptr;
+  }
+}
+
+auto HirBuilder::lower_function(const FunctionDeclNode* fn) -> HirFunction* {
+  const auto* sym = find_symbol_at_decl(fn->name_span().offset);
+
+  // Build params.
+  std::vector<HirParam> hir_params;
+  for (const auto& p : fn->params()) {
+    const auto* param_sym = find_symbol_at_decl(p.name_span.offset);
+    const Type* param_type = nullptr;
+
+    // Get type from typed results via decl type or symbol cache.
+    if (param_sym != nullptr) {
+      // Look up from the typed side tables — the type checker cached
+      // param types in the symbol_types_ map. We can derive it from
+      // the function's TypeFunction.
+      const auto* fn_type_raw = typed_.typed.decl_type(fn);
+      if (fn_type_raw != nullptr &&
+          fn_type_raw->kind() == TypeKind::Function) {
+        const auto* fn_type =
+            static_cast<const TypeFunction*>(fn_type_raw);
+        auto idx = static_cast<size_t>(&p - fn->params().data());
+        if (idx < fn_type->param_types().size()) {
+          param_type = fn_type->param_types()[idx];
+        }
+      }
+    }
+
+    hir_params.push_back({param_sym, param_type, p.name_span});
+  }
+
+  // Return type.
+  const Type* ret_type = nullptr;
+  const auto* fn_type_raw = typed_.typed.decl_type(fn);
+  if (fn_type_raw != nullptr && fn_type_raw->kind() == TypeKind::Function) {
+    ret_type = static_cast<const TypeFunction*>(fn_type_raw)->return_type();
+  }
+
+  // Body: normalize expression-bodied to block with return.
+  std::vector<HirStmt*> hir_body;
+  if (fn->is_expr_bodied()) {
+    auto* expr = lower_expr(fn->expr_body());
+    if (expr != nullptr) {
+      auto* ret = ctx_.alloc<HirReturn>(fn->expr_body()->span(), expr);
+      hir_body.push_back(ret);
+    }
+  } else {
+    hir_body = lower_body(fn->body());
+  }
+
+  return ctx_.alloc<HirFunction>(fn->span(), sym, std::move(hir_params),
+                                 ret_type, std::move(hir_body));
+}
+
+auto HirBuilder::lower_struct(const StructDeclNode* st) -> HirStructDecl* {
+  const auto* sym = find_symbol_at_decl(st->name_span().offset);
+
+  const TypeStruct* struct_type = nullptr;
+  const auto* decl_type = typed_.typed.decl_type(st);
+  if (decl_type != nullptr && decl_type->kind() == TypeKind::Struct) {
+    struct_type = static_cast<const TypeStruct*>(decl_type);
+  }
+
+  return ctx_.alloc<HirStructDecl>(st->span(), sym, struct_type);
+}
+
+// ---------------------------------------------------------------------------
+// Statement lowering
+// ---------------------------------------------------------------------------
+
+auto HirBuilder::lower_body(const std::vector<Stmt*>& body)
+    -> std::vector<HirStmt*> {
+  std::vector<HirStmt*> result;
+  for (const auto* stmt : body) {
+    auto* hir = lower_stmt(stmt);
+    if (hir != nullptr) {
+      result.push_back(hir);
+    }
+  }
+  return result;
+}
+
+auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
+  switch (stmt->kind()) {
+  case NodeKind::LetStatement:
+    return lower_let(static_cast<const LetStatementNode*>(stmt));
+  case NodeKind::Assignment:
+    return lower_assignment(static_cast<const AssignmentNode*>(stmt));
+  case NodeKind::IfStatement:
+    return lower_if(static_cast<const IfStatementNode*>(stmt));
+  case NodeKind::WhileStatement:
+    return lower_while(static_cast<const WhileStatementNode*>(stmt));
+  case NodeKind::ForStatement:
+    return lower_for(static_cast<const ForStatementNode*>(stmt));
+  case NodeKind::ModeBlock:
+    return lower_mode(static_cast<const ModeBlockNode*>(stmt));
+  case NodeKind::ResourceBlock:
+    return lower_resource(static_cast<const ResourceBlockNode*>(stmt));
+  case NodeKind::ReturnStatement:
+    return lower_return(static_cast<const ReturnStatementNode*>(stmt));
+  case NodeKind::ExpressionStatement:
+    return lower_expr_stmt(
+        static_cast<const ExpressionStatementNode*>(stmt));
+  default:
+    return nullptr;
+  }
+}
+
+auto HirBuilder::lower_let(const LetStatementNode* let) -> HirLet* {
+  const auto* sym = find_symbol_at_decl(let->name_span().offset);
+  const auto* type = typed_.typed.local_type(let);
+
+  HirExpr* init = nullptr;
+  if (let->initializer() != nullptr) {
+    init = lower_expr(let->initializer());
+  }
+
+  return ctx_.alloc<HirLet>(let->span(), sym, type, init);
+}
+
+auto HirBuilder::lower_assignment(const AssignmentNode* assign) -> HirAssign* {
+  auto* target = lower_expr(assign->target());
+  auto* value = lower_expr(assign->value());
+  return ctx_.alloc<HirAssign>(assign->span(), target, value);
+}
+
+auto HirBuilder::lower_if(const IfStatementNode* ifn) -> HirIf* {
+  auto* cond = lower_expr(ifn->condition());
+  auto then_body = lower_body(ifn->then_body());
+  auto else_body = lower_body(ifn->else_body());
+  return ctx_.alloc<HirIf>(ifn->span(), cond, std::move(then_body),
+                           std::move(else_body));
+}
+
+auto HirBuilder::lower_while(const WhileStatementNode* wh) -> HirWhile* {
+  auto* cond = lower_expr(wh->condition());
+  auto body = lower_body(wh->body());
+  return ctx_.alloc<HirWhile>(wh->span(), cond, std::move(body));
+}
+
+auto HirBuilder::lower_for(const ForStatementNode* fo) -> HirFor* {
+  const auto* var_sym = find_symbol_at_decl(fo->var_span().offset);
+  auto* iterable = lower_expr(fo->iterable());
+  auto body = lower_body(fo->body());
+  return ctx_.alloc<HirFor>(fo->span(), var_sym, iterable, std::move(body));
+}
+
+auto HirBuilder::lower_mode(const ModeBlockNode* mb) -> HirMode* {
+  auto mode = hir_mode_kind_from_name(mb->mode_name());
+  auto body = lower_body(mb->body());
+  return ctx_.alloc<HirMode>(mb->span(), mode, mb->mode_name(),
+                             std::move(body));
+}
+
+auto HirBuilder::lower_resource(const ResourceBlockNode* rb) -> HirResource* {
+  auto body = lower_body(rb->body());
+  return ctx_.alloc<HirResource>(rb->span(), rb->resource_kind(),
+                                 rb->resource_name(), std::move(body));
+}
+
+auto HirBuilder::lower_return(const ReturnStatementNode* ret) -> HirReturn* {
+  HirExpr* value = nullptr;
+  if (ret->value() != nullptr) {
+    value = lower_expr(ret->value());
+  }
+  return ctx_.alloc<HirReturn>(ret->span(), value);
+}
+
+auto HirBuilder::lower_expr_stmt(const ExpressionStatementNode* es)
+    -> HirExprStmt* {
+  auto* expr = lower_expr(es->expr());
+  return ctx_.alloc<HirExprStmt>(es->span(), expr);
+}
+
+// ---------------------------------------------------------------------------
+// Expression lowering
+// ---------------------------------------------------------------------------
+
+auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
+  if (expr == nullptr) {
+    return nullptr;
+  }
+
+  const auto* type = expr_type(expr);
+
+  switch (expr->kind()) {
+  case NodeKind::IntLiteral: {
+    const auto* lit = static_cast<const IntLiteralNode*>(expr);
+    int64_t val = 0;
+    auto text = lit->text();
+    std::from_chars(text.data(), text.data() + text.size(), val);
+    return ctx_.alloc<HirIntLiteral>(expr->span(), type, val);
+  }
+
+  case NodeKind::FloatLiteral: {
+    const auto* lit = static_cast<const FloatLiteralNode*>(expr);
+    double val = std::strtod(std::string(lit->text()).c_str(), nullptr);
+    return ctx_.alloc<HirFloatLiteral>(expr->span(), type, val);
+  }
+
+  case NodeKind::StringLiteral: {
+    const auto* lit = static_cast<const StringLiteralNode*>(expr);
+    return ctx_.alloc<HirStringLiteral>(expr->span(), type, lit->text());
+  }
+
+  case NodeKind::BoolLiteral: {
+    const auto* lit = static_cast<const BoolLiteralNode*>(expr);
+    return ctx_.alloc<HirBoolLiteral>(expr->span(), type, lit->value());
+  }
+
+  case NodeKind::Identifier: {
+    const auto* sym = find_symbol_at_use(expr->span().offset);
+    return ctx_.alloc<HirSymbolRef>(expr->span(), type, sym);
+  }
+
+  case NodeKind::UnaryExpr: {
+    const auto* un = static_cast<const UnaryExprNode*>(expr);
+    auto* operand = lower_expr(un->operand());
+    return ctx_.alloc<HirUnary>(expr->span(), type, un->op(), operand);
+  }
+
+  case NodeKind::BinaryExpr: {
+    const auto* bin = static_cast<const BinaryExprNode*>(expr);
+    auto* left = lower_expr(bin->left());
+    auto* right = lower_expr(bin->right());
+    return ctx_.alloc<HirBinary>(expr->span(), type, bin->op(), left,
+                                right);
+  }
+
+  case NodeKind::CallExpr: {
+    const auto* call = static_cast<const CallExprNode*>(expr);
+    auto* callee = lower_expr(call->callee());
+    std::vector<HirExpr*> args;
+    for (const auto* arg : call->args()) {
+      args.push_back(lower_expr(arg));
+    }
+    return ctx_.alloc<HirCall>(expr->span(), type, callee, std::move(args));
+  }
+
+  case NodeKind::PipeExpr: {
+    const auto* pipe = static_cast<const PipeExprNode*>(expr);
+    auto* left = lower_expr(pipe->left());
+    auto* right = lower_expr(pipe->right());
+    return ctx_.alloc<HirPipe>(expr->span(), type, left, right);
+  }
+
+  case NodeKind::FieldExpr: {
+    const auto* field = static_cast<const FieldExprNode*>(expr);
+    auto* object = lower_expr(field->object());
+    return ctx_.alloc<HirField>(expr->span(), type, object, field->field());
+  }
+
+  case NodeKind::IndexExpr: {
+    const auto* idx = static_cast<const IndexExprNode*>(expr);
+    auto* object = lower_expr(idx->object());
+    std::vector<HirExpr*> indices;
+    for (const auto* i : idx->indices()) {
+      indices.push_back(lower_expr(i));
+    }
+    return ctx_.alloc<HirIndex>(expr->span(), type, object,
+                                std::move(indices));
+  }
+
+  case NodeKind::Lambda: {
+    const auto* lam = static_cast<const LambdaNode*>(expr);
+    std::vector<HirParam> params;
+    // Lambda params: derive types from the function type if available.
+    const TypeFunction* fn_type = nullptr;
+    if (type != nullptr && type->kind() == TypeKind::Function) {
+      fn_type = static_cast<const TypeFunction*>(type);
+    }
+    for (size_t i = 0; i < lam->params().size(); ++i) {
+      const auto& [name, span] = lam->params()[i];
+      const auto* param_sym = find_symbol_at_use(span.offset);
+      const Type* param_type = nullptr;
+      if (fn_type != nullptr && i < fn_type->param_types().size()) {
+        param_type = fn_type->param_types()[i];
+      }
+      params.push_back({param_sym, param_type, span});
+    }
+    auto* body = lower_expr(lam->body());
+    return ctx_.alloc<HirLambda>(expr->span(), type, std::move(params),
+                                body);
+  }
+
+  default:
+    error(expr->span(), "unsupported expression in HIR builder");
+    return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+auto HirBuilder::find_symbol_at_decl(uint32_t offset) -> const Symbol* {
+  auto it = decl_symbols_.find(offset);
+  return it != decl_symbols_.end() ? it->second : nullptr;
+}
+
+auto HirBuilder::find_symbol_at_use(uint32_t offset) -> const Symbol* {
+  auto it = resolve_.uses.find(offset);
+  return it != resolve_.uses.end() ? it->second : nullptr;
+}
+
+auto HirBuilder::expr_type(const Expr* expr) -> const Type* {
+  return typed_.typed.expr_type(expr);
+}
+
+void HirBuilder::error(Span span, std::string message) {
+  diagnostics_.push_back(Diagnostic::error(span, std::move(message)));
+}
+
+// ---------------------------------------------------------------------------
+// Free-function entry point
+// ---------------------------------------------------------------------------
+
+auto build_hir(const FileNode& file, const ResolveResult& resolve,
+               const TypeCheckResult& typed, HirContext& ctx)
+    -> HirBuildResult {
+  HirBuilder builder(ctx, resolve, typed);
+  return builder.build(file);
+}
+
+} // namespace dao

--- a/compiler/ir/hir/hir_builder.h
+++ b/compiler/ir/hir/hir_builder.h
@@ -1,0 +1,92 @@
+#ifndef DAO_IR_HIR_HIR_BUILDER_H
+#define DAO_IR_HIR_HIR_BUILDER_H
+
+#include "frontend/ast/ast.h"
+#include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+#include "frontend/types/type_context.h"
+#include "ir/hir/hir.h"
+#include "ir/hir/hir_context.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// HirBuildResult — output of HIR construction.
+// ---------------------------------------------------------------------------
+
+struct HirBuildResult {
+  HirModule* module = nullptr;
+  std::vector<Diagnostic> diagnostics;
+};
+
+// ---------------------------------------------------------------------------
+// HirBuilder — lowers checked AST into HIR.
+//
+// Consumes AST + resolve + typed results.
+// Does not redo parsing, resolution, or type checking.
+// ---------------------------------------------------------------------------
+
+class HirBuilder {
+public:
+  HirBuilder(HirContext& ctx, const ResolveResult& resolve,
+             const TypeCheckResult& typed);
+
+  auto build(const FileNode& file) -> HirBuildResult;
+
+private:
+  HirContext& ctx_;
+  const ResolveResult& resolve_;
+  const TypeCheckResult& typed_;
+  std::vector<Diagnostic> diagnostics_;
+
+  // decl_span.offset -> Symbol* for declaration-site lookups.
+  std::unordered_map<uint32_t, const Symbol*> decl_symbols_;
+
+  // --- Declaration lowering ---
+
+  auto lower_decl(const Decl* decl) -> HirDecl*;
+  auto lower_function(const FunctionDeclNode* fn) -> HirFunction*;
+  auto lower_struct(const StructDeclNode* st) -> HirStructDecl*;
+
+  // --- Statement lowering ---
+
+  auto lower_stmt(const Stmt* stmt) -> HirStmt*;
+  auto lower_let(const LetStatementNode* let) -> HirLet*;
+  auto lower_assignment(const AssignmentNode* assign) -> HirAssign*;
+  auto lower_if(const IfStatementNode* ifn) -> HirIf*;
+  auto lower_while(const WhileStatementNode* wh) -> HirWhile*;
+  auto lower_for(const ForStatementNode* fo) -> HirFor*;
+  auto lower_mode(const ModeBlockNode* mb) -> HirMode*;
+  auto lower_resource(const ResourceBlockNode* rb) -> HirResource*;
+  auto lower_return(const ReturnStatementNode* ret) -> HirReturn*;
+  auto lower_expr_stmt(const ExpressionStatementNode* es) -> HirExprStmt*;
+
+  auto lower_body(const std::vector<Stmt*>& body) -> std::vector<HirStmt*>;
+
+  // --- Expression lowering ---
+
+  auto lower_expr(const Expr* expr) -> HirExpr*;
+
+  // --- Helpers ---
+
+  auto find_symbol_at_decl(uint32_t offset) -> const Symbol*;
+  auto find_symbol_at_use(uint32_t offset) -> const Symbol*;
+  auto expr_type(const Expr* expr) -> const Type*;
+
+  void error(Span span, std::string message);
+};
+
+// ---------------------------------------------------------------------------
+// Top-level entry point.
+// ---------------------------------------------------------------------------
+
+auto build_hir(const FileNode& file, const ResolveResult& resolve,
+               const TypeCheckResult& typed, HirContext& ctx)
+    -> HirBuildResult;
+
+} // namespace dao
+
+#endif // DAO_IR_HIR_HIR_BUILDER_H

--- a/compiler/ir/hir/hir_context.h
+++ b/compiler/ir/hir/hir_context.h
@@ -1,0 +1,36 @@
+#ifndef DAO_IR_HIR_HIR_CONTEXT_H
+#define DAO_IR_HIR_HIR_CONTEXT_H
+
+#include "ir/hir/hir.h"
+#include "support/arena.h"
+
+#include <utility>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// HirContext — arena owner for all HIR nodes.
+// ---------------------------------------------------------------------------
+
+class HirContext {
+public:
+  HirContext() = default;
+  ~HirContext() = default;
+
+  HirContext(const HirContext&) = delete;
+  auto operator=(const HirContext&) -> HirContext& = delete;
+  HirContext(HirContext&&) noexcept = default;
+  auto operator=(HirContext&&) noexcept -> HirContext& = default;
+
+  template <typename T, typename... Args>
+  auto alloc(Args&&... args) -> T* {
+    return arena_.alloc<T>(std::forward<Args>(args)...);
+  }
+
+private:
+  Arena arena_;
+};
+
+} // namespace dao
+
+#endif // DAO_IR_HIR_HIR_CONTEXT_H

--- a/compiler/ir/hir/hir_kind.h
+++ b/compiler/ir/hir/hir_kind.h
@@ -1,0 +1,50 @@
+#ifndef DAO_IR_HIR_HIR_KIND_H
+#define DAO_IR_HIR_HIR_KIND_H
+
+#include <cstdint>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// HIR node kind tags.
+// ---------------------------------------------------------------------------
+
+enum class HirKind : std::uint8_t {
+  // Module
+  Module,
+
+  // Declarations
+  Function,
+  StructDecl,
+
+  // Statements
+  Let,
+  Assign,
+  If,
+  While,
+  For,
+  Return,
+  ExprStmt,
+  Mode,
+  Resource,
+
+  // Expressions
+  IntLiteral,
+  FloatLiteral,
+  StringLiteral,
+  BoolLiteral,
+  SymbolRef,
+  Unary,
+  Binary,
+  Call,
+  Field,
+  Index,
+  Pipe,
+  Lambda,
+};
+
+auto hir_kind_name(HirKind kind) -> const char*;
+
+} // namespace dao
+
+#endif // DAO_IR_HIR_HIR_KIND_H

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -1,0 +1,495 @@
+#include "ir/hir/hir_printer.h"
+
+#include "frontend/types/type_printer.h"
+
+#include <string>
+
+namespace dao {
+
+namespace {
+
+// NOLINTBEGIN(readability-identifier-length)
+
+class HirPrinter {
+public:
+  explicit HirPrinter(std::ostream& out) : out_(out) {}
+
+  void print(const HirModule& module) {
+    out_ << "Module\n";
+    for (const auto* decl : module.declarations()) {
+      print_decl(*decl);
+    }
+  }
+
+private:
+  std::ostream& out_;
+  int depth_ = 1;
+
+  void indent() {
+    for (int i = 0; i < depth_; ++i) {
+      out_ << "  ";
+    }
+  }
+
+  struct Scope {
+    int& depth;
+    explicit Scope(int& d) : depth(d) { ++depth; }
+    ~Scope() { --depth; }
+    Scope(const Scope&) = delete;
+    auto operator=(const Scope&) -> Scope& = delete;
+    Scope(Scope&&) = delete;
+    auto operator=(Scope&&) -> Scope& = delete;
+  };
+
+  // --- Type annotation ---
+
+  void print_type_annotation(const Type* type) {
+    if (type != nullptr) {
+      out_ << " : " << print_type(type);
+    }
+  }
+
+  // --- Symbol name ---
+
+  void print_symbol_name(const Symbol* sym) {
+    if (sym != nullptr) {
+      out_ << sym->name;
+    } else {
+      out_ << "<unknown>";
+    }
+  }
+
+  // --- Declarations ---
+
+  void print_decl(const HirDecl& decl) {
+    switch (decl.kind()) {
+    case HirKind::Function:
+      print_function(static_cast<const HirFunction&>(decl));
+      break;
+    case HirKind::StructDecl:
+      print_struct(static_cast<const HirStructDecl&>(decl));
+      break;
+    default:
+      indent();
+      out_ << "UnknownDecl\n";
+      break;
+    }
+  }
+
+  void print_function(const HirFunction& fn) {
+    indent();
+    out_ << "Function ";
+    print_symbol_name(fn.symbol());
+    print_type_annotation(fn.return_type());
+    out_ << "\n";
+    Scope scope(depth_);
+
+    for (const auto& param : fn.params()) {
+      indent();
+      out_ << "Param ";
+      print_symbol_name(param.symbol);
+      print_type_annotation(param.type);
+      out_ << "\n";
+    }
+
+    for (const auto* stmt : fn.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_struct(const HirStructDecl& st) {
+    indent();
+    out_ << "StructDecl ";
+    print_symbol_name(st.symbol());
+    if (st.struct_type() != nullptr) {
+      out_ << " : " << print_type(st.struct_type());
+    }
+    out_ << "\n";
+  }
+
+  // --- Statements ---
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void print_stmt(const HirStmt& stmt) {
+    switch (stmt.kind()) {
+    case HirKind::Let:
+      print_let(static_cast<const HirLet&>(stmt));
+      break;
+    case HirKind::Assign:
+      print_assign(static_cast<const HirAssign&>(stmt));
+      break;
+    case HirKind::If:
+      print_if(static_cast<const HirIf&>(stmt));
+      break;
+    case HirKind::While:
+      print_while(static_cast<const HirWhile&>(stmt));
+      break;
+    case HirKind::For:
+      print_for(static_cast<const HirFor&>(stmt));
+      break;
+    case HirKind::Return:
+      print_return(static_cast<const HirReturn&>(stmt));
+      break;
+    case HirKind::ExprStmt:
+      print_expr_stmt(static_cast<const HirExprStmt&>(stmt));
+      break;
+    case HirKind::Mode:
+      print_mode(static_cast<const HirMode&>(stmt));
+      break;
+    case HirKind::Resource:
+      print_resource(static_cast<const HirResource&>(stmt));
+      break;
+    default:
+      indent();
+      out_ << "UnknownStmt\n";
+      break;
+    }
+  }
+
+  void print_let(const HirLet& node) {
+    indent();
+    out_ << "Let ";
+    print_symbol_name(node.symbol());
+    print_type_annotation(node.type());
+    out_ << "\n";
+    if (node.initializer() != nullptr) {
+      Scope scope(depth_);
+      print_expr(*node.initializer());
+    }
+  }
+
+  void print_assign(const HirAssign& node) {
+    indent();
+    out_ << "Assign\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Target\n";
+    {
+      Scope target_scope(depth_);
+      print_expr(*node.target());
+    }
+    indent();
+    out_ << "Value\n";
+    {
+      Scope value_scope(depth_);
+      print_expr(*node.value());
+    }
+  }
+
+  void print_if(const HirIf& node) {
+    indent();
+    out_ << "If\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Condition\n";
+    {
+      Scope cond_scope(depth_);
+      print_expr(*node.condition());
+    }
+    indent();
+    out_ << "Then\n";
+    {
+      Scope then_scope(depth_);
+      for (const auto* stmt : node.then_body()) {
+        print_stmt(*stmt);
+      }
+    }
+    if (!node.else_body().empty()) {
+      indent();
+      out_ << "Else\n";
+      Scope else_scope(depth_);
+      for (const auto* stmt : node.else_body()) {
+        print_stmt(*stmt);
+      }
+    }
+  }
+
+  void print_while(const HirWhile& node) {
+    indent();
+    out_ << "While\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Condition\n";
+    {
+      Scope cond_scope(depth_);
+      print_expr(*node.condition());
+    }
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_for(const HirFor& node) {
+    indent();
+    out_ << "For ";
+    print_symbol_name(node.var_symbol());
+    out_ << "\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Iterable\n";
+    {
+      Scope iter_scope(depth_);
+      print_expr(*node.iterable());
+    }
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_return(const HirReturn& node) {
+    indent();
+    out_ << "Return\n";
+    if (node.value() != nullptr) {
+      Scope scope(depth_);
+      print_expr(*node.value());
+    }
+  }
+
+  void print_expr_stmt(const HirExprStmt& node) {
+    indent();
+    out_ << "ExprStmt\n";
+    Scope scope(depth_);
+    print_expr(*node.expr());
+  }
+
+  void print_mode(const HirMode& node) {
+    indent();
+    out_ << "Mode " << node.mode_name() << "\n";
+    Scope scope(depth_);
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  void print_resource(const HirResource& node) {
+    indent();
+    out_ << "Resource " << node.resource_kind() << " " << node.resource_name()
+         << "\n";
+    Scope scope(depth_);
+    for (const auto* stmt : node.body()) {
+      print_stmt(*stmt);
+    }
+  }
+
+  // --- Expressions ---
+
+  static auto binary_op_str(BinaryOp op) -> const char* {
+    switch (op) {
+    case BinaryOp::Add:    return "+";
+    case BinaryOp::Sub:    return "-";
+    case BinaryOp::Mul:    return "*";
+    case BinaryOp::Div:    return "/";
+    case BinaryOp::Mod:    return "%";
+    case BinaryOp::EqEq:   return "==";
+    case BinaryOp::BangEq: return "!=";
+    case BinaryOp::Lt:     return "<";
+    case BinaryOp::LtEq:   return "<=";
+    case BinaryOp::Gt:     return ">";
+    case BinaryOp::GtEq:   return ">=";
+    case BinaryOp::And:    return "and";
+    case BinaryOp::Or:     return "or";
+    }
+    return "?";
+  }
+
+  static auto unary_op_str(UnaryOp op) -> const char* {
+    switch (op) {
+    case UnaryOp::Negate: return "-";
+    case UnaryOp::Not:    return "!";
+    case UnaryOp::Deref:  return "*";
+    case UnaryOp::AddrOf: return "&";
+    }
+    return "?";
+  }
+
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void print_expr(const HirExpr& expr) {
+    switch (expr.kind()) {
+    case HirKind::IntLiteral:
+      print_int_literal(static_cast<const HirIntLiteral&>(expr));
+      break;
+    case HirKind::FloatLiteral:
+      print_float_literal(static_cast<const HirFloatLiteral&>(expr));
+      break;
+    case HirKind::StringLiteral:
+      print_string_literal(static_cast<const HirStringLiteral&>(expr));
+      break;
+    case HirKind::BoolLiteral:
+      print_bool_literal(static_cast<const HirBoolLiteral&>(expr));
+      break;
+    case HirKind::SymbolRef:
+      print_symbol_ref(static_cast<const HirSymbolRef&>(expr));
+      break;
+    case HirKind::Unary:
+      print_unary(static_cast<const HirUnary&>(expr));
+      break;
+    case HirKind::Binary:
+      print_binary(static_cast<const HirBinary&>(expr));
+      break;
+    case HirKind::Call:
+      print_call(static_cast<const HirCall&>(expr));
+      break;
+    case HirKind::Field:
+      print_field(static_cast<const HirField&>(expr));
+      break;
+    case HirKind::Index:
+      print_index(static_cast<const HirIndex&>(expr));
+      break;
+    case HirKind::Pipe:
+      print_pipe(static_cast<const HirPipe&>(expr));
+      break;
+    case HirKind::Lambda:
+      print_lambda(static_cast<const HirLambda&>(expr));
+      break;
+    default:
+      indent();
+      out_ << "UnknownExpr\n";
+      break;
+    }
+  }
+
+  void print_int_literal(const HirIntLiteral& node) {
+    indent();
+    out_ << "IntLiteral " << node.value();
+    print_type_annotation(node.type());
+    out_ << "\n";
+  }
+
+  void print_float_literal(const HirFloatLiteral& node) {
+    indent();
+    out_ << "FloatLiteral " << node.value();
+    print_type_annotation(node.type());
+    out_ << "\n";
+  }
+
+  void print_string_literal(const HirStringLiteral& node) {
+    indent();
+    out_ << "StringLiteral " << node.value();
+    print_type_annotation(node.type());
+    out_ << "\n";
+  }
+
+  void print_bool_literal(const HirBoolLiteral& node) {
+    indent();
+    out_ << "BoolLiteral " << (node.value() ? "true" : "false");
+    print_type_annotation(node.type());
+    out_ << "\n";
+  }
+
+  void print_symbol_ref(const HirSymbolRef& node) {
+    indent();
+    out_ << "SymbolRef ";
+    print_symbol_name(node.symbol());
+    print_type_annotation(node.type());
+    out_ << "\n";
+  }
+
+  void print_unary(const HirUnary& node) {
+    indent();
+    out_ << "Unary " << unary_op_str(node.op());
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.operand());
+  }
+
+  void print_binary(const HirBinary& node) {
+    indent();
+    out_ << "Binary " << binary_op_str(node.op());
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.left());
+    print_expr(*node.right());
+  }
+
+  void print_call(const HirCall& node) {
+    indent();
+    out_ << "Call";
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    indent();
+    out_ << "Callee\n";
+    {
+      Scope callee_scope(depth_);
+      print_expr(*node.callee());
+    }
+    if (!node.args().empty()) {
+      indent();
+      out_ << "Args\n";
+      Scope args_scope(depth_);
+      for (const auto* arg : node.args()) {
+        print_expr(*arg);
+      }
+    }
+  }
+
+  void print_field(const HirField& node) {
+    indent();
+    out_ << "Field ." << node.field_name();
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.object());
+  }
+
+  void print_index(const HirIndex& node) {
+    indent();
+    out_ << "Index";
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.object());
+    indent();
+    out_ << "Indices\n";
+    {
+      Scope indices_scope(depth_);
+      for (const auto* idx : node.indices()) {
+        print_expr(*idx);
+      }
+    }
+  }
+
+  void print_pipe(const HirPipe& node) {
+    indent();
+    out_ << "Pipe";
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    print_expr(*node.left());
+    print_expr(*node.right());
+  }
+
+  void print_lambda(const HirLambda& node) {
+    indent();
+    out_ << "Lambda";
+    print_type_annotation(node.type());
+    out_ << "\n";
+    Scope scope(depth_);
+    for (const auto& param : node.params()) {
+      indent();
+      out_ << "Param ";
+      print_symbol_name(param.symbol);
+      print_type_annotation(param.type);
+      out_ << "\n";
+    }
+    indent();
+    out_ << "Body\n";
+    {
+      Scope body_scope(depth_);
+      print_expr(*node.body());
+    }
+  }
+};
+
+// NOLINTEND(readability-identifier-length)
+
+} // namespace
+
+void print_hir(std::ostream& out, const HirModule& module) {
+  HirPrinter printer(out);
+  printer.print(module);
+}
+
+} // namespace dao

--- a/compiler/ir/hir/hir_printer.h
+++ b/compiler/ir/hir/hir_printer.h
@@ -1,0 +1,17 @@
+#ifndef DAO_IR_HIR_HIR_PRINTER_H
+#define DAO_IR_HIR_HIR_PRINTER_H
+
+#include "ir/hir/hir.h"
+
+#include <ostream>
+
+namespace dao {
+
+/// Print a human-readable, indented HIR dump to the given stream.
+/// Output is deterministic and suitable for golden-file testing.
+/// Shows semantic types and resolved symbol identities.
+void print_hir(std::ostream& out, const HirModule& module);
+
+} // namespace dao
+
+#endif // DAO_IR_HIR_HIR_PRINTER_H

--- a/compiler/ir/hir/hir_test.cpp
+++ b/compiler/ir/hir/hir_test.cpp
@@ -1,0 +1,362 @@
+#include "frontend/diagnostics/source.h"
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+#include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+#include "frontend/types/type_context.h"
+#include "ir/hir/hir.h"
+#include "ir/hir/hir_builder.h"
+#include "ir/hir/hir_context.h"
+#include "ir/hir/hir_printer.h"
+
+#include <boost/ut.hpp>
+#include <sstream>
+#include <string>
+
+using namespace boost::ut;
+using namespace dao;
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace {
+
+/// Owns all pipeline state so HIR nodes remain valid.
+struct HirTestPipeline {
+  SourceBuffer source;
+  LexResult lex_result;
+  ParseResult parse_result;
+  ResolveResult resolve_result;
+  TypeContext types;
+  TypeCheckResult check_result;
+  HirContext hir_ctx;
+  HirBuildResult hir_result;
+
+  explicit HirTestPipeline(const std::string& src)
+      : source("test.dao", std::string(src)),
+        lex_result(lex(source)),
+        parse_result(parse(lex_result.tokens)) {
+    if (parse_result.file != nullptr) {
+      resolve_result = resolve(*parse_result.file);
+      check_result =
+          typecheck(*parse_result.file, resolve_result, types);
+      hir_result =
+          build_hir(*parse_result.file, resolve_result, check_result, hir_ctx);
+    }
+  }
+
+  [[nodiscard]] auto module() const -> HirModule* {
+    return hir_result.module;
+  }
+
+  [[nodiscard]] auto dump() const -> std::string {
+    std::ostringstream out;
+    if (hir_result.module != nullptr) {
+      print_hir(out, *hir_result.module);
+    }
+    return out.str();
+  }
+};
+
+/// Returns true if the string contains the given substring.
+auto contains(const std::string& haystack, std::string_view needle) -> bool {
+  return haystack.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Positive: expression-bodied function normalized to HIR
+// ---------------------------------------------------------------------------
+
+suite hir_expr_bodied = [] {
+  "expression-bodied function normalized to return"_test = [] {
+    HirTestPipeline p("fn double(x: i32): i32 -> x + x\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Function double")) << dump;
+    expect(contains(dump, "Param x : i32")) << dump;
+    expect(contains(dump, "Return")) << dump;
+    expect(contains(dump, "Binary +")) << dump;
+    expect(contains(dump, "SymbolRef x")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: block-bodied function
+// ---------------------------------------------------------------------------
+
+suite hir_block_bodied = [] {
+  "block-bodied function"_test = [] {
+    HirTestPipeline p("fn add(a: i32, b: i32): i32\n    return a + b\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Function add : i32")) << dump;
+    expect(contains(dump, "Param a : i32")) << dump;
+    expect(contains(dump, "Param b : i32")) << dump;
+    expect(contains(dump, "Return")) << dump;
+    expect(contains(dump, "Binary + : i32")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: let with inferred type
+// ---------------------------------------------------------------------------
+
+suite hir_let = [] {
+  "let with initializer"_test = [] {
+    HirTestPipeline p("fn main(): i32\n    let x: i32 = 42\n    return x\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Let x : i32")) << dump;
+    expect(contains(dump, "IntLiteral 42 : i32")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: assignment
+// ---------------------------------------------------------------------------
+
+suite hir_assignment = [] {
+  "variable assignment"_test = [] {
+    HirTestPipeline p(
+        "fn main(): i32\n"
+        "    let x: i32 = 0\n"
+        "    x = 42\n"
+        "    return x\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Assign")) << dump;
+    expect(contains(dump, "Target")) << dump;
+    expect(contains(dump, "Value")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: if / while / for
+// ---------------------------------------------------------------------------
+
+suite hir_control_flow = [] {
+  "if statement"_test = [] {
+    HirTestPipeline p(
+        "fn test(x: i32): i32\n"
+        "    if x > 0:\n"
+        "        return x\n"
+        "    return 0\n");
+    auto dump = p.dump();
+    expect(contains(dump, "If")) << dump;
+    expect(contains(dump, "Condition")) << dump;
+    expect(contains(dump, "Then")) << dump;
+    expect(contains(dump, "Binary >")) << dump;
+  };
+
+  "while statement"_test = [] {
+    HirTestPipeline p(
+        "fn test(x: i32): i32\n"
+        "    let i: i32 = 0\n"
+        "    while i < x:\n"
+        "        i = i + 1\n"
+        "    return i\n");
+    auto dump = p.dump();
+    expect(contains(dump, "While")) << dump;
+    expect(contains(dump, "Condition")) << dump;
+    expect(contains(dump, "Binary <")) << dump;
+  };
+
+  "for statement"_test = [] {
+    HirTestPipeline p(
+        "fn test(xs: i32): i32\n"
+        "    for item in xs:\n"
+        "        let y: i32 = item\n"
+        "    return 0\n");
+    auto dump = p.dump();
+    expect(contains(dump, "For item")) << dump;
+    expect(contains(dump, "Iterable")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: return
+// ---------------------------------------------------------------------------
+
+suite hir_return = [] {
+  "return with value"_test = [] {
+    HirTestPipeline p("fn main(): i32\n    return 42\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Return")) << dump;
+    expect(contains(dump, "IntLiteral 42 : i32")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: pipe expression
+// ---------------------------------------------------------------------------
+
+suite hir_pipe = [] {
+  "pipe preserved as first-class node"_test = [] {
+    HirTestPipeline p(
+        "fn double(x: i32): i32 -> x + x\n"
+        "fn main(): i32\n"
+        "    return 5 |> double\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Pipe")) << dump;
+    expect(contains(dump, "IntLiteral 5")) << dump;
+    expect(contains(dump, "SymbolRef double")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: lambda expression
+// ---------------------------------------------------------------------------
+
+suite hir_lambda = [] {
+  "lambda preserved as first-class node"_test = [] {
+    HirTestPipeline p(
+        "fn apply(f: fn(i32) -> i32, x: i32): i32 -> f(x)\n"
+        "fn main(): i32\n"
+        "    return apply(|x| -> x + 1, 5)\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Lambda")) << dump;
+    expect(contains(dump, "Body")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: mode block
+// ---------------------------------------------------------------------------
+
+suite hir_mode = [] {
+  "mode block preserved"_test = [] {
+    HirTestPipeline p(
+        "fn main(): i32\n"
+        "    mode unsafe =>\n"
+        "        let x: i32 = 42\n"
+        "    return 0\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Mode unsafe")) << dump;
+    expect(contains(dump, "Let x : i32")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: resource block
+// ---------------------------------------------------------------------------
+
+suite hir_resource = [] {
+  "resource block preserved"_test = [] {
+    HirTestPipeline p(
+        "fn main(): i32\n"
+        "    resource gpu compute =>\n"
+        "        let x: i32 = 1\n"
+        "    return 0\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Resource gpu compute")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: function call
+// ---------------------------------------------------------------------------
+
+suite hir_call = [] {
+  "function call"_test = [] {
+    HirTestPipeline p(
+        "fn add(a: i32, b: i32): i32 -> a + b\n"
+        "fn main(): i32\n"
+        "    return add(1, 2)\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Call : i32")) << dump;
+    expect(contains(dump, "Callee")) << dump;
+    expect(contains(dump, "SymbolRef add")) << dump;
+    expect(contains(dump, "Args")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Positive: literals
+// ---------------------------------------------------------------------------
+
+suite hir_literals = [] {
+  "integer literal"_test = [] {
+    HirTestPipeline p("fn main(): i32\n    return 42\n");
+    expect(contains(p.dump(), "IntLiteral 42 : i32"));
+  };
+
+  "float literal"_test = [] {
+    HirTestPipeline p("fn main(): f64\n    return 3.14\n");
+    expect(contains(p.dump(), "FloatLiteral 3.14 : f64"));
+  };
+
+  "string literal"_test = [] {
+    HirTestPipeline p("fn main(): string\n    return \"hello\"\n");
+    auto dump = p.dump();
+    expect(contains(dump, "StringLiteral")) << dump;
+    expect(contains(dump, ": string")) << dump;
+  };
+
+  "bool literal"_test = [] {
+    HirTestPipeline p("fn main(): bool\n    return true\n");
+    expect(contains(p.dump(), "BoolLiteral true : bool"));
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Semantic preservation: typed expressions
+// ---------------------------------------------------------------------------
+
+suite hir_semantic = [] {
+  "expressions carry semantic types"_test = [] {
+    HirTestPipeline p("fn main(): i32\n    return 1 + 2\n");
+    expect(p.module() != nullptr);
+    expect(p.hir_result.diagnostics.empty()) << "no HIR diagnostics";
+
+    const auto& decls = p.module()->declarations();
+    expect(decls.size() == 1_ul);
+    const auto* fn = static_cast<const HirFunction*>(decls[0]);
+    expect(fn->body().size() == 1_ul);
+    const auto* ret = static_cast<const HirReturn*>(fn->body()[0]);
+    expect(ret->value() != nullptr);
+    expect(ret->value()->type() != nullptr) << "return expr has type";
+  };
+
+  "symbol references resolved"_test = [] {
+    HirTestPipeline p("fn id(x: i32): i32\n    return x\n");
+    const auto& decls = p.module()->declarations();
+    const auto* fn = static_cast<const HirFunction*>(decls[0]);
+    const auto* ret = static_cast<const HirReturn*>(fn->body()[0]);
+    expect(ret->value()->kind() == HirKind::SymbolRef);
+    const auto* ref = static_cast<const HirSymbolRef*>(ret->value());
+    expect(ref->symbol() != nullptr) << "symbol identity resolved";
+    expect(ref->symbol()->name == "x") << "correct symbol name";
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Struct declaration
+// ---------------------------------------------------------------------------
+
+suite hir_struct = [] {
+  "struct declaration lowered"_test = [] {
+    HirTestPipeline p(
+        "struct Point:\n"
+        "    let x: i32\n"
+        "    let y: i32\n");
+    expect(contains(p.dump(), "StructDecl Point"));
+  };
+};
+
+// ---------------------------------------------------------------------------
+// HIR builder diagnostics (no crashes on empty)
+// ---------------------------------------------------------------------------
+
+suite hir_edge = [] {
+  "empty module"_test = [] {
+    HirTestPipeline p("");
+    expect(p.module() != nullptr);
+    expect(p.module()->declarations().empty());
+  };
+
+  "void function"_test = [] {
+    HirTestPipeline p("fn noop(): void\n    let x: i32 = 1\n");
+    expect(contains(p.dump(), "Function noop"));
+  };
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/ir/hir/hir_test.cpp
+++ b/compiler/ir/hir/hir_test.cpp
@@ -205,14 +205,23 @@ suite hir_pipe = [] {
 // ---------------------------------------------------------------------------
 
 suite hir_lambda = [] {
-  "lambda preserved as first-class node"_test = [] {
+  // NOTE: the parser does not yet support fn(...) -> T as a type syntax,
+  // so lambdas cannot currently pass type checking in a call context.
+  // This test verifies structural lowering: the HIR builder produces a
+  // Lambda node with resolved parameter symbols even without a typed
+  // function context.  The type checker emits a diagnostic, but the
+  // builder still lowers the surrounding AST that parsed successfully.
+  "lambda structural lowering"_test = [] {
+    // A pipe with a lambda parses but the lambda fails type checking.
+    // The builder still runs and produces a Lambda HIR node.
     HirTestPipeline p(
-        "fn apply(f: fn(i32) -> i32, x: i32): i32 -> f(x)\n"
         "fn main(): i32\n"
-        "    return apply(|x| -> x + 1, 5)\n");
+        "    return 5 |> |x| -> x + 1\n");
     auto dump = p.dump();
     expect(contains(dump, "Lambda")) << dump;
     expect(contains(dump, "Body")) << dump;
+    // Lambda param 'x' should have a resolved LambdaParam symbol.
+    expect(contains(dump, "Param x")) << dump;
   };
 };
 

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -66,7 +66,7 @@ Source-facing compiler pipeline.
 
 Compiler-internal target-agnostic representations.
 
-- `hir/` — high-level IR close to Dao semantics
+- `hir/` — typed, symbol-linked HIR: arena-owned node hierarchy, AST-to-HIR builder, and debug printer
 - `mir/` — mid-level IR with explicit control flow and lowering prep
 
 ### `compiler/backend/`


### PR DESCRIPTION
## Summary

Implement Task 9: the first High-Level Intermediate Representation (HIR) for Dao. HIR is a typed, symbol-linked, target-agnostic semantic tree that consumes checked AST + resolve + typed results and produces a form suitable for later MIR lowering.

## Highlights

- Arena-owned HIR node hierarchy with `HirNode`/`HirDecl`/`HirStmt`/`HirExpr` layers (`hir.h`, ~470 lines)
- All HIR expressions carry semantic `Type*` by construction
- Symbol-linked identity via resolved `Symbol*` references (not raw names)
- Pipe, lambda, mode, and resource preserved as first-class HIR constructs per `CONTRACT_HIR_BOUNDARY.md`
- Expression-bodied functions normalized to block body with `HirReturn`
- `HirBuilder` walks checked AST with `decl_symbols_` map pattern for declaration-site lookups (`hir_builder.cpp`, ~280 lines)
- Deterministic `HirPrinter` showing types and symbol identities (`hir_printer.cpp`)
- 20 tests across 12 suites covering TASK_9_HIR.md §16 required coverage
- `daoc hir <file>` CLI command for debug dumps
- `dao_ir` static library with `dao_frontend` dependency

## Test plan

- [x] All 20 HIR tests pass (`ctest -R hir_test`)
- [x] Full test suite (8/8) passes with no regressions
- [x] `daoc hir <file>` produces correct typed, symbol-linked output
- [ ] Reviewer confirms HIR output matches expected semantic structure
- [ ] Reviewer confirms no contract violations against `CONTRACT_HIR_BOUNDARY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)