### PR TITLE
feat(playground): ✨ add typecheck, HIR, and MIR panels to playground

### DIFF
--- a/tools/playground/compiler_service/CMakeLists.txt
+++ b/tools/playground/compiler_service/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(dao_playground
 
 target_link_libraries(dao_playground PRIVATE
   dao_analysis
+  dao_ir
   dao_frontend
   httplib::httplib
   nlohmann_json::nlohmann_json

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -6,6 +6,14 @@
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
 #include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+#include "frontend/types/type_context.h"
+#include "ir/hir/hir_builder.h"
+#include "ir/hir/hir_context.h"
+#include "ir/hir/hir_printer.h"
+#include "ir/mir/mir_builder.h"
+#include "ir/mir/mir_context.h"
+#include "ir/mir/mir_printer.h"
 
 #include <nlohmann/json.hpp>
 
@@ -134,10 +142,87 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res) {
     }
   }
 
+  // Run type checking, HIR, and MIR when lex/parse/resolve succeeded
+  // without errors. Typecheck warnings are surfaced but do not gate IR.
+  std::string hir_text;
+  std::string mir_text;
+  TypeContext types;
+  bool resolve_clean =
+      lex_parse_clean && resolve_result.diagnostics.empty();
+  if (resolve_clean) {
+    auto check_result =
+        typecheck(*parse_result.file, resolve_result, types);
+
+    bool has_errors = false;
+    for (const auto& diag : check_result.diagnostics) {
+      auto loc = source.line_col(diag.span.offset);
+      diagnostics.push_back({
+          {"severity",
+           diag.severity == Severity::Error ? "error" : "warning"},
+          {"offset", diag.span.offset},
+          {"length", diag.span.length},
+          {"line", loc.line},
+          {"col", loc.col},
+          {"message", diag.message},
+      });
+      if (diag.severity == Severity::Error) {
+        has_errors = true;
+      }
+    }
+
+    if (!has_errors) {
+      HirContext hir_ctx;
+      auto hir_result = build_hir(*parse_result.file, resolve_result,
+                                  check_result, hir_ctx);
+
+      for (const auto& diag : hir_result.diagnostics) {
+        auto loc = source.line_col(diag.span.offset);
+        diagnostics.push_back({
+            {"severity", "error"},
+            {"offset", diag.span.offset},
+            {"length", diag.span.length},
+            {"line", loc.line},
+            {"col", loc.col},
+            {"message", diag.message},
+        });
+      }
+
+      if (hir_result.module != nullptr) {
+        std::ostringstream hir_out;
+        print_hir(hir_out, *hir_result.module);
+        hir_text = hir_out.str();
+
+        MirContext mir_ctx;
+        auto mir_result =
+            build_mir(*hir_result.module, mir_ctx, types);
+
+        for (const auto& diag : mir_result.diagnostics) {
+          auto loc = source.line_col(diag.span.offset);
+          diagnostics.push_back({
+              {"severity", "error"},
+              {"offset", diag.span.offset},
+              {"length", diag.span.length},
+              {"line", loc.line},
+              {"col", loc.col},
+              {"message", diag.message},
+          });
+        }
+
+        if (mir_result.module != nullptr) {
+          std::ostringstream mir_out;
+          print_mir(mir_out, *mir_result.module);
+          mir_text = mir_out.str();
+        }
+      }
+    }
+  }
+
   nlohmann::json response = {
       {"tokens", tokens},
       {"semanticTokens", semantic_tokens_json},
       {"ast", ast_text},
+      {"hir", hir_text},
+      {"mir", mir_text},
       {"diagnostics", diagnostics},
   };
 

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -143,8 +143,10 @@ async function doAnalyze() {
     // Force decoration rebuild by dispatching empty transaction.
     editor.dispatch({});
 
-    // Update AST panel.
+    // Update IR panels.
     document.getElementById("ast-output").textContent = data.ast || "";
+    document.getElementById("hir-output").textContent = data.hir || "";
+    document.getElementById("mir-output").textContent = data.mir || "";
 
     // Update diagnostics panel.
     renderDiagnostics(data.diagnostics || []);
@@ -217,6 +219,23 @@ async function loadExamples() {
     console.error("failed to load example list:", err);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Tab switching
+// ---------------------------------------------------------------------------
+
+document.querySelector(".panel-tabs").addEventListener("click", (e) => {
+  const tab = e.target.closest(".tab");
+  if (!tab) return;
+  const target = tab.dataset.tab;
+
+  document.querySelectorAll(".panel-tabs .tab").forEach((t) =>
+    t.classList.toggle("active", t === tab)
+  );
+  document.querySelectorAll("#ir-panel .tab-content").forEach((c) =>
+    c.classList.toggle("active", c.id === `${target}-output`)
+  );
+});
 
 // ---------------------------------------------------------------------------
 // Init

--- a/tools/playground/frontend/app.js
+++ b/tools/playground/frontend/app.js
@@ -86,9 +86,11 @@ const tokenHighlighter = ViewPlugin.fromClass(
 // Editor setup
 // ---------------------------------------------------------------------------
 
-const defaultSource = `fn main(): i32
-    print("hello, dao")
-    0
+const defaultSource = `fn add(a: i32, b: i32): i32 -> a + b
+
+fn main(): i32
+    let x: i32 = add(1, 2)
+    return x
 `;
 
 const editor = new EditorView({

--- a/tools/playground/frontend/index.html
+++ b/tools/playground/frontend/index.html
@@ -21,9 +21,15 @@
       <div id="editor-container"></div>
     </div>
     <div id="right-panels">
-      <div id="ast-panel">
-        <div class="panel-header">AST</div>
-        <pre id="ast-output"></pre>
+      <div id="ir-panel">
+        <div class="panel-tabs">
+          <button class="tab active" data-tab="ast">AST</button>
+          <button class="tab" data-tab="hir">HIR</button>
+          <button class="tab" data-tab="mir">MIR</button>
+        </div>
+        <pre id="ast-output" class="tab-content active"></pre>
+        <pre id="hir-output" class="tab-content"></pre>
+        <pre id="mir-output" class="tab-content"></pre>
       </div>
       <div id="diagnostics-panel">
         <div class="panel-header">Diagnostics</div>

--- a/tools/playground/frontend/style.css
+++ b/tools/playground/frontend/style.css
@@ -76,7 +76,7 @@ main {
   min-height: 0;
 }
 
-#ast-panel {
+#ir-panel {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -102,7 +102,37 @@ main {
   border-bottom: 1px solid var(--border);
 }
 
-#ast-output {
+.panel-tabs {
+  background: var(--bg-header);
+  display: flex;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-tabs .tab {
+  background: none;
+  border: none;
+  color: var(--fg-dim);
+  padding: 4px 12px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.panel-tabs .tab:hover {
+  color: var(--fg);
+}
+
+.panel-tabs .tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tab-content {
+  display: none;
   flex: 1;
   padding: 12px;
   overflow: auto;
@@ -110,6 +140,10 @@ main {
   line-height: 1.5;
   white-space: pre;
   min-height: 0;
+}
+
+.tab-content.active {
+  display: block;
 }
 
 #diagnostics-output {

--- a/tools/playground/frontend/style.css
+++ b/tools/playground/frontend/style.css
@@ -133,7 +133,6 @@ main {
 
 .tab-content {
   display: none;
-  flex: 1;
   padding: 12px;
   overflow: auto;
   font-size: 13px;
@@ -144,6 +143,7 @@ main {
 
 .tab-content.active {
   display: block;
+  flex: 1;
 }
 
 #diagnostics-output {


### PR DESCRIPTION
## Summary

Wire the full compiler pipeline (typecheck → HIR → MIR) into the playground's `/api/analyze` endpoint and add a tabbed AST/HIR/MIR panel in the frontend, bringing the playground up to date with the compiler after Tasks 8–10.

## Highlights

- Add typecheck stage with severity-aware diagnostics (error vs warning)
- Run HIR and MIR builders when typecheck succeeds without errors
- Surface HIR and MIR diagnostics alongside lex/parse/resolve errors
- Return `hir` and `mir` text fields in the analyze response JSON
- Replace single AST panel with tabbed AST / HIR / MIR viewer
- Link `dao_ir` library into playground build
- Tab switching via vanilla JS event delegation

## Test plan

- [x] All 9 test suites pass
- [x] Playground binary builds and links cleanly
- [x] Smoke test: `POST /api/analyze` returns populated `hir` and `mir` fields for valid source
- [x] Response includes typecheck diagnostics when present
- [ ] Manual: open playground in browser, verify tab switching between AST/HIR/MIR

🤖 Generated with [Claude Code](https://claude.com/claude-code)