### PR TITLE
fix(typecheck): 🐛 resolve type aliases in declaration registration

### DIFF
--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -276,6 +276,24 @@ void TypeChecker::register_declarations(const FileNode& file) {
       break;
     }
 
+    case NodeKind::AliasDecl: {
+      const auto* alias = static_cast<const AliasDeclNode*>(decl);
+      auto decl_it = decl_symbols_.find(alias->name_span().offset);
+      if (decl_it == decl_symbols_.end()) {
+        break;
+      }
+      const auto* sym = decl_it->second;
+
+      // Resolve the aliased type and cache it so later lookups of the
+      // alias name transparently return the underlying type.
+      const auto* aliased_type = resolve_type_node(alias->type());
+      if (aliased_type != nullptr) {
+        symbol_types_[sym] = aliased_type;
+        typed_.set_decl_type(alias, aliased_type);
+      }
+      break;
+    }
+
     default:
       break;
     }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -217,6 +217,29 @@ auto TypeChecker::resolve_symbol_type_for_type_decl(const Symbol* sym) -> const 
 // ---------------------------------------------------------------------------
 
 void TypeChecker::register_declarations(const FileNode& file) {
+  // Pass 1a: register type aliases first so that functions and structs
+  // can reference them regardless of source order.
+  for (const auto* decl : file.declarations()) {
+    if (decl->kind() != NodeKind::AliasDecl) {
+      continue;
+    }
+    const auto* alias = static_cast<const AliasDeclNode*>(decl);
+    auto decl_it = decl_symbols_.find(alias->name_span().offset);
+    if (decl_it == decl_symbols_.end()) {
+      continue;
+    }
+    const auto* sym = decl_it->second;
+
+    // Resolve the aliased type and cache it so later lookups of the
+    // alias name transparently return the underlying type.
+    const auto* aliased_type = resolve_type_node(alias->type());
+    if (aliased_type != nullptr) {
+      symbol_types_[sym] = aliased_type;
+      typed_.set_decl_type(alias, aliased_type);
+    }
+  }
+
+  // Pass 1b: register functions and structs, which may reference aliases.
   for (const auto* decl : file.declarations()) {
     switch (decl->kind()) {
     case NodeKind::FunctionDecl: {
@@ -273,24 +296,6 @@ void TypeChecker::register_declarations(const FileNode& file) {
           types_.make_struct(sym, st->name(), std::move(fields));
       symbol_types_[sym] = struct_type;
       typed_.set_decl_type(st, struct_type);
-      break;
-    }
-
-    case NodeKind::AliasDecl: {
-      const auto* alias = static_cast<const AliasDeclNode*>(decl);
-      auto decl_it = decl_symbols_.find(alias->name_span().offset);
-      if (decl_it == decl_symbols_.end()) {
-        break;
-      }
-      const auto* sym = decl_it->second;
-
-      // Resolve the aliased type and cache it so later lookups of the
-      // alias name transparently return the underlying type.
-      const auto* aliased_type = resolve_type_node(alias->type());
-      if (aliased_type != nullptr) {
-        symbol_types_[sym] = aliased_type;
-        typed_.set_decl_type(alias, aliased_type);
-      }
       break;
     }
 

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -49,6 +49,40 @@ auto is_ok(const TypeCheckResult& result) -> bool {
   return true;
 }
 
+/// Owns all pipeline state so typed results remain valid.
+struct TypecheckPipeline {
+  SourceBuffer source;
+  LexResult lex_result;
+  ParseResult parse_result;
+  ResolveResult resolve_result;
+  TypeContext types;
+  TypeCheckResult check_result;
+
+  explicit TypecheckPipeline(const std::string& src)
+      : source("test.dao", std::string(src)),
+        lex_result(lex(source)),
+        parse_result(parse(lex_result.tokens)) {
+    if (parse_result.file != nullptr) {
+      resolve_result = resolve(*parse_result.file);
+      check_result = typecheck(*parse_result.file, resolve_result, types);
+    }
+  }
+
+  /// Look up the function type registered for the first FunctionDecl.
+  [[nodiscard]] auto first_fn_type() const -> const Type* {
+    if (parse_result.file == nullptr) {
+      return nullptr;
+    }
+    for (const auto* decl : parse_result.file->declarations()) {
+      if (decl->kind() == NodeKind::FunctionDecl) {
+        return check_result.typed.decl_type(
+            static_cast<const Decl*>(decl));
+      }
+    }
+    return nullptr;
+  }
+};
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -318,11 +352,24 @@ suite type_alias = [] {
     expect(result.diagnostics.empty()) << "alias return type should typecheck";
   };
 
-  "forward-declared alias resolves"_test = [] {
-    auto result = check_source(
+  "forward-declared alias resolves with typed fn signature"_test = [] {
+    TypecheckPipeline pipe(
         "fn test(a: NodeId): NodeId -> a\n"
         "type NodeId = i32\n");
-    expect(result.diagnostics.empty()) << "forward alias should typecheck";
+    expect(pipe.check_result.diagnostics.empty())
+        << "forward alias should typecheck";
+    const auto* fn_type = pipe.first_fn_type();
+    expect(fn_type != nullptr) << "function type must be populated";
+    if (fn_type != nullptr) {
+      expect(fn_type->kind() == TypeKind::Function)
+          << "must be function type";
+      const auto* ft = static_cast<const TypeFunction*>(fn_type);
+      expect(ft->param_types().size() == 1_ul);
+      expect(ft->param_types()[0] != nullptr)
+          << "param type must not be null";
+      expect(ft->param_types()[0]->kind() == TypeKind::Builtin)
+          << "alias param must resolve to builtin";
+    }
   };
 
   "alias type mismatch still caught"_test = [] {

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -318,6 +318,13 @@ suite type_alias = [] {
     expect(result.diagnostics.empty()) << "alias return type should typecheck";
   };
 
+  "forward-declared alias resolves"_test = [] {
+    auto result = check_source(
+        "fn test(a: NodeId): NodeId -> a\n"
+        "type NodeId = i32\n");
+    expect(result.diagnostics.empty()) << "forward alias should typecheck";
+  };
+
   "alias type mismatch still caught"_test = [] {
     auto result = check_source(
         "type NodeId = i32\n"

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -291,6 +291,41 @@ suite typecheck_negative = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+suite type_alias = [] {
+  "alias resolves to underlying type"_test = [] {
+    auto result = check_source(
+        "type NodeId = i32\n"
+        "fn test(a: NodeId): NodeId -> a\n");
+    expect(result.diagnostics.empty()) << "alias param should typecheck";
+  };
+
+  "alias-to-alias chains resolve"_test = [] {
+    auto result = check_source(
+        "type NodeId = i32\n"
+        "type MyNode = NodeId\n"
+        "fn test(a: MyNode): i32 -> a\n");
+    expect(result.diagnostics.empty()) << "chained alias should typecheck";
+  };
+
+  "alias used in return type"_test = [] {
+    auto result = check_source(
+        "type Score = f64\n"
+        "fn test(): Score -> 0.0\n");
+    expect(result.diagnostics.empty()) << "alias return type should typecheck";
+  };
+
+  "alias type mismatch still caught"_test = [] {
+    auto result = check_source(
+        "type NodeId = i32\n"
+        "fn test(a: NodeId): bool -> a\n");
+    expect(has_error_containing(result, "does not match return type"));
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)


### PR DESCRIPTION
## Summary

Type aliases (`type NodeId = i32`) were parsed and resolved correctly but never registered in the typechecker's `symbol_types_` map during pass 1. This caused all alias-typed params and return types to resolve as `nullptr`, producing untyped params in HIR and MIR (e.g. `Param a` instead of `Param a : i32`).

## Highlights

- Add `AliasDecl` case to `register_declarations()` in the typechecker
- Resolve alias RHS via `resolve_type_node()` and cache in `symbol_types_`
- Alias-to-alias chaining resolves transitively (`MyNode → NodeId → i32`)
- Type mismatches through aliases still caught correctly
- 4 new typecheck tests: alias params, chaining, return types, mismatch detection

## Test plan

- [x] All 9 test suites pass (including 4 new alias tests)
- [x] `daoc hir` shows typed params for alias-typed functions
- [x] `daoc mir` shows typed params and locals for alias-typed functions
- [x] Alias-to-alias chaining verified manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)