### PR TITLE
feat(backend): ✨ implement MIR→LLVM IR backend with type lowering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ ai/baselines/*.json
 # Build
 build/
 
+# CTest
+Testing/
+
 # Conan
 CMakeUserPresets.json
 
@@ -19,3 +22,6 @@ CMakeUserPresets.json
 # Tool caches
 .cache/
 .task/
+
+# Local Claude Code instructions
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,16 @@ The current frozen surface assumptions are:
 Agents must not introduce alternate spellings for these without an
 explicit syntax revision task.
 
+## Dependency Discipline
+
+- All dependencies are managed via **Conan 2.x** in manifest mode
+  (`conanfile.txt` or `conanfile.py`).
+- Agents must **never** install, suggest, or attempt to install system
+  packages (e.g. via `zypper`, `apt`, `dnf`, `brew`, or any other
+  system package manager). No exceptions.
+- If a dependency is not available in Conan, escalate — do not
+  work around it with system packages.
+
 ## Repository Discipline
 
 - `docs/contracts/` contains binding contracts only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_testing()
 
 add_subdirectory(compiler/frontend)
 add_subdirectory(compiler/ir)
+add_subdirectory(compiler/backend)
 add_subdirectory(compiler/analysis)
 add_subdirectory(compiler/driver)
 add_subdirectory(tools/playground)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
         --build=missing
         -of {{.BUILD_DIR}}
     sources:
-      - conanfile.txt
+      - conanfile.py
       - "{{.PROFILE}}"
     generates:
       - "{{.BUILD_DIR}}/conan_toolchain.cmake"
@@ -95,3 +95,9 @@ tasks:
     deps: [build]
     cmds:
       - "{{.BUILD_DIR}}/compiler/driver/daoc resolve {{.CLI_ARGS}}"
+
+  llvm-ir:
+    desc: "Run daoc llvm-ir on a file (usage: task llvm-ir -- file.dao)"
+    deps: [build]
+    cmds:
+      - "{{.BUILD_DIR}}/compiler/driver/daoc llvm-ir {{.CLI_ARGS}}"

--- a/compiler/backend/CMakeLists.txt
+++ b/compiler/backend/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(llvm)

--- a/compiler/backend/llvm/CMakeLists.txt
+++ b/compiler/backend/llvm/CMakeLists.txt
@@ -1,0 +1,37 @@
+find_package(LLVM REQUIRED)
+
+add_library(dao_backend_llvm STATIC
+  llvm_type_lowering.cpp
+  llvm_backend.cpp
+)
+
+target_include_directories(dao_backend_llvm PUBLIC
+  ${CMAKE_SOURCE_DIR}/compiler
+)
+
+target_link_libraries(dao_backend_llvm
+  PUBLIC
+    dao_ir
+    dao_frontend
+    llvm-core::llvm-core
+)
+
+# Tests
+find_package(ut REQUIRED)
+
+add_executable(llvm_backend_test
+  llvm_backend_test.cpp
+)
+
+target_link_libraries(llvm_backend_test
+  PRIVATE
+    dao_backend_llvm
+    Boost::ut
+)
+
+target_compile_definitions(llvm_backend_test PRIVATE
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
+include(CTest)
+add_test(NAME llvm_backend_test COMMAND llvm_backend_test)

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -1,0 +1,696 @@
+#include "backend/llvm/llvm_backend.h"
+
+#include "ir/mir/mir.h"
+#include "ir/mir/mir_kind.h"
+
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/raw_os_ostream.h>
+
+#include <cassert>
+#include <string>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// LlvmBackend
+// ---------------------------------------------------------------------------
+
+LlvmBackend::LlvmBackend(llvm::LLVMContext& ctx) : ctx_(ctx), types_(ctx) {}
+
+auto LlvmBackend::lower(const MirModule& mir_module) -> LlvmBackendResult {
+  module_ = std::make_unique<llvm::Module>("dao_module", ctx_);
+  diagnostics_.clear();
+
+  // First pass: declare all functions (forward declarations).
+  for (const auto* fn : mir_module.functions) {
+    if (fn->symbol == nullptr) {
+      continue;
+    }
+
+    // Build LLVM function type.
+    auto* ret_type = types_.lower(fn->return_type);
+    if (ret_type == nullptr) {
+      emit_diagnostic(fn->span, "cannot lower return type: " + types_.error());
+      continue;
+    }
+
+    std::vector<llvm::Type*> param_types;
+    for (const auto& local : fn->locals) {
+      if (!local.is_param) {
+        break; // params come first
+      }
+      auto* pt = types_.lower(local.type);
+      if (pt == nullptr) {
+        emit_diagnostic(local.span, "cannot lower param type: " + types_.error());
+        break;
+      }
+      // String params are passed by pointer for C ABI compatibility.
+      if (LlvmTypeLowering::is_string_type(local.type)) {
+        pt = llvm::PointerType::getUnqual(pt);
+      }
+      param_types.push_back(pt);
+    }
+
+    auto* fn_type = llvm::FunctionType::get(ret_type, param_types, /*isVarArg=*/false);
+    auto* llvm_fn = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage,
+        std::string(fn->symbol->name), module_.get());
+
+    // Name parameters.
+    size_t idx = 0;
+    for (auto& arg : llvm_fn->args()) {
+      if (idx < fn->locals.size() && fn->locals[idx].is_param) {
+        if (fn->locals[idx].symbol != nullptr) {
+          arg.setName(std::string(fn->locals[idx].symbol->name));
+        }
+      }
+      ++idx;
+    }
+  }
+
+  // Second pass: lower function bodies.
+  for (const auto* fn : mir_module.functions) {
+    if (!lower_function(*fn)) {
+      // Diagnostics already emitted.
+    }
+  }
+
+  // Do not return a partial module when lowering produced errors.
+  if (!diagnostics_.empty()) {
+    module_.reset();
+  }
+
+  return {.module = std::move(module_), .diagnostics = std::move(diagnostics_)};
+}
+
+void LlvmBackend::print_ir(std::ostream& out, const llvm::Module& module) {
+  llvm::raw_os_ostream llvm_out(out);
+  module.print(llvm_out, nullptr);
+}
+
+void LlvmBackend::emit_diagnostic(Span span, const std::string& message) {
+  diagnostics_.push_back(
+      Diagnostic{.severity = Severity::Error, .span = span, .message = message});
+}
+
+// ---------------------------------------------------------------------------
+// Function lowering
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
+  if (fn.symbol == nullptr) {
+    return true; // skip anonymous functions (lambdas handled separately)
+  }
+
+  auto* llvm_fn = module_->getFunction(std::string(fn.symbol->name));
+  if (llvm_fn == nullptr) {
+    emit_diagnostic(fn.span, "function not declared: " + std::string(fn.symbol->name));
+    return false;
+  }
+
+  // If no blocks, this is a declaration (extern). Leave it as-is.
+  if (fn.blocks.empty()) {
+    return true;
+  }
+
+  FunctionState state;
+  state.llvm_fn = llvm_fn;
+
+  // Create all basic blocks first (for forward branches).
+  for (const auto* block : fn.blocks) {
+    auto* bb = llvm::BasicBlock::Create(
+        ctx_, "bb" + std::to_string(block->id.id), llvm_fn);
+    state.blocks[block->id.id] = bb;
+  }
+
+  // Create entry block allocas for all locals.
+  llvm::IRBuilder<> builder(ctx_);
+  state.builder = &builder;
+
+  auto* entry_bb = state.blocks[fn.blocks[0]->id.id];
+  builder.SetInsertPoint(entry_bb);
+
+  // Allocate locals. Params get their alloca here too (store from arg below).
+  for (const auto& local : fn.locals) {
+    auto* local_type = types_.lower(local.type);
+    if (local_type == nullptr) {
+      emit_diagnostic(local.span, "cannot lower local type: " + types_.error());
+      return false;
+    }
+    // String locals store the struct, not a pointer.
+    auto* alloca = builder.CreateAlloca(
+        local_type, nullptr,
+        local.symbol != nullptr ? std::string(local.symbol->name) : "");
+    state.locals[local.id.id] = alloca;
+  }
+
+  // Store function parameters into their allocas.
+  size_t param_idx = 0;
+  for (auto& arg : llvm_fn->args()) {
+    if (param_idx < fn.locals.size() && fn.locals[param_idx].is_param) {
+      auto* alloca = state.locals[fn.locals[param_idx].id.id];
+      // For string params (passed by pointer), load the struct value.
+      if (LlvmTypeLowering::is_string_type(fn.locals[param_idx].type)) {
+        auto* loaded = builder.CreateLoad(types_.string_type(), &arg);
+        builder.CreateStore(loaded, alloca);
+      } else {
+        builder.CreateStore(&arg, alloca);
+      }
+    }
+    ++param_idx;
+  }
+
+  // Lower each block.
+  for (const auto* block : fn.blocks) {
+    if (!lower_block(*block, fn, state)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Block lowering
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_block(const MirBlock& block, const MirFunction& fn,
+                                FunctionState& state) -> bool {
+  auto* bb = state.blocks[block.id.id];
+  state.builder->SetInsertPoint(bb);
+
+  for (const auto* inst : block.insts) {
+    if (!lower_inst(*inst, fn, state)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Instruction dispatch
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
+                               FunctionState& state) -> bool {
+  switch (inst.kind) {
+  case MirInstKind::ConstInt:
+    return lower_const_int(inst, state);
+  case MirInstKind::ConstFloat:
+    return lower_const_float(inst, state);
+  case MirInstKind::ConstBool:
+    return lower_const_bool(inst, state);
+  case MirInstKind::ConstString:
+    return lower_const_string(inst, state);
+  case MirInstKind::Unary:
+    return lower_unary(inst, state);
+  case MirInstKind::Binary:
+    return lower_binary(inst, state);
+  case MirInstKind::Store:
+    return lower_store(inst, fn, state);
+  case MirInstKind::Load:
+    return lower_load(inst, fn, state);
+  case MirInstKind::FnRef:
+    return lower_fn_ref(inst, state);
+  case MirInstKind::Call:
+    return lower_call(inst, state);
+  case MirInstKind::Return:
+    return lower_return(inst, state);
+  case MirInstKind::Br:
+    return lower_br(inst, state);
+  case MirInstKind::CondBr:
+    return lower_cond_br(inst, state);
+
+  // Mode unsafe — permission semantics enforced upstream; no-op in codegen.
+  case MirInstKind::ModeEnter:
+    if (inst.mode_kind != HirModeKind::Unsafe) {
+      emit_diagnostic(inst.span,
+                       "mode '" + std::string(inst.region_name) +
+                       "' lowering not yet supported");
+      return false;
+    }
+    return true;
+  case MirInstKind::ModeExit:
+    if (inst.mode_kind != HirModeKind::Unsafe) {
+      // Entry already diagnosed; skip duplicate.
+    }
+    return true;
+
+  // Resource regions — no codegen support yet.
+  case MirInstKind::ResourceEnter:
+    emit_diagnostic(inst.span,
+                     "resource region lowering not yet supported");
+    return false;
+  case MirInstKind::ResourceExit:
+    return true;
+
+  // AddrOf — address of a place.
+  case MirInstKind::AddrOf: {
+    if (inst.place == nullptr) {
+      emit_diagnostic(inst.span, "AddrOf with null place");
+      return false;
+    }
+    if (!inst.place->projections.empty()) {
+      emit_diagnostic(inst.span,
+                       "AddrOf with projections not yet supported");
+      return false;
+    }
+    auto it = state.locals.find(inst.place->local.id);
+    if (it == state.locals.end()) {
+      emit_diagnostic(inst.span, "AddrOf: unknown local");
+      return false;
+    }
+    state.values[inst.result.id] = it->second;
+    return true;
+  }
+
+  // Unsupported constructs — fail explicitly per contract.
+  case MirInstKind::FieldAccess:
+    emit_diagnostic(inst.span, "field access lowering not yet implemented");
+    return false;
+  case MirInstKind::IndexAccess:
+    emit_diagnostic(inst.span, "index access lowering not yet implemented");
+    return false;
+  case MirInstKind::IterInit:
+  case MirInstKind::IterHasNext:
+  case MirInstKind::IterNext:
+    emit_diagnostic(inst.span, "iteration lowering not yet implemented");
+    return false;
+  case MirInstKind::Lambda:
+    emit_diagnostic(inst.span, "lambda lowering not yet implemented");
+    return false;
+  }
+
+  emit_diagnostic(inst.span, "unknown MIR instruction kind");
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Value lookup
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::get_value(MirValueId id, FunctionState& state) -> llvm::Value* {
+  auto it = state.values.find(id.id);
+  if (it != state.values.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Constant lowering
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_const_int(const MirInst& inst, FunctionState& state) -> bool {
+  auto* type = types_.lower(inst.type);
+  if (type == nullptr) {
+    emit_diagnostic(inst.span, "cannot lower const int type: " + types_.error());
+    return false;
+  }
+  auto* val = llvm::ConstantInt::get(type, static_cast<uint64_t>(inst.const_int),
+                                     /*isSigned=*/!LlvmTypeLowering::is_unsigned(inst.type));
+  state.values[inst.result.id] = val;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_const_float(const MirInst& inst, FunctionState& state) -> bool {
+  auto* type = types_.lower(inst.type);
+  if (type == nullptr) {
+    emit_diagnostic(inst.span, "cannot lower const float type: " + types_.error());
+    return false;
+  }
+  auto* val = llvm::ConstantFP::get(type, inst.const_float);
+  state.values[inst.result.id] = val;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_const_bool(const MirInst& inst, FunctionState& state) -> bool {
+  auto* val = llvm::ConstantInt::get(llvm::Type::getInt1Ty(ctx_),
+                                     inst.const_bool ? 1 : 0);
+  state.values[inst.result.id] = val;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_const_string(const MirInst& inst, FunctionState& state) -> bool {
+  // Create a global constant for the string data.
+  auto str = std::string(inst.const_string);
+  auto* str_constant = llvm::ConstantDataArray::getString(ctx_, str, /*AddNull=*/true);
+  auto* global = new llvm::GlobalVariable(
+      *module_, str_constant->getType(), /*isConstant=*/true,
+      llvm::GlobalValue::PrivateLinkage, str_constant, ".str");
+  global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+
+  // Build a dao.string struct value: { i8* ptr, i64 len }.
+  auto* str_type = types_.string_type();
+  auto* zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx_), 0);
+  auto* gep = state.builder->CreateInBoundsGEP(
+      str_constant->getType(), global, {zero, zero}, "str.ptr");
+  auto* len = llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx_), str.size());
+
+  // Build the struct aggregate.
+  llvm::Value* agg = llvm::UndefValue::get(str_type);
+  agg = state.builder->CreateInsertValue(agg, gep, 0, "str.with_ptr");
+  agg = state.builder->CreateInsertValue(agg, len, 1, "str.with_len");
+
+  state.values[inst.result.id] = agg;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Unary / binary operations
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_unary(const MirInst& inst, FunctionState& state) -> bool {
+  auto* operand = get_value(inst.operand, state);
+  if (operand == nullptr) {
+    emit_diagnostic(inst.span, "unary operand not found");
+    return false;
+  }
+
+  llvm::Value* result = nullptr;
+  switch (inst.unary_op) {
+  case UnaryOp::Negate:
+    if (operand->getType()->isFloatingPointTy()) {
+      result = state.builder->CreateFNeg(operand, "fneg");
+    } else {
+      result = state.builder->CreateNeg(operand, "neg");
+    }
+    break;
+  case UnaryOp::Not:
+    result = state.builder->CreateNot(operand, "not");
+    break;
+  case UnaryOp::Deref:
+  case UnaryOp::AddrOf:
+    // These should be lowered to Load/AddrOf MIR instructions by the MIR builder.
+    emit_diagnostic(inst.span, "unexpected Deref/AddrOf as unary op in MIR");
+    return false;
+  }
+
+  if (result != nullptr) {
+    state.values[inst.result.id] = result;
+    state.value_types[inst.result.id] = inst.type;
+  }
+  return result != nullptr;
+}
+
+auto LlvmBackend::lower_binary(const MirInst& inst, FunctionState& state) -> bool {
+  auto* lhs = get_value(inst.lhs, state);
+  auto* rhs = get_value(inst.rhs, state);
+  if (lhs == nullptr || rhs == nullptr) {
+    emit_diagnostic(inst.span, "binary operand not found");
+    return false;
+  }
+
+  bool is_float = lhs->getType()->isFloatingPointTy();
+  // For signedness, check the LHS operand's semantic type, not the result type.
+  // Comparisons have result type bool, but signedness comes from operands.
+  auto lhs_type_it = state.value_types.find(inst.lhs.id);
+  const Type* operand_type = lhs_type_it != state.value_types.end() ? lhs_type_it->second : inst.type;
+  bool is_unsigned_op = LlvmTypeLowering::is_unsigned(operand_type);
+  llvm::Value* result = nullptr;
+
+  switch (inst.binary_op) {
+  case BinaryOp::Add:
+    result = is_float ? state.builder->CreateFAdd(lhs, rhs, "fadd")
+                      : state.builder->CreateAdd(lhs, rhs, "add");
+    break;
+  case BinaryOp::Sub:
+    result = is_float ? state.builder->CreateFSub(lhs, rhs, "fsub")
+                      : state.builder->CreateSub(lhs, rhs, "sub");
+    break;
+  case BinaryOp::Mul:
+    result = is_float ? state.builder->CreateFMul(lhs, rhs, "fmul")
+                      : state.builder->CreateMul(lhs, rhs, "mul");
+    break;
+  case BinaryOp::Div:
+    if (is_float) {
+      result = state.builder->CreateFDiv(lhs, rhs, "fdiv");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateUDiv(lhs, rhs, "udiv");
+    } else {
+      result = state.builder->CreateSDiv(lhs, rhs, "sdiv");
+    }
+    break;
+  case BinaryOp::Mod:
+    if (is_float) {
+      result = state.builder->CreateFRem(lhs, rhs, "fmod");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateURem(lhs, rhs, "urem");
+    } else {
+      result = state.builder->CreateSRem(lhs, rhs, "srem");
+    }
+    break;
+
+  // Comparisons
+  case BinaryOp::EqEq:
+    result = is_float ? state.builder->CreateFCmpOEQ(lhs, rhs, "feq")
+                      : state.builder->CreateICmpEQ(lhs, rhs, "eq");
+    break;
+  case BinaryOp::BangEq:
+    result = is_float ? state.builder->CreateFCmpONE(lhs, rhs, "fne")
+                      : state.builder->CreateICmpNE(lhs, rhs, "ne");
+    break;
+  case BinaryOp::Lt:
+    if (is_float) {
+      result = state.builder->CreateFCmpOLT(lhs, rhs, "flt");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateICmpULT(lhs, rhs, "ult");
+    } else {
+      result = state.builder->CreateICmpSLT(lhs, rhs, "slt");
+    }
+    break;
+  case BinaryOp::LtEq:
+    if (is_float) {
+      result = state.builder->CreateFCmpOLE(lhs, rhs, "fle");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateICmpULE(lhs, rhs, "ule");
+    } else {
+      result = state.builder->CreateICmpSLE(lhs, rhs, "sle");
+    }
+    break;
+  case BinaryOp::Gt:
+    if (is_float) {
+      result = state.builder->CreateFCmpOGT(lhs, rhs, "fgt");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateICmpUGT(lhs, rhs, "ugt");
+    } else {
+      result = state.builder->CreateICmpSGT(lhs, rhs, "sgt");
+    }
+    break;
+  case BinaryOp::GtEq:
+    if (is_float) {
+      result = state.builder->CreateFCmpOGE(lhs, rhs, "fge");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateICmpUGE(lhs, rhs, "uge");
+    } else {
+      result = state.builder->CreateICmpSGE(lhs, rhs, "sge");
+    }
+    break;
+
+  // Boolean logic
+  case BinaryOp::And:
+    result = state.builder->CreateAnd(lhs, rhs, "and");
+    break;
+  case BinaryOp::Or:
+    result = state.builder->CreateOr(lhs, rhs, "or");
+    break;
+  }
+
+  if (result != nullptr) {
+    state.values[inst.result.id] = result;
+    state.value_types[inst.result.id] = inst.type;
+  }
+  return result != nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Memory operations
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_store(const MirInst& inst, const MirFunction& fn,
+                                FunctionState& state) -> bool {
+  if (inst.place == nullptr) {
+    emit_diagnostic(inst.span, "store with null place");
+    return false;
+  }
+
+  if (!inst.place->projections.empty()) {
+    emit_diagnostic(inst.span,
+                     "store to projected place (field/index/deref) "
+                     "not yet supported");
+    return false;
+  }
+
+  auto* value = get_value(inst.store_value, state);
+  if (value == nullptr) {
+    emit_diagnostic(inst.span, "store value not found");
+    return false;
+  }
+
+  auto it = state.locals.find(inst.place->local.id);
+  if (it == state.locals.end()) {
+    emit_diagnostic(inst.span, "store target local not found");
+    return false;
+  }
+
+  state.builder->CreateStore(value, it->second);
+  return true;
+}
+
+auto LlvmBackend::lower_load(const MirInst& inst, const MirFunction& fn,
+                               FunctionState& state) -> bool {
+  if (inst.place == nullptr) {
+    emit_diagnostic(inst.span, "load with null place");
+    return false;
+  }
+
+  if (!inst.place->projections.empty()) {
+    emit_diagnostic(inst.span,
+                     "load from projected place (field/index/deref) "
+                     "not yet supported");
+    return false;
+  }
+
+  auto it = state.locals.find(inst.place->local.id);
+  if (it == state.locals.end()) {
+    emit_diagnostic(inst.span, "load source local not found");
+    return false;
+  }
+
+  auto* local_type = types_.lower(inst.type);
+  if (local_type == nullptr) {
+    emit_diagnostic(inst.span, "cannot lower load type: " + types_.error());
+    return false;
+  }
+
+  auto* val = state.builder->CreateLoad(local_type, it->second, "load");
+  state.values[inst.result.id] = val;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Function reference and calls
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_fn_ref(const MirInst& inst, FunctionState& state) -> bool {
+  if (inst.fn_symbol == nullptr) {
+    emit_diagnostic(inst.span, "FnRef with null symbol");
+    return false;
+  }
+
+  auto* fn = module_->getFunction(std::string(inst.fn_symbol->name));
+  if (fn == nullptr) {
+    emit_diagnostic(inst.span,
+                    "function not found: " + std::string(inst.fn_symbol->name));
+    return false;
+  }
+
+  state.values[inst.result.id] = fn;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_call(const MirInst& inst, FunctionState& state) -> bool {
+  auto* callee_val = get_value(inst.callee, state);
+  if (callee_val == nullptr) {
+    emit_diagnostic(inst.span, "call callee not found");
+    return false;
+  }
+
+  auto* callee_fn = llvm::dyn_cast<llvm::Function>(callee_val);
+  if (callee_fn == nullptr) {
+    emit_diagnostic(inst.span, "call callee is not a function");
+    return false;
+  }
+
+  std::vector<llvm::Value*> args;
+  if (inst.call_args != nullptr) {
+    args.reserve(inst.call_args->size());
+    for (size_t i = 0; i < inst.call_args->size(); ++i) {
+      auto* arg_val = get_value((*inst.call_args)[i], state);
+      if (arg_val == nullptr) {
+        emit_diagnostic(inst.span, "call argument not found");
+        return false;
+      }
+      // If the callee expects a pointer to string struct, create a
+      // temporary alloca and pass its address.
+      if (i < callee_fn->getFunctionType()->getNumParams()) {
+        auto* param_type = callee_fn->getFunctionType()->getParamType(i);
+        if (param_type->isPointerTy() && arg_val->getType() == types_.string_type()) {
+          auto* tmp = state.builder->CreateAlloca(types_.string_type(), nullptr, "str.arg");
+          state.builder->CreateStore(arg_val, tmp);
+          arg_val = tmp;
+        }
+      }
+      args.push_back(arg_val);
+    }
+  }
+
+  auto* call = state.builder->CreateCall(callee_fn->getFunctionType(),
+                                          callee_fn, args);
+  if (!callee_fn->getReturnType()->isVoidTy() && inst.result.valid()) {
+    state.values[inst.result.id] = call;
+    state.value_types[inst.result.id] = inst.type;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Terminators
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_return(const MirInst& inst, FunctionState& state) -> bool {
+  if (inst.has_return_value) {
+    auto* val = get_value(inst.return_value, state);
+    if (val == nullptr) {
+      emit_diagnostic(inst.span, "return value not found");
+      return false;
+    }
+    state.builder->CreateRet(val);
+  } else {
+    state.builder->CreateRetVoid();
+  }
+  return true;
+}
+
+auto LlvmBackend::lower_br(const MirInst& inst, FunctionState& state) -> bool {
+  auto it = state.blocks.find(inst.br_target.id);
+  if (it == state.blocks.end()) {
+    emit_diagnostic(inst.span, "branch target block not found");
+    return false;
+  }
+  state.builder->CreateBr(it->second);
+  return true;
+}
+
+auto LlvmBackend::lower_cond_br(const MirInst& inst, FunctionState& state) -> bool {
+  auto* cond = get_value(inst.cond, state);
+  if (cond == nullptr) {
+    emit_diagnostic(inst.span, "conditional branch condition not found");
+    return false;
+  }
+
+  auto then_it = state.blocks.find(inst.then_block.id);
+  auto else_it = state.blocks.find(inst.else_block.id);
+  if (then_it == state.blocks.end() || else_it == state.blocks.end()) {
+    emit_diagnostic(inst.span, "conditional branch target block not found");
+    return false;
+  }
+
+  state.builder->CreateCondBr(cond, then_it->second, else_it->second);
+  return true;
+}
+
+} // namespace dao

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -1,0 +1,102 @@
+#ifndef DAO_BACKEND_LLVM_LLVM_BACKEND_H
+#define DAO_BACKEND_LLVM_LLVM_BACKEND_H
+
+#include "backend/llvm/llvm_type_lowering.h"
+#include "frontend/diagnostics/diagnostic.h"
+#include "frontend/diagnostics/source.h"
+#include "ir/mir/mir.h"
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// LlvmBackendResult — output of LLVM lowering.
+// ---------------------------------------------------------------------------
+
+struct LlvmBackendResult {
+  std::unique_ptr<llvm::Module> module;
+  std::vector<Diagnostic> diagnostics;
+};
+
+// ---------------------------------------------------------------------------
+// LlvmBackend — top-level MIR → LLVM IR lowering.
+//
+// Consumes a MirModule and produces an llvm::Module. This is the only
+// public entry point for the LLVM backend.
+// ---------------------------------------------------------------------------
+
+class LlvmBackend {
+public:
+  explicit LlvmBackend(llvm::LLVMContext& ctx);
+
+  auto lower(const MirModule& mir_module) -> LlvmBackendResult;
+
+  // Emit textual LLVM IR to a stream.
+  static void print_ir(std::ostream& out, const llvm::Module& module);
+
+private:
+  llvm::LLVMContext& ctx_;
+  LlvmTypeLowering types_;
+  std::unique_ptr<llvm::Module> module_;
+  std::vector<Diagnostic> diagnostics_;
+
+  void emit_diagnostic(Span span, const std::string& message);
+
+  // Function lowering
+  auto lower_function(const MirFunction& fn) -> bool;
+
+  // Per-function state
+  struct FunctionState {
+    llvm::Function* llvm_fn = nullptr;
+    llvm::IRBuilder<>* builder = nullptr;
+
+    // MIR LocalId → LLVM alloca (for named locals / params)
+    std::unordered_map<uint32_t, llvm::AllocaInst*> locals;
+
+    // MIR MirValueId → LLVM Value* (for SSA temporaries)
+    std::unordered_map<uint32_t, llvm::Value*> values;
+
+    // MIR MirValueId → semantic Type* (for signedness decisions)
+    std::unordered_map<uint32_t, const Type*> value_types;
+
+    // MIR BlockId → LLVM BasicBlock*
+    std::unordered_map<uint32_t, llvm::BasicBlock*> blocks;
+  };
+
+  auto lower_block(const MirBlock& block, const MirFunction& fn,
+                    FunctionState& state) -> bool;
+  auto lower_inst(const MirInst& inst, const MirFunction& fn,
+                   FunctionState& state) -> bool;
+
+  // Instruction lowering helpers
+  auto lower_const_int(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_const_float(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_const_bool(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_const_string(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_unary(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_binary(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_store(const MirInst& inst, const MirFunction& fn,
+                    FunctionState& state) -> bool;
+  auto lower_load(const MirInst& inst, const MirFunction& fn,
+                   FunctionState& state) -> bool;
+  auto lower_fn_ref(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_call(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_return(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_br(const MirInst& inst, FunctionState& state) -> bool;
+  auto lower_cond_br(const MirInst& inst, FunctionState& state) -> bool;
+
+  // Value lookup
+  auto get_value(MirValueId id, FunctionState& state) -> llvm::Value*;
+};
+
+} // namespace dao
+
+#endif // DAO_BACKEND_LLVM_LLVM_BACKEND_H

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -1,0 +1,397 @@
+#include "backend/llvm/llvm_backend.h"
+#include "backend/llvm/llvm_type_lowering.h"
+#include "frontend/diagnostics/source.h"
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+#include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+#include "frontend/types/type_context.h"
+#include "ir/hir/hir_builder.h"
+#include "ir/hir/hir_context.h"
+#include "ir/mir/mir_builder.h"
+#include "ir/mir/mir_context.h"
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+#include <boost/ut.hpp>
+#include <sstream>
+#include <string>
+
+using namespace boost::ut;
+using namespace dao;
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace {
+
+/// Full pipeline: source → MIR → LLVM IR.
+struct LlvmTestPipeline {
+  SourceBuffer source;
+  LexResult lex_result;
+  ParseResult parse_result;
+  ResolveResult resolve_result;
+  TypeContext types;
+  TypeCheckResult check_result;
+  HirContext hir_ctx;
+  HirBuildResult hir_result;
+  MirContext mir_ctx;
+  MirBuildResult mir_result;
+  llvm::LLVMContext llvm_ctx;
+  LlvmBackendResult llvm_result;
+
+  explicit LlvmTestPipeline(const std::string& src)
+      : source("test.dao", std::string(src)),
+        lex_result(lex(source)),
+        parse_result(parse(lex_result.tokens)) {
+    if (parse_result.file != nullptr) {
+      resolve_result = resolve(*parse_result.file);
+      check_result = typecheck(*parse_result.file, resolve_result, types);
+      hir_result = build_hir(*parse_result.file, resolve_result, check_result, hir_ctx);
+      if (hir_result.module != nullptr) {
+        mir_result = build_mir(*hir_result.module, mir_ctx, types);
+        if (mir_result.module != nullptr) {
+          LlvmBackend backend(llvm_ctx);
+          llvm_result = backend.lower(*mir_result.module);
+        }
+      }
+    }
+  }
+
+  [[nodiscard]] auto ir() const -> std::string {
+    std::ostringstream out;
+    if (llvm_result.module != nullptr) {
+      LlvmBackend::print_ir(out, *llvm_result.module);
+    }
+    return out.str();
+  }
+
+  [[nodiscard]] auto has_errors() const -> bool {
+    return !llvm_result.diagnostics.empty();
+  }
+};
+
+auto contains(const std::string& haystack, std::string_view needle) -> bool {
+  return haystack.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Type lowering
+// ---------------------------------------------------------------------------
+
+suite type_lowering = [] {
+  "builtin scalars lower correctly"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+    TypeContext types;
+
+    expect(lowering.lower(types.i32()) != nullptr);
+    expect(lowering.lower(types.i64()) != nullptr);
+    expect(lowering.lower(types.f32()) != nullptr);
+    expect(lowering.lower(types.f64()) != nullptr);
+    expect(lowering.lower(types.bool_type()) != nullptr);
+    expect(lowering.lower(types.u8()) != nullptr);
+    expect(lowering.lower(types.u64()) != nullptr);
+  };
+
+  "void type lowers"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+    TypeContext types;
+
+    auto* lowered = lowering.lower(types.void_type());
+    expect(lowered != nullptr);
+    expect(lowered->isVoidTy());
+  };
+
+  "pointer type lowers"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+    TypeContext types;
+
+    auto* lowered = lowering.lower(types.pointer_to(types.i32()));
+    expect(lowered != nullptr);
+    expect(lowered->isPointerTy());
+  };
+
+  "string type lowers to struct"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+    TypeContext types;
+
+    auto* str = types.named_type(nullptr, "string", {});
+    auto* lowered = lowering.lower(str);
+    expect(lowered != nullptr);
+    expect(lowered->isStructTy());
+  };
+
+  "null type returns error"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+
+    expect(lowering.lower(nullptr) == nullptr);
+    expect(!lowering.error().empty());
+  };
+
+  "generic param fails"_test = [] {
+    llvm::LLVMContext ctx;
+    LlvmTypeLowering lowering(ctx);
+    TypeContext types;
+
+    auto* gp = types.generic_param("T", 0);
+    expect(lowering.lower(gp) == nullptr);
+    expect(contains(lowering.error(), "generic"));
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Simple function lowering
+// ---------------------------------------------------------------------------
+
+suite simple_functions = [] {
+  "empty function with i32 return"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn answer(): i32\n"
+        "  return 42\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "define i32 @answer()")) << ir;
+    expect(contains(ir, "ret i32 42")) << ir;
+  };
+
+  "void function"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn noop(): void\n"
+        "  return\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "define void @noop()")) << ir;
+    expect(contains(ir, "ret void")) << ir;
+  };
+
+  "function with params"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn add(a: i32, b: i32): i32\n"
+        "  return a + b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "define i32 @add(i32 %a, i32 %b)")) << ir;
+    expect(contains(ir, "add")) << ir;
+    expect(contains(ir, "ret i32")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Arithmetic and comparisons
+// ---------------------------------------------------------------------------
+
+suite arithmetic = [] {
+  "integer arithmetic"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn calc(x: i32, y: i32): i32\n"
+        "  return x * y + x - y\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "mul")) << ir;
+    expect(contains(ir, "add")) << ir;
+    expect(contains(ir, "sub")) << ir;
+  };
+
+  "float arithmetic"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn calc(x: f64, y: f64): f64\n"
+        "  return x + y\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "fadd")) << ir;
+  };
+
+  "comparison produces i1"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn lt(a: i32, b: i32): bool\n"
+        "  return a < b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "icmp slt")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Control flow
+// ---------------------------------------------------------------------------
+
+suite control_flow = [] {
+  "if-else produces conditional branch"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn abs(x: i32): i32\n"
+        "  if x < 0:\n"
+        "    return 0 - x\n"
+        "  else:\n"
+        "    return x\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "br i1")) << ir;
+    expect(contains(ir, "ret i32")) << ir;
+  };
+
+  "while loop"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn countdown(n: i32): i32\n"
+        "  let x: i32 = n\n"
+        "  while x > 0:\n"
+        "    x = x - 1\n"
+        "  return x\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "br i1")) << ir;
+    expect(contains(ir, "icmp sgt")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// String literals
+// ---------------------------------------------------------------------------
+
+suite strings = [] {
+  "string constant creates global"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn print(msg: string): void\n"
+        "  return\n"
+        "\n"
+        "fn main(): i32\n"
+        "  print(\"hello\")\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "@.str")) << ir;
+    expect(contains(ir, "hello")) << ir;
+    expect(contains(ir, "dao.string")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Function calls
+// ---------------------------------------------------------------------------
+
+suite calls = [] {
+  "direct function call"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn double(x: i32): i32\n"
+        "  return x + x\n"
+        "\n"
+        "fn main(): i32\n"
+        "  return double(21)\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "call i32 @double")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Extern declarations (no body)
+// ---------------------------------------------------------------------------
+
+suite externs = [] {
+  "declaration without body produces declare"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn print(msg: string): void\n"
+        "  return\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "define void @print")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Module structure
+// ---------------------------------------------------------------------------
+
+suite module_structure = [] {
+  "module contains all functions"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn foo(): i32\n"
+        "  return 1\n"
+        "\n"
+        "fn bar(): i32\n"
+        "  return 2\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "@foo")) << ir;
+    expect(contains(ir, "@bar")) << ir;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Unsupported constructs — must fail explicitly
+// ---------------------------------------------------------------------------
+
+suite unsupported_constructs = [] {
+  "mode parallel is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn test(): i32\n"
+        "  mode parallel =>\n"
+        "    return 1\n"
+        "  return 0\n");
+    expect(pipe.has_errors()) << "mode parallel should fail";
+  };
+
+  "mode unsafe is accepted"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn test(x: i32): i32\n"
+        "  mode unsafe =>\n"
+        "    return x\n"
+        "  return 0\n");
+    expect(!pipe.has_errors()) << "mode unsafe should be no-op";
+  };
+
+  "resource region is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn test(): i32\n"
+        "  resource memory Arena =>\n"
+        "    return 1\n"
+        "  return 0\n");
+    expect(pipe.has_errors()) << "resource should fail";
+  };
+
+  "field assignment is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "struct Point:\n"
+        "  let x: i32\n"
+        "  let y: i32\n"
+        "\n"
+        "fn sety(p: Point): i32\n"
+        "  p.y = 1\n"
+        "  return 0\n");
+    expect(pipe.has_errors()) << "projected store should fail";
+  };
+
+  "field load is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "struct Point:\n"
+        "  let x: i32\n"
+        "  let y: i32\n"
+        "\n"
+        "fn gety(p: Point): i32\n"
+        "  return p.y\n");
+    expect(pipe.has_errors()) << "projected load should fail";
+  };
+
+  "address-of field is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "struct Point:\n"
+        "  let x: i32\n"
+        "  let y: i32\n"
+        "\n"
+        "fn addr(p: Point): *i32\n"
+        "  mode unsafe =>\n"
+        "    return &p.y\n"
+        "  return &p.x\n");
+    expect(pipe.has_errors()) << "projected AddrOf should fail";
+  };
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -1,0 +1,173 @@
+#include "backend/llvm/llvm_type_lowering.h"
+
+#include "frontend/types/type.h"
+
+#include <llvm/IR/DerivedTypes.h>
+
+namespace dao {
+
+LlvmTypeLowering::LlvmTypeLowering(llvm::LLVMContext& ctx) : ctx_(ctx) {}
+
+auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
+  if (type == nullptr) {
+    error_ = "cannot lower null type";
+    return nullptr;
+  }
+
+  switch (type->kind()) {
+  case TypeKind::Builtin: {
+    const auto* b = static_cast<const TypeBuiltin*>(type);
+    return lower_builtin(b->builtin());
+  }
+
+  case TypeKind::Void:
+    return llvm::Type::getVoidTy(ctx_);
+
+  case TypeKind::Pointer: {
+    const auto* p = static_cast<const TypePointer*>(type);
+    auto* pointee = lower(p->pointee());
+    if (pointee == nullptr) {
+      return nullptr;
+    }
+    return llvm::PointerType::getUnqual(pointee);
+  }
+
+  case TypeKind::Function: {
+    const auto* f = static_cast<const TypeFunction*>(type);
+    auto* ret = lower(f->return_type());
+    if (ret == nullptr) {
+      return nullptr;
+    }
+    std::vector<llvm::Type*> params;
+    params.reserve(f->param_types().size());
+    for (const auto* param : f->param_types()) {
+      auto* lowered = lower(param);
+      if (lowered == nullptr) {
+        return nullptr;
+      }
+      params.push_back(lowered);
+    }
+    return llvm::FunctionType::get(ret, params, /*isVarArg=*/false);
+  }
+
+  case TypeKind::Named: {
+    const auto* n = static_cast<const TypeNamed*>(type);
+    if (n->name() == "string") {
+      return string_type();
+    }
+    error_ = "unsupported named type: " + std::string(n->name());
+    return nullptr;
+  }
+
+  case TypeKind::Struct:
+    return lower_struct(static_cast<const TypeStruct*>(type));
+
+  case TypeKind::GenericParam: {
+    const auto* g = static_cast<const TypeGenericParam*>(type);
+    error_ = "cannot lower unresolved generic parameter: " + std::string(g->name());
+    return nullptr;
+  }
+
+  case TypeKind::Enum: {
+    const auto* e = static_cast<const TypeEnum*>(type);
+    error_ = "enum lowering not yet implemented: " + std::string(e->name());
+    return nullptr;
+  }
+  }
+
+  error_ = "unknown type kind";
+  return nullptr;
+}
+
+auto LlvmTypeLowering::is_string_type(const Type* type) -> bool {
+  if (type == nullptr) {
+    return false;
+  }
+  if (type->kind() != TypeKind::Named) {
+    return false;
+  }
+  const auto* n = static_cast<const TypeNamed*>(type);
+  return n->name() == "string" && n->decl_id() == nullptr;
+}
+
+auto LlvmTypeLowering::is_unsigned(const Type* type) -> bool {
+  if (type == nullptr || type->kind() != TypeKind::Builtin) {
+    return false;
+  }
+  const auto* b = static_cast<const TypeBuiltin*>(type);
+  switch (b->builtin()) {
+  case BuiltinKind::U8:
+  case BuiltinKind::U16:
+  case BuiltinKind::U32:
+  case BuiltinKind::U64:
+    return true;
+  default:
+    return false;
+  }
+}
+
+auto LlvmTypeLowering::string_type() -> llvm::StructType* {
+  if (string_type_ == nullptr) {
+    // String representation: { i8*, i64 } — pointer to bytes + length.
+    // This is C-ABI-compatible per CONTRACT_BOOTSTRAP_AND_INTEROP.md.
+    string_type_ = llvm::StructType::create(
+        ctx_,
+        {llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(ctx_)),
+         llvm::Type::getInt64Ty(ctx_)},
+        "dao.string");
+  }
+  return string_type_;
+}
+
+auto LlvmTypeLowering::lower_builtin(BuiltinKind kind) -> llvm::Type* {
+  switch (kind) {
+  case BuiltinKind::I8:
+  case BuiltinKind::U8:
+    return llvm::Type::getInt8Ty(ctx_);
+  case BuiltinKind::I16:
+  case BuiltinKind::U16:
+    return llvm::Type::getInt16Ty(ctx_);
+  case BuiltinKind::I32:
+  case BuiltinKind::U32:
+    return llvm::Type::getInt32Ty(ctx_);
+  case BuiltinKind::I64:
+  case BuiltinKind::U64:
+    return llvm::Type::getInt64Ty(ctx_);
+  case BuiltinKind::F32:
+    return llvm::Type::getFloatTy(ctx_);
+  case BuiltinKind::F64:
+    return llvm::Type::getDoubleTy(ctx_);
+  case BuiltinKind::Bool:
+    return llvm::Type::getInt1Ty(ctx_);
+  }
+  error_ = "unknown builtin kind";
+  return nullptr;
+}
+
+auto LlvmTypeLowering::lower_struct(const TypeStruct* type) -> llvm::Type* {
+  // Check cache first to break potential cycles.
+  auto it = struct_cache_.find(type->decl_id());
+  if (it != struct_cache_.end()) {
+    return it->second;
+  }
+
+  // Create opaque struct first (for potential self-reference).
+  auto* st = llvm::StructType::create(ctx_, "dao." + std::string(type->name()));
+  struct_cache_[type->decl_id()] = st;
+
+  // Lower field types.
+  std::vector<llvm::Type*> field_types;
+  field_types.reserve(type->fields().size());
+  for (const auto& field : type->fields()) {
+    auto* lowered = lower(field.type);
+    if (lowered == nullptr) {
+      return nullptr;
+    }
+    field_types.push_back(lowered);
+  }
+
+  st->setBody(field_types);
+  return st;
+}
+
+} // namespace dao

--- a/compiler/backend/llvm/llvm_type_lowering.h
+++ b/compiler/backend/llvm/llvm_type_lowering.h
@@ -1,0 +1,56 @@
+#ifndef DAO_BACKEND_LLVM_LLVM_TYPE_LOWERING_H
+#define DAO_BACKEND_LLVM_LLVM_TYPE_LOWERING_H
+
+#include "frontend/types/type.h"
+
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Type.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// LlvmTypeLowering — centralized semantic Type* → llvm::Type* mapping.
+//
+// All LLVM type decisions live here. Backend code must not create LLVM
+// types ad hoc; it must go through this layer.
+// ---------------------------------------------------------------------------
+
+class LlvmTypeLowering {
+public:
+  explicit LlvmTypeLowering(llvm::LLVMContext& ctx);
+
+  // Lower a Dao semantic type to an LLVM type.
+  // Returns nullptr and sets error if the type cannot be lowered.
+  auto lower(const Type* type) -> llvm::Type*;
+
+  // Check whether a type is the predeclared string type.
+  static auto is_string_type(const Type* type) -> bool;
+
+  // Check whether a type is an unsigned integer builtin.
+  static auto is_unsigned(const Type* type) -> bool;
+
+  // Get the LLVM string representation type: { i8*, i64 } (ptr + length).
+  auto string_type() -> llvm::StructType*;
+
+  // Access the last lowering error (empty if none).
+  [[nodiscard]] auto error() const -> const std::string& { return error_; }
+
+private:
+  llvm::LLVMContext& ctx_;
+  llvm::StructType* string_type_ = nullptr;
+  std::string error_;
+
+  // Cache for struct type lowering to break cycles.
+  std::unordered_map<const void*, llvm::StructType*> struct_cache_;
+
+  auto lower_builtin(BuiltinKind kind) -> llvm::Type*;
+  auto lower_struct(const TypeStruct* type) -> llvm::Type*;
+};
+
+} // namespace dao
+
+#endif // DAO_BACKEND_LLVM_LLVM_TYPE_LOWERING_H

--- a/compiler/driver/CMakeLists.txt
+++ b/compiler/driver/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(daoc main.cpp)
-target_link_libraries(daoc PRIVATE dao_analysis dao_ir dao_frontend)
+target_link_libraries(daoc PRIVATE dao_analysis dao_backend_llvm dao_ir dao_frontend)

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -8,9 +8,12 @@
 #include "ir/hir/hir_builder.h"
 #include "ir/hir/hir_context.h"
 #include "ir/hir/hir_printer.h"
+#include "backend/llvm/llvm_backend.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
 #include "ir/mir/mir_printer.h"
+
+#include <llvm/IR/LLVMContext.h>
 
 #include <cstdlib>
 #include <filesystem>
@@ -331,6 +334,80 @@ void cmd_mir(const std::filesystem::path& path) {
   }
 }
 
+// Build and emit LLVM IR. Output is deterministic.
+void cmd_llvm_ir(const std::filesystem::path& path) {
+  auto result = lex_and_parse(path);
+  if (result.parse_result.file == nullptr) {
+    return;
+  }
+
+  auto resolve_result = dao::resolve(*result.parse_result.file);
+
+  for (const auto& diag : resolve_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+  }
+
+  dao::TypeContext types;
+  auto check_result =
+      dao::typecheck(*result.parse_result.file, resolve_result, types);
+
+  bool has_errors = !resolve_result.diagnostics.empty();
+
+  for (const auto& diag : check_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    auto severity = diag.severity == dao::Severity::Error ? "error" : "warning";
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": " << severity << ": " << diag.message << "\n";
+    if (diag.severity == dao::Severity::Error) {
+      has_errors = true;
+    }
+  }
+
+  if (has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  dao::HirContext hir_ctx;
+  auto hir_result = dao::build_hir(*result.parse_result.file, resolve_result,
+                                   check_result, hir_ctx);
+
+  if (hir_result.module == nullptr) {
+    return;
+  }
+
+  dao::MirContext mir_ctx;
+  auto mir_result = dao::build_mir(*hir_result.module, mir_ctx, types);
+
+  for (const auto& diag : mir_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+    has_errors = true;
+  }
+
+  if (mir_result.module == nullptr || has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  llvm::LLVMContext llvm_ctx;
+  dao::LlvmBackend backend(llvm_ctx);
+  auto llvm_result = backend.lower(*mir_result.module);
+
+  for (const auto& diag : llvm_result.diagnostics) {
+    auto loc = result.source.line_col(diag.span.offset);
+    std::cerr << path.filename().string() << ":" << loc.line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+  }
+
+  if (llvm_result.module == nullptr || !llvm_result.diagnostics.empty()) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  dao::LlvmBackend::print_ir(std::cout, *llvm_result.module);
+}
+
 // Pretty-print AST. Output is deterministic and suitable for golden-file testing.
 void cmd_ast(const std::filesystem::path& path) {
   auto result = lex_and_parse(path);
@@ -344,7 +421,7 @@ void cmd_ast(const std::filesystem::path& path) {
 auto main(int argc, char* argv[]) -> int {
   if (argc < 2) {
     std::cerr << "usage: daoc <command> <file>\n";
-    std::cerr << "commands: lex, parse, ast, tokens, resolve, check, hir, mir\n";
+    std::cerr << "commands: lex, parse, ast, tokens, resolve, check, hir, mir, llvm-ir\n";
     return EXIT_FAILURE;
   }
 
@@ -452,6 +529,21 @@ auto main(int argc, char* argv[]) -> int {
       return EXIT_FAILURE;
     }
     cmd_mir(mir_path);
+    return EXIT_SUCCESS;
+  }
+
+  // daoc llvm-ir <file>
+  if (arg1 == "llvm-ir") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc llvm-ir <file>\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path llvm_ir_path(argv[2]);
+    if (!std::filesystem::exists(llvm_ir_path)) {
+      std::cerr << "error: file not found: " << llvm_ir_path << "\n";
+      return EXIT_FAILURE;
+    }
+    cmd_llvm_ir(llvm_ir_path);
     return EXIT_SUCCESS;
   }
 

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -281,8 +281,10 @@ private:
   void print_return(const ReturnStatementNode& node) {
     indent();
     out_ << "ReturnStatement\n";
-    Scope scope(depth_);
-    print_expr(*node.value());
+    if (node.value() != nullptr) {
+      Scope scope(depth_);
+      print_expr(*node.value());
+    }
   }
 
   void print_expr_stmt(const ExpressionStatementNode& node) {

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -396,7 +396,12 @@ private:
 
   auto parse_return_statement() -> ReturnStatementNode* {
     const auto& kw = consume(TokenKind::KwReturn);
-    auto* value = parse_expression();
+    Expr* value = nullptr;
+    if (peek_kind() != TokenKind::Newline &&
+        peek_kind() != TokenKind::Dedent &&
+        peek_kind() != TokenKind::Eof) {
+      value = parse_expression();
+    }
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
     Span span = span_from(kw.span);

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -213,10 +213,15 @@ suite typecheck_control_flow = [] {
 // ---------------------------------------------------------------------------
 
 suite typecheck_void = [] {
-  // NOTE: bare "return" (without expression) is not yet supported by the
-  // parser. When it is, add:
-  //   "void function with bare return" — should typecheck cleanly
-  //   "bare return in non-void function" — should error
+  "void function with bare return"_test = [] {
+    auto result = check_source("fn noop(): void\n    return\n");
+    expect(is_ok(result));
+  };
+
+  "bare return in non-void function"_test = [] {
+    auto result = check_source("fn bad(): i32\n    return\n");
+    expect(has_error_containing(result, "bare return"));
+  };
 
   "void function without explicit return"_test = [] {
     auto result = check_source("fn noop(): void\n    let x = 1\n");
@@ -301,9 +306,6 @@ suite typecheck_negative = [] {
         "    *p\n");
     expect(has_error_containing(result, "mode unsafe"));
   };
-
-  // "bare return in non-void function" — deferred: parser does not yet
-  // support bare return.
 
   "logical not on non-bool"_test = [] {
     auto result = check_source("fn bad(): bool -> !42\n");

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeDeps, CMakeToolchain
+
+
+class DaoConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def requirements(self):
+        self.requires("boost-ext-ut/2.3.1")
+        self.requires("cpp-httplib/0.18.3")
+        self.requires("nlohmann_json/3.11.3")
+        self.requires("llvm-core/19.1.7")
+
+    def configure(self):
+        self.options["llvm-core"].with_z3 = False
+        self.options["llvm-core"].exceptions = True
+        self.options["llvm-core"].rtti = True
+        self.options["llvm-core"].targets = "X86"
+        self.options["llvm-core"].with_ffi = False
+        self.options["llvm-core"].with_libedit = False
+        self.options["llvm-core"].with_xml2 = False
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,8 +1,0 @@
-[requires]
-boost-ext-ut/2.3.1
-cpp-httplib/0.18.3
-nlohmann_json/3.11.3
-
-[generators]
-CMakeDeps
-CMakeToolchain

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -73,7 +73,7 @@ Compiler-internal target-agnostic representations.
 
 Target-specific lowering.
 
-- `llvm/` — initial backend target
+- `llvm/` — initial backend target: MIR→LLVM IR lowering, type lowering, function/block/instruction emission, textual IR output
 
 ### `compiler/driver/`
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -24,15 +24,13 @@ for the Dao compiler project. It is subordinate to `CLAUDE.md` and
 ### Package manager
 
 - **Conan 2.x** in manifest mode
-- `conanfile.txt` initially; upgrade to `conanfile.py` if custom logic
-  is needed
+- `conanfile.py` with custom logic for LLVM option configuration
 - Compiler profiles managed via Conan profiles
   (e.g. `profiles/clang-17-debug`, `profiles/gcc-13-release`)
 - One `conan.lock` per profile, committed under `locks/`
   (e.g. `locks/clang-17-debug.lock`); lockfiles are
   configuration-specific and must not be shared across profiles
-- LLVM is a system dependency found via `find_package`, not managed
-  by Conan
+- LLVM is managed by Conan like all other dependencies
 
 ### Test framework
 
@@ -89,7 +87,7 @@ Deliverables:
 
 - `CMakeLists.txt` (root) — top-level build with C++23 target
 - `CMakePresets.json` — presets for clang debug/release
-- `conanfile.txt` — declares boost-ext/ut 2.3.1
+- `conanfile.py` — declares boost-ext/ut, cpp-httplib, nlohmann_json, llvm-core
 - `profiles/clang-17-debug` — Conan profile for primary dev
 - `locks/clang-17-debug.lock` — committed lockfile for primary profile
 - `.clang-format` — LLVM base + Dao overrides

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -18,12 +18,13 @@ Defines the currently frozen syntax surface for Dao's early design phase.
 ```dao
 fn read(ptr: *i32): i32
     let value: i32
-    value
+    return value
 ```
 
 Rules:
 - no token follows the return type
 - the body begins on the next indented line
+- `return` is always required; there is no implicit tail-expression return
 
 ### Expression-bodied form
 

--- a/examples/astar.dao
+++ b/examples/astar.dao
@@ -19,4 +19,4 @@ fn a_star(g: Graph, start: NodeId, goal: NodeId): List[NodeId]
             if current == goal:
                 return reconstruct_path(came_from, start, goal)
 
-        List[NodeId]()
+        return List[NodeId]()

--- a/examples/hello.dao
+++ b/examples/hello.dao
@@ -1,6 +1,6 @@
 fn print(msg: string): void
-    0
+    return
 
 fn main(): i32
     print("hello, dao")
-    0
+    return 0

--- a/examples/unsafe.dao
+++ b/examples/unsafe.dao
@@ -4,4 +4,4 @@ fn read(ptr: *i32): i32
     mode unsafe =>
         value = *ptr
 
-    value
+    return value

--- a/profiles/clang-21-debug
+++ b/profiles/clang-21-debug
@@ -3,8 +3,10 @@ arch=x86_64
 build_type=Debug
 compiler=clang
 compiler.cppstd=23
+compiler.libcxx=libstdc++11
 compiler.version=21
 os=Linux
 
 [conf]
 tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
+termcap/*:tools.build:cflags=["-std=gnu11"]

--- a/spec/syntax_probes/astar.dao
+++ b/spec/syntax_probes/astar.dao
@@ -19,4 +19,4 @@ fn a_star(g: Graph, start: NodeId, goal: NodeId): List[NodeId]
             if current == goal:
                 return reconstruct_path(came_from, start, goal)
 
-        List[NodeId]()
+        return List[NodeId]()

--- a/spec/syntax_probes/functions.dao
+++ b/spec/syntax_probes/functions.dao
@@ -6,4 +6,4 @@ fn read(ptr: *i32): i32
     mode unsafe =>
         value = *ptr
 
-    value
+    return value

--- a/spec/syntax_probes/modes_and_resources.dao
+++ b/spec/syntax_probes/modes_and_resources.dao
@@ -7,4 +7,4 @@ fn search(start: NodeId, goal: NodeId): List[NodeId]
         mode parallel =>
             let frontier = PriorityQueue[NodeId]()
             frontier.push(start)
-            [goal]
+            return [goal]

--- a/spec/syntax_probes/pipelines.dao
+++ b/spec/syntax_probes/pipelines.dao
@@ -4,6 +4,6 @@ fn filter(pred: i32): i32 -> 0
 fn map(f: i32): i32 -> 0
 
 fn positive_squares(xs: List[i32]): List[i32]
-    xs
+    return xs
     |> filter |x| -> x > 0
     |> map |x| -> x * x

--- a/testdata/ast/examples_astar.ast
+++ b/testdata/ast/examples_astar.ast
@@ -62,7 +62,7 @@ File
                   Identifier came_from
                   Identifier start
                   Identifier goal
-      ExpressionStatement
+      ReturnStatement
         CallExpr
           Callee
             IndexExpr

--- a/testdata/ast/examples_hello.ast
+++ b/testdata/ast/examples_hello.ast
@@ -2,8 +2,7 @@ File
   FunctionDecl print
     Param msg: string
     ReturnType: void
-    ExpressionStatement
-      IntLiteral 0
+    ReturnStatement
   FunctionDecl main
     ReturnType: i32
     ExpressionStatement
@@ -12,5 +11,5 @@ File
           Identifier print
         Args
           StringLiteral "hello, dao"
-    ExpressionStatement
+    ReturnStatement
       IntLiteral 0

--- a/testdata/ast/examples_unsafe.ast
+++ b/testdata/ast/examples_unsafe.ast
@@ -10,5 +10,5 @@ File
         Value
           UnaryExpr *
             Identifier ptr
-    ExpressionStatement
+    ReturnStatement
       Identifier value

--- a/testdata/ast/probes_astar.ast
+++ b/testdata/ast/probes_astar.ast
@@ -62,7 +62,7 @@ File
                   Identifier came_from
                   Identifier start
                   Identifier goal
-      ExpressionStatement
+      ReturnStatement
         CallExpr
           Callee
             IndexExpr

--- a/testdata/ast/probes_functions.ast
+++ b/testdata/ast/probes_functions.ast
@@ -19,5 +19,5 @@ File
         Value
           UnaryExpr *
             Identifier ptr
-    ExpressionStatement
+    ReturnStatement
       Identifier value

--- a/testdata/ast/probes_modes_and_resources.ast
+++ b/testdata/ast/probes_modes_and_resources.ast
@@ -22,6 +22,6 @@ File
                 Identifier frontier
             Args
               Identifier start
-        ExpressionStatement
+        ReturnStatement
           ListLiteral
             Identifier goal

--- a/testdata/ast/probes_pipelines.ast
+++ b/testdata/ast/probes_pipelines.ast
@@ -13,7 +13,7 @@ File
   FunctionDecl positive_squares
     Param xs: List[i32]
     ReturnType: List[i32]
-    ExpressionStatement
+    ReturnStatement
       PipeExpr
         Identifier xs
         CallExpr


### PR DESCRIPTION
## Summary

Implements the initial LLVM backend (Task 11), completing the compiler pipeline from Dao source through MIR to LLVM IR. Also enforces explicit `return` as a language rule, adds bare `return` support for void functions, and hardens the backend against silent miscompilation.

## Highlights

- **LlvmTypeLowering**: all builtins, void, pointer, string as `{i8*, i64}`, struct layout; explicit failure for enums/generics
- **LlvmBackend**: full instruction lowering — constants, unary/binary ops (signed/unsigned/float), store/load, FnRef, call, Br/CondBr/Return
- **Explicit failure contract**: projected places (field/index/deref), `mode parallel`/`gpu`, resource regions, lambda, iteration all rejected with diagnostics — no silent miscompilation
- **Backend API safety**: module nulled on error; callers cannot consume partial IR
- **`daoc llvm-ir` command**: fail-on-error exit semantics, no partial IR on stdout
- **Explicit return enforced**: `CONTRACT_SYNTAX_SURFACE.md` updated — no implicit tail-expression return; parser supports bare `return` for void functions
- **Conan migration**: `conanfile.txt` → `conanfile.py` for LLVM option configuration (X86-only, reduced deps)
- **24 backend tests**: type lowering, functions, arithmetic, control flow, strings, calls, module structure, plus negative tests for projected places and mode/resource rejection

## Test plan

- [x] `ctest --test-dir build/debug` — 10/10 pass (including 24 new backend assertions)
- [x] `daoc llvm-ir` exits 0 on valid input, exits 1 with diagnostic on unsupported constructs
- [x] Projected places (`p.y = 1`, `&p.y`) rejected with diagnostic
- [x] `mode parallel =>` and `resource memory =>` rejected; `mode unsafe =>` accepted as no-op
- [x] All examples/probes updated to explicit `return`, golden ASTs regenerated

## Breaking Changes

- `conanfile.txt` removed, replaced by `conanfile.py` — re-run `conan install`
- Dao now requires explicit `return` in all block-bodied functions; implicit tail-expression return is no longer accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)