### PR TITLE
refactor(ast): ♻️ replace OOP class hierarchy with std::variant containers

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -160,10 +160,10 @@ public:
   }
 
   void visit_file(const FileNode& file) {
-    for (const auto* imp : file.imports()) {
-      visit_import(static_cast<const ImportNode&>(*imp));
+    for (const auto* imp : file.imports) {
+      visit_import(*imp);
     }
-    for (const auto* decl : file.declarations()) {
+    for (const auto* decl : file.declarations) {
       visit_decl(*decl);
     }
   }
@@ -209,7 +209,7 @@ private:
   void visit_import(const ImportNode& node) {
     // Leading segments of an import path are module references.
     // The last segment is the binding site — classified as decl.module.
-    auto spans = segment_spans(node.path());
+    auto spans = segment_spans(node.path);
     for (size_t i = 0; i < spans.size(); ++i) {
       if (i + 1 < spans.size()) {
         classify(spans[i].second, "use.module");
@@ -224,23 +224,24 @@ private:
   void visit_decl(const Decl& decl) {
     switch (decl.kind()) {
     case NodeKind::FunctionDecl:
-      visit_function(static_cast<const FunctionDeclNode&>(decl));
+      visit_function(decl);
       break;
     case NodeKind::ClassDecl:
-      visit_class(static_cast<const ClassDeclNode&>(decl));
+      visit_class(decl);
       break;
     case NodeKind::AliasDecl:
-      visit_alias(static_cast<const AliasDeclNode&>(decl));
+      visit_alias(decl);
       break;
     default:
       break;
     }
   }
 
-  void visit_function(const FunctionDeclNode& fn) {
-    classify(fn.name_span(), "decl.function");
+  void visit_function(const Decl& decl) {
+    const auto& fn = decl.as<FunctionDecl>();
+    classify(fn.name_span, "decl.function");
 
-    for (const auto& param : fn.params()) {
+    for (const auto& param : fn.params) {
       // Parameter binders are declaration sites, not uses. The frozen
       // taxonomy has use.variable.param but no decl.variable.param.
       // Omit until name resolution can classify actual references.
@@ -249,35 +250,37 @@ private:
       }
     }
 
-    if (fn.return_type() != nullptr) {
-      visit_type(*fn.return_type());
+    if (fn.return_type != nullptr) {
+      visit_type(*fn.return_type);
     }
 
-    for (const auto* stmt : fn.body()) {
+    for (const auto* stmt : fn.body) {
       visit_stmt(*stmt);
     }
 
-    if (fn.expr_body() != nullptr) {
-      visit_expr(*fn.expr_body());
+    if (fn.expr_body != nullptr) {
+      visit_expr(*fn.expr_body);
     }
   }
 
-  void visit_class(const ClassDeclNode& st) {
-    classify(st.name_span(), "decl.type");
+  void visit_class(const Decl& decl) {
+    const auto& st = decl.as<ClassDecl>();
+    classify(st.name_span, "decl.type");
 
-    for (const auto* field : st.fields()) {
-      classify(field->name_span(), "decl.field");
-      if (field->type() != nullptr) {
-        visit_type(*field->type());
+    for (const auto* field : st.fields) {
+      classify(field->name_span, "decl.field");
+      if (field->type != nullptr) {
+        visit_type(*field->type);
       }
     }
   }
 
-  void visit_alias(const AliasDeclNode& alias) {
-    classify(alias.name_span(), "decl.type");
+  void visit_alias(const Decl& decl) {
+    const auto& alias = decl.as<AliasDecl>();
+    classify(alias.name_span, "decl.type");
 
-    if (alias.type() != nullptr) {
-      visit_type(*alias.type());
+    if (alias.type != nullptr) {
+      visit_type(*alias.type);
     }
   }
 
@@ -286,89 +289,89 @@ private:
   void visit_stmt(const Stmt& stmt) {
     switch (stmt.kind()) {
     case NodeKind::LetStatement: {
-      const auto& let_stmt = static_cast<const LetStatementNode&>(stmt);
+      const auto& let_stmt = stmt.as<LetStatement>();
       // Let binders are declaration sites, not uses. The frozen
       // taxonomy has use.variable.local but no decl.variable.local.
       // Omit until name resolution can classify actual references.
-      if (let_stmt.type() != nullptr) {
-        visit_type(*let_stmt.type());
+      if (let_stmt.type != nullptr) {
+        visit_type(*let_stmt.type);
       }
-      if (let_stmt.initializer() != nullptr) {
-        visit_expr(*let_stmt.initializer());
+      if (let_stmt.initializer != nullptr) {
+        visit_expr(*let_stmt.initializer);
       }
       break;
     }
     case NodeKind::Assignment: {
-      const auto& assign = static_cast<const AssignmentNode&>(stmt);
-      visit_expr(*assign.target());
-      visit_expr(*assign.value());
+      const auto& assign = stmt.as<Assignment>();
+      visit_expr(*assign.target);
+      visit_expr(*assign.value);
       break;
     }
     case NodeKind::IfStatement: {
-      const auto& if_stmt = static_cast<const IfStatementNode&>(stmt);
-      visit_expr(*if_stmt.condition());
-      for (const auto* s : if_stmt.then_body()) {
+      const auto& if_stmt = stmt.as<IfStatement>();
+      visit_expr(*if_stmt.condition);
+      for (const auto* s : if_stmt.then_body) {
         visit_stmt(*s);
       }
-      for (const auto* s : if_stmt.else_body()) {
+      for (const auto* s : if_stmt.else_body) {
         visit_stmt(*s);
       }
       break;
     }
     case NodeKind::WhileStatement: {
-      const auto& while_stmt = static_cast<const WhileStatementNode&>(stmt);
-      visit_expr(*while_stmt.condition());
-      for (const auto* s : while_stmt.body()) {
+      const auto& while_stmt = stmt.as<WhileStatement>();
+      visit_expr(*while_stmt.condition);
+      for (const auto* s : while_stmt.body) {
         visit_stmt(*s);
       }
       break;
     }
     case NodeKind::ForStatement: {
-      const auto& for_stmt = static_cast<const ForStatementNode&>(stmt);
+      const auto& for_stmt = stmt.as<ForStatement>();
       // For-loop binders are declaration sites — omit like let binders.
-      visit_expr(*for_stmt.iterable());
-      for (const auto* s : for_stmt.body()) {
+      visit_expr(*for_stmt.iterable);
+      for (const auto* s : for_stmt.body) {
         visit_stmt(*s);
       }
       break;
     }
     case NodeKind::ModeBlock: {
-      const auto& mode = static_cast<const ModeBlockNode&>(stmt);
-      auto mode_name = mode.mode_name();
+      const auto& mode = stmt.as<ModeBlock>();
+      auto mode_name = mode.mode_name;
       if (mode_name == "unsafe") {
-        classify(mode.name_span(), "mode.unsafe");
+        classify(mode.name_span, "mode.unsafe");
       } else if (mode_name == "gpu") {
-        classify(mode.name_span(), "mode.gpu");
+        classify(mode.name_span, "mode.gpu");
       } else if (mode_name == "parallel") {
-        classify(mode.name_span(), "mode.parallel");
+        classify(mode.name_span, "mode.parallel");
       }
-      for (const auto* s : mode.body()) {
+      for (const auto* s : mode.body) {
         visit_stmt(*s);
       }
       break;
     }
     case NodeKind::ResourceBlock: {
-      const auto& res = static_cast<const ResourceBlockNode&>(stmt);
-      auto kind = res.resource_kind();
+      const auto& res = stmt.as<ResourceBlock>();
+      auto kind = res.resource_kind;
       if (kind == "memory") {
-        classify(res.kind_span(), "resource.kind.memory");
+        classify(res.kind_span, "resource.kind.memory");
       }
-      classify(res.name_span(), "resource.binding");
-      for (const auto* s : res.body()) {
+      classify(res.name_span, "resource.binding");
+      for (const auto* s : res.body) {
         visit_stmt(*s);
       }
       break;
     }
     case NodeKind::ReturnStatement: {
-      const auto& ret = static_cast<const ReturnStatementNode&>(stmt);
-      if (ret.value() != nullptr) {
-        visit_expr(*ret.value());
+      const auto& ret = stmt.as<ReturnStatement>();
+      if (ret.value != nullptr) {
+        visit_expr(*ret.value);
       }
       break;
     }
     case NodeKind::ExpressionStatement: {
-      const auto& expr_stmt = static_cast<const ExpressionStatementNode&>(stmt);
-      visit_expr(*expr_stmt.expr());
+      const auto& expr_stmt = stmt.as<ExpressionStatement>();
+      visit_expr(*expr_stmt.expr);
       break;
     }
     default:
@@ -381,55 +384,55 @@ private:
   void visit_expr(const Expr& expr) {
     switch (expr.kind()) {
     case NodeKind::BinaryExpr: {
-      const auto& bin = static_cast<const BinaryExprNode&>(expr);
-      visit_expr(*bin.left());
-      visit_expr(*bin.right());
+      const auto& bin = expr.as<BinaryExpr>();
+      visit_expr(*bin.left);
+      visit_expr(*bin.right);
       break;
     }
     case NodeKind::UnaryExpr: {
-      const auto& unary = static_cast<const UnaryExprNode&>(expr);
-      visit_expr(*unary.operand());
+      const auto& unary = expr.as<UnaryExpr>();
+      visit_expr(*unary.operand);
       break;
     }
     case NodeKind::CallExpr: {
-      const auto& call = static_cast<const CallExprNode&>(expr);
-      visit_expr(*call.callee());
-      for (const auto* arg : call.args()) {
+      const auto& call = expr.as<CallExpr>();
+      visit_expr(*call.callee);
+      for (const auto* arg : call.args) {
         visit_expr(*arg);
       }
       break;
     }
     case NodeKind::IndexExpr: {
-      const auto& idx = static_cast<const IndexExprNode&>(expr);
-      visit_expr(*idx.object());
-      for (const auto* i : idx.indices()) {
+      const auto& idx = expr.as<IndexExpr>();
+      visit_expr(*idx.object);
+      for (const auto* i : idx.indices) {
         visit_expr(*i);
       }
       break;
     }
     case NodeKind::FieldExpr: {
-      const auto& field = static_cast<const FieldExprNode&>(expr);
-      visit_expr(*field.object());
-      classify(field.field_span(), "use.field");
+      const auto& field = expr.as<FieldExpr>();
+      visit_expr(*field.object);
+      classify(field.field_span, "use.field");
       break;
     }
     case NodeKind::PipeExpr: {
-      const auto& pipe = static_cast<const PipeExprNode&>(expr);
-      visit_expr(*pipe.left());
-      visit_expr(*pipe.right());
+      const auto& pipe = expr.as<PipeExpr>();
+      visit_expr(*pipe.left);
+      visit_expr(*pipe.right);
       break;
     }
     case NodeKind::Lambda: {
-      const auto& lam = static_cast<const LambdaNode&>(expr);
-      for (const auto& [name, span] : lam.params()) {
+      const auto& lam = expr.as<LambdaExpr>();
+      for (const auto& [name, span] : lam.params) {
         classify(span, "lambda.param");
       }
-      visit_expr(*lam.body());
+      visit_expr(*lam.body);
       break;
     }
     case NodeKind::ListLiteral: {
-      const auto& list = static_cast<const ListLiteralNode&>(expr);
-      for (const auto* elem : list.elements()) {
+      const auto& list = expr.as<ListLiteral>();
+      for (const auto* elem : list.elements) {
         visit_expr(*elem);
       }
       break;
@@ -458,22 +461,22 @@ private:
   void visit_type(const TypeNode& type) {
     switch (type.kind()) {
     case NodeKind::NamedType: {
-      const auto& named = static_cast<const NamedTypeNode&>(type);
+      const auto& named = type.as<NamedType>();
       // Classify the type name: leading segments are use.module,
       // the final segment is type.builtin or type.nominal.
-      if (!named.name().segments.empty()) {
-        auto type_name = named.name().segments.back();
+      if (!named.name.segments.empty()) {
+        auto type_name = named.name.segments.back();
         auto category = is_builtin_type(type_name) ? "type.builtin" : "type.nominal";
-        classify_qualified(named.name(), category);
+        classify_qualified(named.name, category);
       }
-      for (const auto* arg : named.type_args()) {
+      for (const auto* arg : named.type_args) {
         visit_type(*arg);
       }
       break;
     }
     case NodeKind::PointerType: {
-      const auto& ptr = static_cast<const PointerTypeNode&>(type);
-      visit_type(*ptr.pointee());
+      const auto& ptr = type.as<PointerType>();
+      visit_type(*ptr.pointee);
       break;
     }
     default:

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -119,8 +119,8 @@ auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
 void cmd_parse(const std::filesystem::path& path) {
   auto result = lex_and_parse(path);
   if (result.parse_result.file != nullptr) {
-    std::cout << "File: " << result.parse_result.file->imports().size() << " imports, "
-              << result.parse_result.file->declarations().size() << " declarations\n";
+    std::cout << "File: " << result.parse_result.file->imports.size() << " imports, "
+              << result.parse_result.file->declarations.size() << " declarations\n";
   }
 }
 

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -2,6 +2,62 @@
 
 namespace dao {
 
+// ---------------------------------------------------------------------------
+// kind() — derived from active variant alternative.
+// ---------------------------------------------------------------------------
+
+auto Decl::kind() const -> NodeKind {
+  return std::visit(overloaded{
+      [](const FunctionDecl&) { return NodeKind::FunctionDecl; },
+      [](const ClassDecl&) { return NodeKind::ClassDecl; },
+      [](const AliasDecl&) { return NodeKind::AliasDecl; },
+  }, payload);
+}
+
+auto Stmt::kind() const -> NodeKind {
+  return std::visit(overloaded{
+      [](const LetStatement&) { return NodeKind::LetStatement; },
+      [](const Assignment&) { return NodeKind::Assignment; },
+      [](const IfStatement&) { return NodeKind::IfStatement; },
+      [](const WhileStatement&) { return NodeKind::WhileStatement; },
+      [](const ForStatement&) { return NodeKind::ForStatement; },
+      [](const ModeBlock&) { return NodeKind::ModeBlock; },
+      [](const ResourceBlock&) { return NodeKind::ResourceBlock; },
+      [](const ReturnStatement&) { return NodeKind::ReturnStatement; },
+      [](const ExpressionStatement&) { return NodeKind::ExpressionStatement; },
+  }, payload);
+}
+
+auto Expr::kind() const -> NodeKind {
+  return std::visit(overloaded{
+      [](const BinaryExpr&) { return NodeKind::BinaryExpr; },
+      [](const UnaryExpr&) { return NodeKind::UnaryExpr; },
+      [](const CallExpr&) { return NodeKind::CallExpr; },
+      [](const IndexExpr&) { return NodeKind::IndexExpr; },
+      [](const FieldExpr&) { return NodeKind::FieldExpr; },
+      [](const PipeExpr&) { return NodeKind::PipeExpr; },
+      [](const LambdaExpr&) { return NodeKind::Lambda; },
+      [](const IntLiteral&) { return NodeKind::IntLiteral; },
+      [](const FloatLiteral&) { return NodeKind::FloatLiteral; },
+      [](const StringLiteral&) { return NodeKind::StringLiteral; },
+      [](const BoolLiteral&) { return NodeKind::BoolLiteral; },
+      [](const ListLiteral&) { return NodeKind::ListLiteral; },
+      [](const IdentifierExpr&) { return NodeKind::Identifier; },
+      [](const QualifiedName&) { return NodeKind::QualifiedName; },
+  }, payload);
+}
+
+auto TypeNode::kind() const -> NodeKind {
+  return std::visit(overloaded{
+      [](const NamedType&) { return NodeKind::NamedType; },
+      [](const PointerType&) { return NodeKind::PointerType; },
+  }, payload);
+}
+
+// ---------------------------------------------------------------------------
+// node_kind_name
+// ---------------------------------------------------------------------------
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto node_kind_name(NodeKind kind) -> const char* {
   switch (kind) {

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -3,11 +3,12 @@
 
 #include "frontend/diagnostics/source.h"
 #include "support/arena.h"
+#include "support/variant.h"
 
-#include <cassert>
 #include <cstdint>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace dao {
@@ -84,68 +85,13 @@ enum class NodeKind : std::uint8_t {
 };
 
 // ---------------------------------------------------------------------------
-// Base classes
+// Forward declarations for recursive references.
 // ---------------------------------------------------------------------------
 
-class AstNode {
-public:
-  explicit AstNode(NodeKind kind, Span span) : kind_(kind), span_(span) {
-  }
-  virtual ~AstNode() = default;
-
-  AstNode(const AstNode&) = delete;
-  auto operator=(const AstNode&) -> AstNode& = delete;
-  AstNode(AstNode&&) = delete;
-  auto operator=(AstNode&&) -> AstNode& = delete;
-
-  [[nodiscard]] auto kind() const -> NodeKind {
-    return kind_;
-  }
-  [[nodiscard]] auto span() const -> Span {
-    return span_;
-  }
-
-protected:
-  void set_span(Span span) {
-    span_ = span;
-  }
-
-private:
-  NodeKind kind_;
-  Span span_;
-};
-
-class Decl : public AstNode {
-public:
-  using AstNode::AstNode;
-  static auto classof(const AstNode* node) -> bool {
-    return node->kind() >= NodeKind::FunctionDecl && node->kind() <= NodeKind::AliasDecl;
-  }
-};
-
-class Stmt : public AstNode {
-public:
-  using AstNode::AstNode;
-  static auto classof(const AstNode* node) -> bool {
-    return node->kind() >= NodeKind::LetStatement && node->kind() <= NodeKind::ExpressionStatement;
-  }
-};
-
-class Expr : public AstNode {
-public:
-  using AstNode::AstNode;
-  static auto classof(const AstNode* node) -> bool {
-    return node->kind() >= NodeKind::BinaryExpr && node->kind() <= NodeKind::QualifiedName;
-  }
-};
-
-class TypeNode : public AstNode {
-public:
-  using AstNode::AstNode;
-  static auto classof(const AstNode* node) -> bool {
-    return node->kind() >= NodeKind::NamedType && node->kind() <= NodeKind::PointerType;
-  }
-};
+struct Decl;
+struct Stmt;
+struct Expr;
+struct TypeNode;
 
 // ---------------------------------------------------------------------------
 // Utility types
@@ -190,650 +136,275 @@ enum class UnaryOp : std::uint8_t {
 };
 
 // ---------------------------------------------------------------------------
-// File-level nodes
+// File-level nodes — standalone, not part of any variant.
 // ---------------------------------------------------------------------------
 
-class FileNode : public AstNode {
-public:
-  FileNode(Span span, std::vector<AstNode*> imports, std::vector<Decl*> declarations)
-      : AstNode(NodeKind::File, span), imports_(std::move(imports)),
-        declarations_(std::move(declarations)) {
-  }
-
-  [[nodiscard]] auto imports() const -> const std::vector<AstNode*>& {
-    return imports_;
-  }
-  [[nodiscard]] auto declarations() const -> const std::vector<Decl*>& {
-    return declarations_;
-  }
-
-private:
-  std::vector<AstNode*> imports_;
-  std::vector<Decl*> declarations_;
+struct ImportNode {
+  Span span;
+  QualifiedPath path;
 };
 
-class ImportNode : public AstNode {
-public:
-  ImportNode(Span span, QualifiedPath path)
-      : AstNode(NodeKind::Import, span), path_(std::move(path)) {
-  }
-
-  [[nodiscard]] auto path() const -> const QualifiedPath& {
-    return path_;
-  }
-
-private:
-  QualifiedPath path_;
+struct FileNode {
+  Span span;
+  std::vector<ImportNode*> imports;
+  std::vector<Decl*> declarations;
 };
 
 // ---------------------------------------------------------------------------
-// Declarations
+// Class field specifier — standalone, not part of any variant.
 // ---------------------------------------------------------------------------
 
-class FunctionDeclNode : public Decl {
-public:
-  FunctionDeclNode(Span span,
-                   std::string_view name,
-                   Span name_span,
-                   std::vector<Param> params,
-                   TypeNode* return_type,
-                   std::vector<Stmt*> body,
-                   Expr* expr_body,
-                   bool is_extern = false)
-      : Decl(NodeKind::FunctionDecl, span), name_(name), name_span_(name_span),
-        params_(std::move(params)), return_type_(return_type), body_(std::move(body)),
-        expr_body_(expr_body), is_extern_(is_extern) {
-  }
+struct FieldSpec {
+  Span span;
+  std::string_view name;
+  Span name_span;
+  TypeNode* type;
+};
 
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto params() const -> const std::vector<Param>& {
-    return params_;
-  }
-  [[nodiscard]] auto return_type() const -> TypeNode* {
-    return return_type_;
-  }
-  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
-    return body_;
-  }
-  [[nodiscard]] auto expr_body() const -> Expr* {
-    return expr_body_;
-  }
+// ---------------------------------------------------------------------------
+// Declaration payloads
+// ---------------------------------------------------------------------------
+
+struct FunctionDecl {
+  std::string_view name;
+  Span name_span;
+  std::vector<Param> params;
+  TypeNode* return_type;       // nullable
+  std::vector<Stmt*> body;     // empty if expression-bodied or extern
+  Expr* expr_body;             // nullptr if block-bodied or extern
+  bool is_extern = false;
+
   [[nodiscard]] auto is_expr_bodied() const -> bool {
-    return expr_body_ != nullptr;
+    return expr_body != nullptr;
   }
-  [[nodiscard]] auto is_extern() const -> bool {
-    return is_extern_;
-  }
-
-private:
-  std::string_view name_;
-  Span name_span_;
-  std::vector<Param> params_;
-  TypeNode* return_type_;   // nullable
-  std::vector<Stmt*> body_; // empty if expression-bodied or extern
-  Expr* expr_body_;         // nullptr if block-bodied or extern
-  bool is_extern_ = false;
 };
+
+struct ClassDecl {
+  std::string_view name;
+  Span name_span;
+  std::vector<FieldSpec*> fields;
+};
+
+struct AliasDecl {
+  std::string_view name;
+  Span name_span;
+  TypeNode* type;
+};
+
+using DeclPayload = std::variant<FunctionDecl, ClassDecl, AliasDecl>;
 
 // ---------------------------------------------------------------------------
-// Class field specifier
+// Statement payloads
 // ---------------------------------------------------------------------------
 
-class FieldSpecNode : public AstNode {
-public:
-  FieldSpecNode(Span span, std::string_view name, Span name_span, TypeNode* type)
-      : AstNode(NodeKind::FieldSpec, span), name_(name), name_span_(name_span), type_(type) {
-  }
-
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto type() const -> TypeNode* {
-    return type_;
-  }
-
-private:
-  std::string_view name_;
-  Span name_span_;
-  TypeNode* type_;
+struct LetStatement {
+  std::string_view name;
+  Span name_span;
+  TypeNode* type;        // nullable
+  Expr* initializer;     // nullable
 };
 
-class ClassDeclNode : public Decl {
-public:
-  ClassDeclNode(Span span, std::string_view name, Span name_span,
-                std::vector<FieldSpecNode*> fields)
-      : Decl(NodeKind::ClassDecl, span), name_(name), name_span_(name_span),
-        fields_(std::move(fields)) {
-  }
-
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto fields() const -> const std::vector<FieldSpecNode*>& {
-    return fields_;
-  }
-
-private:
-  std::string_view name_;
-  Span name_span_;
-  std::vector<FieldSpecNode*> fields_;
+struct Assignment {
+  Expr* target;
+  Expr* value;
 };
 
-class AliasDeclNode : public Decl {
-public:
-  AliasDeclNode(Span span, std::string_view name, Span name_span, TypeNode* type)
-      : Decl(NodeKind::AliasDecl, span), name_(name), name_span_(name_span), type_(type) {
-  }
+struct IfStatement {
+  Expr* condition;
+  std::vector<Stmt*> then_body;
+  std::vector<Stmt*> else_body;
 
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto type() const -> TypeNode* {
-    return type_;
-  }
-
-private:
-  std::string_view name_;
-  Span name_span_;
-  TypeNode* type_;
-};
-
-// ---------------------------------------------------------------------------
-// Statements
-// ---------------------------------------------------------------------------
-
-class LetStatementNode : public Stmt {
-public:
-  LetStatementNode(
-      Span span, std::string_view name, Span name_span, TypeNode* type, Expr* initializer)
-      : Stmt(NodeKind::LetStatement, span), name_(name), name_span_(name_span), type_(type),
-        initializer_(initializer) {
-  }
-
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto type() const -> TypeNode* {
-    return type_;
-  }
-  [[nodiscard]] auto initializer() const -> Expr* {
-    return initializer_;
-  }
-
-private:
-  std::string_view name_;
-  Span name_span_;
-  TypeNode* type_;    // nullable
-  Expr* initializer_; // nullable
-};
-
-class AssignmentNode : public Stmt {
-public:
-  AssignmentNode(Span span, Expr* target, Expr* value)
-      : Stmt(NodeKind::Assignment, span), target_(target), value_(value) {
-  }
-
-  [[nodiscard]] auto target() const -> Expr* {
-    return target_;
-  }
-  [[nodiscard]] auto value() const -> Expr* {
-    return value_;
-  }
-
-private:
-  Expr* target_;
-  Expr* value_;
-};
-
-class IfStatementNode : public Stmt {
-public:
-  IfStatementNode(Span span,
-                  Expr* condition,
-                  std::vector<Stmt*> then_body,
-                  std::vector<Stmt*> else_body)
-      : Stmt(NodeKind::IfStatement, span), condition_(condition), then_body_(std::move(then_body)),
-        else_body_(std::move(else_body)) {
-  }
-
-  [[nodiscard]] auto condition() const -> Expr* {
-    return condition_;
-  }
-  [[nodiscard]] auto then_body() const -> const std::vector<Stmt*>& {
-    return then_body_;
-  }
-  [[nodiscard]] auto else_body() const -> const std::vector<Stmt*>& {
-    return else_body_;
-  }
   [[nodiscard]] auto has_else() const -> bool {
-    return !else_body_.empty();
+    return !else_body.empty();
   }
-
-private:
-  Expr* condition_;
-  std::vector<Stmt*> then_body_;
-  std::vector<Stmt*> else_body_;
 };
 
-class WhileStatementNode : public Stmt {
-public:
-  WhileStatementNode(Span span, Expr* condition, std::vector<Stmt*> body)
-      : Stmt(NodeKind::WhileStatement, span), condition_(condition), body_(std::move(body)) {
-  }
-
-  [[nodiscard]] auto condition() const -> Expr* {
-    return condition_;
-  }
-  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
-    return body_;
-  }
-
-private:
-  Expr* condition_;
-  std::vector<Stmt*> body_;
+struct WhileStatement {
+  Expr* condition;
+  std::vector<Stmt*> body;
 };
 
-class ForStatementNode : public Stmt {
-public:
-  ForStatementNode(
-      Span span, std::string_view var, Span var_span, Expr* iterable, std::vector<Stmt*> body)
-      : Stmt(NodeKind::ForStatement, span), var_(var), var_span_(var_span), iterable_(iterable),
-        body_(std::move(body)) {
-  }
-
-  [[nodiscard]] auto var() const -> std::string_view {
-    return var_;
-  }
-  [[nodiscard]] auto var_span() const -> Span {
-    return var_span_;
-  }
-  [[nodiscard]] auto iterable() const -> Expr* {
-    return iterable_;
-  }
-  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
-    return body_;
-  }
-
-private:
-  std::string_view var_;
-  Span var_span_;
-  Expr* iterable_;
-  std::vector<Stmt*> body_;
+struct ForStatement {
+  std::string_view var;
+  Span var_span;
+  Expr* iterable;
+  std::vector<Stmt*> body;
 };
 
-class ModeBlockNode : public Stmt {
-public:
-  ModeBlockNode(Span span, std::string_view mode_name, Span name_span, std::vector<Stmt*> body)
-      : Stmt(NodeKind::ModeBlock, span), mode_name_(mode_name), name_span_(name_span),
-        body_(std::move(body)) {
-  }
-
-  [[nodiscard]] auto mode_name() const -> std::string_view {
-    return mode_name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
-    return body_;
-  }
-
-private:
-  std::string_view mode_name_;
-  Span name_span_;
-  std::vector<Stmt*> body_;
+struct ModeBlock {
+  std::string_view mode_name;
+  Span name_span;
+  std::vector<Stmt*> body;
 };
 
-class ResourceBlockNode : public Stmt {
-public:
-  ResourceBlockNode(Span span,
-                    std::string_view resource_kind,
-                    Span kind_span,
-                    std::string_view resource_name,
-                    Span name_span,
-                    std::vector<Stmt*> body)
-      : Stmt(NodeKind::ResourceBlock, span), resource_kind_(resource_kind), kind_span_(kind_span),
-        resource_name_(resource_name), name_span_(name_span), body_(std::move(body)) {
-  }
-
-  [[nodiscard]] auto resource_kind() const -> std::string_view {
-    return resource_kind_;
-  }
-  [[nodiscard]] auto kind_span() const -> Span {
-    return kind_span_;
-  }
-  [[nodiscard]] auto resource_name() const -> std::string_view {
-    return resource_name_;
-  }
-  [[nodiscard]] auto name_span() const -> Span {
-    return name_span_;
-  }
-  [[nodiscard]] auto body() const -> const std::vector<Stmt*>& {
-    return body_;
-  }
-
-private:
-  std::string_view resource_kind_;
-  Span kind_span_;
-  std::string_view resource_name_;
-  Span name_span_;
-  std::vector<Stmt*> body_;
+struct ResourceBlock {
+  std::string_view resource_kind;
+  Span kind_span;
+  std::string_view resource_name;
+  Span name_span;
+  std::vector<Stmt*> body;
 };
 
-class ReturnStatementNode : public Stmt {
-public:
-  ReturnStatementNode(Span span, Expr* value)
-      : Stmt(NodeKind::ReturnStatement, span), value_(value) {
-  }
-
-  [[nodiscard]] auto value() const -> Expr* {
-    return value_;
-  }
-
-private:
-  Expr* value_;
+struct ReturnStatement {
+  Expr* value; // nullable for bare return
 };
 
-class ExpressionStatementNode : public Stmt {
-public:
-  ExpressionStatementNode(Span span, Expr* expr)
-      : Stmt(NodeKind::ExpressionStatement, span), expr_(expr) {
-  }
-
-  [[nodiscard]] auto expr() const -> Expr* {
-    return expr_;
-  }
-
-private:
-  Expr* expr_;
+struct ExpressionStatement {
+  Expr* expr;
 };
+
+using StmtPayload = std::variant<
+    LetStatement, Assignment, IfStatement, WhileStatement, ForStatement,
+    ModeBlock, ResourceBlock, ReturnStatement, ExpressionStatement>;
 
 // ---------------------------------------------------------------------------
-// Expressions
+// Expression payloads
 // ---------------------------------------------------------------------------
 
-class BinaryExprNode : public Expr {
-public:
-  // NOLINTNEXTLINE(readability-identifier-length)
-  BinaryExprNode(Span span, BinaryOp op, Expr* left, Expr* right)
-      : Expr(NodeKind::BinaryExpr, span), op_(op), left_(left), right_(right) {
-  }
-
-  [[nodiscard]] auto op() const -> BinaryOp {
-    return op_;
-  }
-  [[nodiscard]] auto left() const -> Expr* {
-    return left_;
-  }
-  [[nodiscard]] auto right() const -> Expr* {
-    return right_;
-  }
-
-private:
-  BinaryOp op_;
-  Expr* left_;
-  Expr* right_;
+struct BinaryExpr {
+  BinaryOp op;
+  Expr* left;
+  Expr* right;
 };
 
-class UnaryExprNode : public Expr {
-public:
-  // NOLINTNEXTLINE(readability-identifier-length)
-  UnaryExprNode(Span span, UnaryOp op, Expr* operand)
-      : Expr(NodeKind::UnaryExpr, span), op_(op), operand_(operand) {
-  }
-
-  [[nodiscard]] auto op() const -> UnaryOp {
-    return op_;
-  }
-  [[nodiscard]] auto operand() const -> Expr* {
-    return operand_;
-  }
-
-private:
-  UnaryOp op_;
-  Expr* operand_;
+struct UnaryExpr {
+  UnaryOp op;
+  Expr* operand;
 };
 
-class CallExprNode : public Expr {
-public:
-  CallExprNode(Span span, Expr* callee, std::vector<Expr*> args)
-      : Expr(NodeKind::CallExpr, span), callee_(callee), args_(std::move(args)) {
-  }
-
-  [[nodiscard]] auto callee() const -> Expr* {
-    return callee_;
-  }
-  [[nodiscard]] auto args() const -> const std::vector<Expr*>& {
-    return args_;
-  }
-
-private:
-  Expr* callee_;
-  std::vector<Expr*> args_;
+struct CallExpr {
+  Expr* callee;
+  std::vector<Expr*> args;
 };
 
-class IndexExprNode : public Expr {
-public:
-  IndexExprNode(Span span, Expr* object, std::vector<Expr*> indices)
-      : Expr(NodeKind::IndexExpr, span), object_(object), indices_(std::move(indices)) {
-  }
-
-  [[nodiscard]] auto object() const -> Expr* {
-    return object_;
-  }
-  [[nodiscard]] auto indices() const -> const std::vector<Expr*>& {
-    return indices_;
-  }
-
-private:
-  Expr* object_;
-  std::vector<Expr*> indices_;
+struct IndexExpr {
+  Expr* object;
+  std::vector<Expr*> indices;
 };
 
-class FieldExprNode : public Expr {
-public:
-  FieldExprNode(Span span, Expr* object, std::string_view field, Span field_span)
-      : Expr(NodeKind::FieldExpr, span), object_(object), field_(field), field_span_(field_span) {
-  }
-
-  [[nodiscard]] auto object() const -> Expr* {
-    return object_;
-  }
-  [[nodiscard]] auto field() const -> std::string_view {
-    return field_;
-  }
-  [[nodiscard]] auto field_span() const -> Span {
-    return field_span_;
-  }
-
-private:
-  Expr* object_;
-  std::string_view field_;
-  Span field_span_;
+struct FieldExpr {
+  Expr* object;
+  std::string_view field;
+  Span field_span;
 };
 
-class PipeExprNode : public Expr {
-public:
-  PipeExprNode(Span span, Expr* left, Expr* right)
-      : Expr(NodeKind::PipeExpr, span), left_(left), right_(right) {
-  }
-
-  [[nodiscard]] auto left() const -> Expr* {
-    return left_;
-  }
-  [[nodiscard]] auto right() const -> Expr* {
-    return right_;
-  }
-
-private:
-  Expr* left_;
-  Expr* right_;
+struct PipeExpr {
+  Expr* left;
+  Expr* right;
 };
 
-class LambdaNode : public Expr {
-public:
-  LambdaNode(Span span, std::vector<std::pair<std::string_view, Span>> params, Expr* body)
-      : Expr(NodeKind::Lambda, span), params_(std::move(params)), body_(body) {
-  }
-
-  [[nodiscard]] auto params() const -> const std::vector<std::pair<std::string_view, Span>>& {
-    return params_;
-  }
-  [[nodiscard]] auto body() const -> Expr* {
-    return body_;
-  }
-
-private:
-  std::vector<std::pair<std::string_view, Span>> params_;
-  Expr* body_;
+struct LambdaExpr {
+  std::vector<std::pair<std::string_view, Span>> params;
+  Expr* body;
 };
 
-class IntLiteralNode : public Expr {
-public:
-  IntLiteralNode(Span span, std::string_view text) : Expr(NodeKind::IntLiteral, span), text_(text) {
-  }
+struct IntLiteral   { std::string_view text; };
+struct FloatLiteral { std::string_view text; };
+struct StringLiteral { std::string_view text; };
+struct BoolLiteral  { bool value; };
 
-  [[nodiscard]] auto text() const -> std::string_view {
-    return text_;
-  }
-
-private:
-  std::string_view text_;
+struct ListLiteral {
+  std::vector<Expr*> elements;
 };
 
-class FloatLiteralNode : public Expr {
-public:
-  FloatLiteralNode(Span span, std::string_view text)
-      : Expr(NodeKind::FloatLiteral, span), text_(text) {
-  }
-
-  [[nodiscard]] auto text() const -> std::string_view {
-    return text_;
-  }
-
-private:
-  std::string_view text_;
+struct IdentifierExpr {
+  std::string_view name;
 };
 
-class StringLiteralNode : public Expr {
-public:
-  StringLiteralNode(Span span, std::string_view text)
-      : Expr(NodeKind::StringLiteral, span), text_(text) {
-  }
-
-  [[nodiscard]] auto text() const -> std::string_view {
-    return text_;
-  }
-
-private:
-  std::string_view text_;
+struct QualifiedName {
+  std::vector<std::string_view> segments;
 };
 
-class BoolLiteralNode : public Expr {
-public:
-  BoolLiteralNode(Span span, bool value) : Expr(NodeKind::BoolLiteral, span), value_(value) {
-  }
-
-  [[nodiscard]] auto value() const -> bool {
-    return value_;
-  }
-
-private:
-  bool value_;
-};
-
-class ListLiteralNode : public Expr {
-public:
-  ListLiteralNode(Span span, std::vector<Expr*> elements)
-      : Expr(NodeKind::ListLiteral, span), elements_(std::move(elements)) {
-  }
-
-  [[nodiscard]] auto elements() const -> const std::vector<Expr*>& {
-    return elements_;
-  }
-
-private:
-  std::vector<Expr*> elements_;
-};
-
-class IdentifierNode : public Expr {
-public:
-  IdentifierNode(Span span, std::string_view name) : Expr(NodeKind::Identifier, span), name_(name) {
-  }
-
-  [[nodiscard]] auto name() const -> std::string_view {
-    return name_;
-  }
-
-private:
-  std::string_view name_;
-};
-
-class QualifiedNameNode : public Expr {
-public:
-  QualifiedNameNode(Span span, std::vector<std::string_view> segments)
-      : Expr(NodeKind::QualifiedName, span), segments_(std::move(segments)) {
-  }
-
-  [[nodiscard]] auto segments() const -> const std::vector<std::string_view>& {
-    return segments_;
-  }
-
-private:
-  std::vector<std::string_view> segments_;
-};
+using ExprPayload = std::variant<
+    BinaryExpr, UnaryExpr, CallExpr, IndexExpr, FieldExpr, PipeExpr,
+    LambdaExpr, IntLiteral, FloatLiteral, StringLiteral, BoolLiteral,
+    ListLiteral, IdentifierExpr, QualifiedName>;
 
 // ---------------------------------------------------------------------------
-// Type nodes
+// Type node payloads
 // ---------------------------------------------------------------------------
 
-class NamedTypeNode : public TypeNode {
-public:
-  NamedTypeNode(Span span, QualifiedPath name, std::vector<TypeNode*> type_args)
-      : TypeNode(NodeKind::NamedType, span), name_(std::move(name)),
-        type_args_(std::move(type_args)) {
-  }
-
-  [[nodiscard]] auto name() const -> const QualifiedPath& {
-    return name_;
-  }
-  [[nodiscard]] auto type_args() const -> const std::vector<TypeNode*>& {
-    return type_args_;
-  }
-
-private:
-  QualifiedPath name_;
-  std::vector<TypeNode*> type_args_;
+struct NamedType {
+  QualifiedPath name;
+  std::vector<TypeNode*> type_args;
 };
 
-class PointerTypeNode : public TypeNode {
-public:
-  PointerTypeNode(Span span, TypeNode* pointee)
-      : TypeNode(NodeKind::PointerType, span), pointee_(pointee) {
-  }
+struct PointerType {
+  TypeNode* pointee;
+};
 
-  [[nodiscard]] auto pointee() const -> TypeNode* {
-    return pointee_;
-  }
+using TypeNodePayload = std::variant<NamedType, PointerType>;
 
-private:
-  TypeNode* pointee_;
+// ---------------------------------------------------------------------------
+// Container nodes — arena-allocated.
+//
+// Each container holds a span and a typed payload variant. The kind()
+// method derives NodeKind from the active variant alternative.
+// as<T>() / is<T>() provide typed access.
+// ---------------------------------------------------------------------------
+
+struct Decl {
+  Span span;
+  DeclPayload payload;
+
+  [[nodiscard]] auto kind() const -> NodeKind;
+
+  template <typename T>
+  [[nodiscard]] auto as() const -> const T& {
+    return std::get<T>(payload);
+  }
+  template <typename T>
+  [[nodiscard]] auto is() const -> bool {
+    return std::holds_alternative<T>(payload);
+  }
+};
+
+struct Stmt {
+  Span span;
+  StmtPayload payload;
+
+  [[nodiscard]] auto kind() const -> NodeKind;
+
+  template <typename T>
+  [[nodiscard]] auto as() const -> const T& {
+    return std::get<T>(payload);
+  }
+  template <typename T>
+  [[nodiscard]] auto is() const -> bool {
+    return std::holds_alternative<T>(payload);
+  }
+};
+
+struct Expr {
+  Span span;
+  ExprPayload payload;
+
+  [[nodiscard]] auto kind() const -> NodeKind;
+
+  template <typename T>
+  [[nodiscard]] auto as() const -> const T& {
+    return std::get<T>(payload);
+  }
+  template <typename T>
+  [[nodiscard]] auto is() const -> bool {
+    return std::holds_alternative<T>(payload);
+  }
+};
+
+struct TypeNode {
+  Span span;
+  TypeNodePayload payload;
+
+  [[nodiscard]] auto kind() const -> NodeKind;
+
+  template <typename T>
+  [[nodiscard]] auto as() const -> const T& {
+    return std::get<T>(payload);
+  }
+  template <typename T>
+  [[nodiscard]] auto is() const -> bool {
+    return std::holds_alternative<T>(payload);
+  }
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -1,5 +1,7 @@
 #include "frontend/ast/ast_printer.h"
 
+#include "support/variant.h"
+
 #include <string>
 
 namespace dao {
@@ -15,10 +17,10 @@ public:
 
   void print(const FileNode& file) {
     out_ << "File\n";
-    for (const auto* imp : file.imports()) {
-      print_import(static_cast<const ImportNode&>(*imp));
+    for (const auto* imp : file.imports) {
+      print_import(*imp);
     }
-    for (const auto* decl : file.declarations()) {
+    for (const auto* decl : file.declarations) {
       print_decl(*decl);
     }
   }
@@ -54,7 +56,7 @@ private:
   void print_import(const ImportNode& node) {
     indent();
     out_ << "Import ";
-    print_qualified_path(node.path());
+    print_qualified_path(node.path);
     out_ << "\n";
   }
 
@@ -63,43 +65,33 @@ private:
   // -----------------------------------------------------------------------
 
   void print_decl(const Decl& decl) {
-    switch (decl.kind()) {
-    case NodeKind::FunctionDecl:
-      print_function_decl(static_cast<const FunctionDeclNode&>(decl));
-      break;
-    case NodeKind::ClassDecl:
-      print_class_decl(static_cast<const ClassDeclNode&>(decl));
-      break;
-    case NodeKind::AliasDecl:
-      print_alias_decl(static_cast<const AliasDeclNode&>(decl));
-      break;
-    default:
-      indent();
-      out_ << "UnknownDecl\n";
-      break;
-    }
+    std::visit(overloaded{
+        [&](const FunctionDecl& fn) { print_function_decl(fn); },
+        [&](const ClassDecl& cls) { print_class_decl(cls); },
+        [&](const AliasDecl& alias) { print_alias_decl(alias); },
+    }, decl.payload);
   }
 
-  void print_function_decl(const FunctionDeclNode& fn) {
+  void print_function_decl(const FunctionDecl& fn) {
     indent();
-    if (fn.is_extern()) {
-      out_ << "ExternFunctionDecl " << fn.name() << "\n";
+    if (fn.is_extern) {
+      out_ << "ExternFunctionDecl " << fn.name << "\n";
     } else {
-      out_ << "FunctionDecl " << fn.name() << "\n";
+      out_ << "FunctionDecl " << fn.name << "\n";
     }
     Scope scope(depth_);
 
-    for (const auto& param : fn.params()) {
+    for (const auto& param : fn.params) {
       indent();
       out_ << "Param " << param.name << ": ";
       print_type_inline(*param.type);
       out_ << "\n";
     }
 
-    if (fn.return_type() != nullptr) {
+    if (fn.return_type != nullptr) {
       indent();
       out_ << "ReturnType: ";
-      print_type_inline(*fn.return_type());
+      print_type_inline(*fn.return_type);
       out_ << "\n";
     }
 
@@ -108,31 +100,31 @@ private:
       out_ << "ExprBody\n";
       {
         Scope body_scope(depth_);
-        print_expr(*fn.expr_body());
+        print_expr(*fn.expr_body);
       }
     } else {
-      for (const auto* stmt : fn.body()) {
+      for (const auto* stmt : fn.body) {
         print_stmt(*stmt);
       }
     }
   }
 
-  void print_class_decl(const ClassDeclNode& node) {
+  void print_class_decl(const ClassDecl& node) {
     indent();
-    out_ << "ClassDecl " << node.name() << "\n";
+    out_ << "ClassDecl " << node.name << "\n";
     Scope scope(depth_);
-    for (const auto* field : node.fields()) {
+    for (const auto* field : node.fields) {
       indent();
-      out_ << "Field " << field->name() << ": ";
-      print_type_inline(*field->type());
+      out_ << "Field " << field->name << ": ";
+      print_type_inline(*field->type);
       out_ << "\n";
     }
   }
 
-  void print_alias_decl(const AliasDeclNode& node) {
+  void print_alias_decl(const AliasDecl& node) {
     indent();
-    out_ << "AliasDecl " << node.name() << " = ";
-    print_type_inline(*node.type());
+    out_ << "AliasDecl " << node.name << " = ";
+    print_type_inline(*node.type);
     out_ << "\n";
   }
 
@@ -142,257 +134,128 @@ private:
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   void print_stmt(const Stmt& stmt) {
-    switch (stmt.kind()) {
-    case NodeKind::LetStatement:
-      print_let(static_cast<const LetStatementNode&>(stmt));
-      break;
-    case NodeKind::Assignment:
-      print_assignment(static_cast<const AssignmentNode&>(stmt));
-      break;
-    case NodeKind::IfStatement:
-      print_if(static_cast<const IfStatementNode&>(stmt));
-      break;
-    case NodeKind::WhileStatement:
-      print_while(static_cast<const WhileStatementNode&>(stmt));
-      break;
-    case NodeKind::ForStatement:
-      print_for(static_cast<const ForStatementNode&>(stmt));
-      break;
-    case NodeKind::ModeBlock:
-      print_mode(static_cast<const ModeBlockNode&>(stmt));
-      break;
-    case NodeKind::ResourceBlock:
-      print_resource(static_cast<const ResourceBlockNode&>(stmt));
-      break;
-    case NodeKind::ReturnStatement:
-      print_return(static_cast<const ReturnStatementNode&>(stmt));
-      break;
-    case NodeKind::ExpressionStatement:
-      print_expr_stmt(static_cast<const ExpressionStatementNode&>(stmt));
-      break;
-    default:
-      indent();
-      out_ << "UnknownStmt\n";
-      break;
-    }
-  }
-
-  void print_let(const LetStatementNode& node) {
-    indent();
-    out_ << "LetStatement " << node.name();
-    if (node.type() != nullptr) {
-      out_ << ": ";
-      print_type_inline(*node.type());
-    }
-    out_ << "\n";
-    if (node.initializer() != nullptr) {
-      Scope scope(depth_);
-      print_expr(*node.initializer());
-    }
-  }
-
-  void print_assignment(const AssignmentNode& node) {
-    indent();
-    out_ << "Assignment\n";
-    Scope scope(depth_);
-    indent();
-    out_ << "Target\n";
-    {
-      Scope target_scope(depth_);
-      print_expr(*node.target());
-    }
-    indent();
-    out_ << "Value\n";
-    {
-      Scope value_scope(depth_);
-      print_expr(*node.value());
-    }
-  }
-
-  void print_if(const IfStatementNode& node) {
-    indent();
-    out_ << "IfStatement\n";
-    Scope scope(depth_);
-    indent();
-    out_ << "Condition\n";
-    {
-      Scope cond_scope(depth_);
-      print_expr(*node.condition());
-    }
-    indent();
-    out_ << "Then\n";
-    {
-      Scope then_scope(depth_);
-      for (const auto* stmt : node.then_body()) {
-        print_stmt(*stmt);
-      }
-    }
-    if (node.has_else()) {
-      indent();
-      out_ << "Else\n";
-      Scope else_scope(depth_);
-      for (const auto* stmt : node.else_body()) {
-        print_stmt(*stmt);
-      }
-    }
-  }
-
-  void print_while(const WhileStatementNode& node) {
-    indent();
-    out_ << "WhileStatement\n";
-    Scope scope(depth_);
-    indent();
-    out_ << "Condition\n";
-    {
-      Scope cond_scope(depth_);
-      print_expr(*node.condition());
-    }
-    for (const auto* stmt : node.body()) {
-      print_stmt(*stmt);
-    }
-  }
-
-  void print_for(const ForStatementNode& node) {
-    indent();
-    out_ << "ForStatement " << node.var() << "\n";
-    Scope scope(depth_);
-    indent();
-    out_ << "Iterable\n";
-    {
-      Scope iter_scope(depth_);
-      print_expr(*node.iterable());
-    }
-    for (const auto* stmt : node.body()) {
-      print_stmt(*stmt);
-    }
-  }
-
-  void print_mode(const ModeBlockNode& node) {
-    indent();
-    out_ << "ModeBlock " << node.mode_name() << "\n";
-    Scope scope(depth_);
-    for (const auto* stmt : node.body()) {
-      print_stmt(*stmt);
-    }
-  }
-
-  void print_resource(const ResourceBlockNode& node) {
-    indent();
-    out_ << "ResourceBlock " << node.resource_kind() << " " << node.resource_name() << "\n";
-    Scope scope(depth_);
-    for (const auto* stmt : node.body()) {
-      print_stmt(*stmt);
-    }
-  }
-
-  void print_return(const ReturnStatementNode& node) {
-    indent();
-    out_ << "ReturnStatement\n";
-    if (node.value() != nullptr) {
-      Scope scope(depth_);
-      print_expr(*node.value());
-    }
-  }
-
-  void print_expr_stmt(const ExpressionStatementNode& node) {
-    indent();
-    out_ << "ExpressionStatement\n";
-    Scope scope(depth_);
-    print_expr(*node.expr());
+    std::visit(overloaded{
+        [&](const LetStatement& node) {
+          indent();
+          out_ << "LetStatement " << node.name;
+          if (node.type != nullptr) {
+            out_ << ": ";
+            print_type_inline(*node.type);
+          }
+          out_ << "\n";
+          if (node.initializer != nullptr) {
+            Scope scope(depth_);
+            print_expr(*node.initializer);
+          }
+        },
+        [&](const Assignment& node) {
+          indent();
+          out_ << "Assignment\n";
+          Scope scope(depth_);
+          indent();
+          out_ << "Target\n";
+          {
+            Scope target_scope(depth_);
+            print_expr(*node.target);
+          }
+          indent();
+          out_ << "Value\n";
+          {
+            Scope value_scope(depth_);
+            print_expr(*node.value);
+          }
+        },
+        [&](const IfStatement& node) {
+          indent();
+          out_ << "IfStatement\n";
+          Scope scope(depth_);
+          indent();
+          out_ << "Condition\n";
+          {
+            Scope cond_scope(depth_);
+            print_expr(*node.condition);
+          }
+          indent();
+          out_ << "Then\n";
+          {
+            Scope then_scope(depth_);
+            for (const auto* s : node.then_body) {
+              print_stmt(*s);
+            }
+          }
+          if (node.has_else()) {
+            indent();
+            out_ << "Else\n";
+            Scope else_scope(depth_);
+            for (const auto* s : node.else_body) {
+              print_stmt(*s);
+            }
+          }
+        },
+        [&](const WhileStatement& node) {
+          indent();
+          out_ << "WhileStatement\n";
+          Scope scope(depth_);
+          indent();
+          out_ << "Condition\n";
+          {
+            Scope cond_scope(depth_);
+            print_expr(*node.condition);
+          }
+          for (const auto* s : node.body) {
+            print_stmt(*s);
+          }
+        },
+        [&](const ForStatement& node) {
+          indent();
+          out_ << "ForStatement " << node.var << "\n";
+          Scope scope(depth_);
+          indent();
+          out_ << "Iterable\n";
+          {
+            Scope iter_scope(depth_);
+            print_expr(*node.iterable);
+          }
+          for (const auto* s : node.body) {
+            print_stmt(*s);
+          }
+        },
+        [&](const ModeBlock& node) {
+          indent();
+          out_ << "ModeBlock " << node.mode_name << "\n";
+          Scope scope(depth_);
+          for (const auto* s : node.body) {
+            print_stmt(*s);
+          }
+        },
+        [&](const ResourceBlock& node) {
+          indent();
+          out_ << "ResourceBlock " << node.resource_kind << " " << node.resource_name << "\n";
+          Scope scope(depth_);
+          for (const auto* s : node.body) {
+            print_stmt(*s);
+          }
+        },
+        [&](const ReturnStatement& node) {
+          indent();
+          out_ << "ReturnStatement\n";
+          if (node.value != nullptr) {
+            Scope scope(depth_);
+            print_expr(*node.value);
+          }
+        },
+        [&](const ExpressionStatement& node) {
+          indent();
+          out_ << "ExpressionStatement\n";
+          Scope scope(depth_);
+          print_expr(*node.expr);
+        },
+    }, stmt.payload);
   }
 
   // -----------------------------------------------------------------------
   // Expressions
   // -----------------------------------------------------------------------
-
-  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-  void print_expr(const Expr& expr) {
-    switch (expr.kind()) {
-    case NodeKind::IntLiteral:
-      print_int_literal(static_cast<const IntLiteralNode&>(expr));
-      break;
-    case NodeKind::FloatLiteral:
-      print_float_literal(static_cast<const FloatLiteralNode&>(expr));
-      break;
-    case NodeKind::StringLiteral:
-      print_string_literal(static_cast<const StringLiteralNode&>(expr));
-      break;
-    case NodeKind::BoolLiteral:
-      print_bool_literal(static_cast<const BoolLiteralNode&>(expr));
-      break;
-    case NodeKind::Identifier:
-      print_identifier(static_cast<const IdentifierNode&>(expr));
-      break;
-    case NodeKind::QualifiedName:
-      print_qualified_name(static_cast<const QualifiedNameNode&>(expr));
-      break;
-    case NodeKind::BinaryExpr:
-      print_binary(static_cast<const BinaryExprNode&>(expr));
-      break;
-    case NodeKind::UnaryExpr:
-      print_unary(static_cast<const UnaryExprNode&>(expr));
-      break;
-    case NodeKind::CallExpr:
-      print_call(static_cast<const CallExprNode&>(expr));
-      break;
-    case NodeKind::IndexExpr:
-      print_index(static_cast<const IndexExprNode&>(expr));
-      break;
-    case NodeKind::FieldExpr:
-      print_field(static_cast<const FieldExprNode&>(expr));
-      break;
-    case NodeKind::PipeExpr:
-      print_pipe(static_cast<const PipeExprNode&>(expr));
-      break;
-    case NodeKind::Lambda:
-      print_lambda(static_cast<const LambdaNode&>(expr));
-      break;
-    case NodeKind::ListLiteral:
-      print_list_literal(static_cast<const ListLiteralNode&>(expr));
-      break;
-    default:
-      indent();
-      out_ << "UnknownExpr\n";
-      break;
-    }
-  }
-
-  void print_int_literal(const IntLiteralNode& node) {
-    indent();
-    out_ << "IntLiteral " << node.text() << "\n";
-  }
-
-  void print_float_literal(const FloatLiteralNode& node) {
-    indent();
-    out_ << "FloatLiteral " << node.text() << "\n";
-  }
-
-  void print_string_literal(const StringLiteralNode& node) {
-    indent();
-    out_ << "StringLiteral " << node.text() << "\n";
-  }
-
-  void print_bool_literal(const BoolLiteralNode& node) {
-    indent();
-    out_ << "BoolLiteral " << (node.value() ? "true" : "false") << "\n";
-  }
-
-  void print_identifier(const IdentifierNode& node) {
-    indent();
-    out_ << "Identifier " << node.name() << "\n";
-  }
-
-  void print_qualified_name(const QualifiedNameNode& node) {
-    indent();
-    out_ << "QualifiedName ";
-    for (size_t i = 0; i < node.segments().size(); ++i) {
-      if (i > 0) {
-        out_ << "::";
-      }
-      out_ << node.segments()[i];
-    }
-    out_ << "\n";
-  }
 
   static auto binary_op_str(BinaryOp op) -> const char* {
     switch (op) {
@@ -440,91 +303,120 @@ private:
     return "?";
   }
 
-  void print_binary(const BinaryExprNode& node) {
-    indent();
-    out_ << "BinaryExpr " << binary_op_str(node.op()) << "\n";
-    Scope scope(depth_);
-    print_expr(*node.left());
-    print_expr(*node.right());
-  }
-
-  void print_unary(const UnaryExprNode& node) {
-    indent();
-    out_ << "UnaryExpr " << unary_op_str(node.op()) << "\n";
-    Scope scope(depth_);
-    print_expr(*node.operand());
-  }
-
-  void print_call(const CallExprNode& node) {
-    indent();
-    out_ << "CallExpr\n";
-    Scope scope(depth_);
-    indent();
-    out_ << "Callee\n";
-    {
-      Scope callee_scope(depth_);
-      print_expr(*node.callee());
-    }
-    if (!node.args().empty()) {
-      indent();
-      out_ << "Args\n";
-      Scope args_scope(depth_);
-      for (const auto* arg : node.args()) {
-        print_expr(*arg);
-      }
-    }
-  }
-
-  void print_index(const IndexExprNode& node) {
-    indent();
-    out_ << "IndexExpr\n";
-    Scope scope(depth_);
-    print_expr(*node.object());
-    indent();
-    out_ << "Indices\n";
-    {
-      Scope indices_scope(depth_);
-      for (const auto* idx : node.indices()) {
-        print_expr(*idx);
-      }
-    }
-  }
-
-  void print_field(const FieldExprNode& node) {
-    indent();
-    out_ << "FieldExpr ." << node.field() << "\n";
-    Scope scope(depth_);
-    print_expr(*node.object());
-  }
-
-  void print_pipe(const PipeExprNode& node) {
-    indent();
-    out_ << "PipeExpr\n";
-    Scope scope(depth_);
-    print_expr(*node.left());
-    print_expr(*node.right());
-  }
-
-  void print_lambda(const LambdaNode& node) {
-    indent();
-    out_ << "Lambda";
-    for (const auto& [name, span] : node.params()) {
-      out_ << " " << name;
-    }
-    out_ << "\n";
-    Scope scope(depth_);
-    print_expr(*node.body());
-  }
-
-  void print_list_literal(const ListLiteralNode& node) {
-    indent();
-    out_ << "ListLiteral\n";
-    if (!node.elements().empty()) {
-      Scope scope(depth_);
-      for (const auto* elem : node.elements()) {
-        print_expr(*elem);
-      }
-    }
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  void print_expr(const Expr& expr) {
+    std::visit(overloaded{
+        [&](const IntLiteral& node) {
+          indent();
+          out_ << "IntLiteral " << node.text << "\n";
+        },
+        [&](const FloatLiteral& node) {
+          indent();
+          out_ << "FloatLiteral " << node.text << "\n";
+        },
+        [&](const StringLiteral& node) {
+          indent();
+          out_ << "StringLiteral " << node.text << "\n";
+        },
+        [&](const BoolLiteral& node) {
+          indent();
+          out_ << "BoolLiteral " << (node.value ? "true" : "false") << "\n";
+        },
+        [&](const IdentifierExpr& node) {
+          indent();
+          out_ << "Identifier " << node.name << "\n";
+        },
+        [&](const QualifiedName& node) {
+          indent();
+          out_ << "QualifiedName ";
+          for (size_t i = 0; i < node.segments.size(); ++i) {
+            if (i > 0) {
+              out_ << "::";
+            }
+            out_ << node.segments[i];
+          }
+          out_ << "\n";
+        },
+        [&](const BinaryExpr& node) {
+          indent();
+          out_ << "BinaryExpr " << binary_op_str(node.op) << "\n";
+          Scope scope(depth_);
+          print_expr(*node.left);
+          print_expr(*node.right);
+        },
+        [&](const UnaryExpr& node) {
+          indent();
+          out_ << "UnaryExpr " << unary_op_str(node.op) << "\n";
+          Scope scope(depth_);
+          print_expr(*node.operand);
+        },
+        [&](const CallExpr& node) {
+          indent();
+          out_ << "CallExpr\n";
+          Scope scope(depth_);
+          indent();
+          out_ << "Callee\n";
+          {
+            Scope callee_scope(depth_);
+            print_expr(*node.callee);
+          }
+          if (!node.args.empty()) {
+            indent();
+            out_ << "Args\n";
+            Scope args_scope(depth_);
+            for (const auto* arg : node.args) {
+              print_expr(*arg);
+            }
+          }
+        },
+        [&](const IndexExpr& node) {
+          indent();
+          out_ << "IndexExpr\n";
+          Scope scope(depth_);
+          print_expr(*node.object);
+          indent();
+          out_ << "Indices\n";
+          {
+            Scope indices_scope(depth_);
+            for (const auto* idx : node.indices) {
+              print_expr(*idx);
+            }
+          }
+        },
+        [&](const FieldExpr& node) {
+          indent();
+          out_ << "FieldExpr ." << node.field << "\n";
+          Scope scope(depth_);
+          print_expr(*node.object);
+        },
+        [&](const PipeExpr& node) {
+          indent();
+          out_ << "PipeExpr\n";
+          Scope scope(depth_);
+          print_expr(*node.left);
+          print_expr(*node.right);
+        },
+        [&](const LambdaExpr& node) {
+          indent();
+          out_ << "Lambda";
+          for (const auto& [name, span] : node.params) {
+            out_ << " " << name;
+          }
+          out_ << "\n";
+          Scope scope(depth_);
+          print_expr(*node.body);
+        },
+        [&](const ListLiteral& node) {
+          indent();
+          out_ << "ListLiteral\n";
+          if (!node.elements.empty()) {
+            Scope scope(depth_);
+            for (const auto* elem : node.elements) {
+              print_expr(*elem);
+            }
+          }
+        },
+    }, expr.payload);
   }
 
   // -----------------------------------------------------------------------
@@ -532,36 +424,25 @@ private:
   // -----------------------------------------------------------------------
 
   void print_type_inline(const TypeNode& type) {
-    switch (type.kind()) {
-    case NodeKind::NamedType:
-      print_named_type_inline(static_cast<const NamedTypeNode&>(type));
-      break;
-    case NodeKind::PointerType:
-      print_pointer_type_inline(static_cast<const PointerTypeNode&>(type));
-      break;
-    default:
-      out_ << "?";
-      break;
-    }
-  }
-
-  void print_named_type_inline(const NamedTypeNode& type) {
-    print_qualified_path(type.name());
-    if (!type.type_args().empty()) {
-      out_ << "[";
-      for (size_t i = 0; i < type.type_args().size(); ++i) {
-        if (i > 0) {
-          out_ << ", ";
-        }
-        print_type_inline(*type.type_args()[i]);
-      }
-      out_ << "]";
-    }
-  }
-
-  void print_pointer_type_inline(const PointerTypeNode& type) {
-    out_ << "*";
-    print_type_inline(*type.pointee());
+    std::visit(overloaded{
+        [&](const NamedType& named) {
+          print_qualified_path(named.name);
+          if (!named.type_args.empty()) {
+            out_ << "[";
+            for (size_t i = 0; i < named.type_args.size(); ++i) {
+              if (i > 0) {
+                out_ << ", ";
+              }
+              print_type_inline(*named.type_args[i]);
+            }
+            out_ << "]";
+          }
+        },
+        [&](const PointerType& ptr) {
+          out_ << "*";
+          print_type_inline(*ptr.pointee);
+        },
+    }, type.payload);
   }
 
   void print_qualified_path(const QualifiedPath& path) {

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -82,7 +82,7 @@ private:
     skip_newlines();
     Span file_span = peek().span;
 
-    std::vector<AstNode*> imports;
+    std::vector<ImportNode*> imports;
     while (peek_kind() == TokenKind::KwImport) {
       imports.push_back(parse_import());
       skip_newlines();
@@ -158,7 +158,8 @@ private:
         consume(TokenKind::Colon);
         auto fields = parse_field_list();
         Span span = span_from(peek().span);
-        return ctx_.alloc<ClassDeclNode>(span, name_tok.text, name_tok.span, std::move(fields));
+        return ctx_.alloc<Decl>(
+            span, ClassDecl{name_tok.text, name_tok.span, std::move(fields)});
       }
       error("expected declaration (fn, extern, class, or type)");
       advance(); // skip problematic token
@@ -166,7 +167,7 @@ private:
     }
   }
 
-  auto parse_extern_decl() -> FunctionDeclNode* {
+  auto parse_extern_decl() -> Decl* {
     advance(); // consume 'extern'
     if (peek_kind() != TokenKind::KwFn) {
       error("expected 'fn' after 'extern'");
@@ -175,7 +176,7 @@ private:
     return parse_function_decl(/*is_extern=*/true);
   }
 
-  auto parse_function_decl(bool is_extern) -> FunctionDeclNode* {
+  auto parse_function_decl(bool is_extern) -> Decl* {
     const auto& kw = consume(TokenKind::KwFn);
     const auto& name_tok = consume(TokenKind::Identifier);
 
@@ -220,14 +221,10 @@ private:
     }
 
     Span span = span_from(kw.span);
-    return ctx_.alloc<FunctionDeclNode>(span,
-                                        name_tok.text,
-                                        name_tok.span,
-                                        std::move(params),
-                                        return_type,
-                                        std::move(body),
-                                        expr_body,
-                                        is_extern);
+    return ctx_.alloc<Decl>(
+        span,
+        FunctionDecl{name_tok.text, name_tok.span, std::move(params),
+                     return_type, std::move(body), expr_body, is_extern});
   }
 
   auto parse_params() -> std::vector<Param> {
@@ -250,19 +247,20 @@ private:
     return {.name = name_tok.text, .name_span = name_tok.span, .type = type};
   }
 
-  auto parse_class_decl() -> ClassDeclNode* {
+  auto parse_class_decl() -> Decl* {
     const auto& kw = consume(TokenKind::KwClass);
     const auto& name_tok = consume(TokenKind::Identifier);
     consume(TokenKind::Colon);
     auto fields = parse_field_list();
     Span span = span_from(kw.span);
-    return ctx_.alloc<ClassDeclNode>(span, name_tok.text, name_tok.span, std::move(fields));
+    return ctx_.alloc<Decl>(
+        span, ClassDecl{name_tok.text, name_tok.span, std::move(fields)});
   }
 
-  auto parse_field_list() -> std::vector<FieldSpecNode*> {
+  auto parse_field_list() -> std::vector<FieldSpec*> {
     consume(TokenKind::Newline);
     consume(TokenKind::Indent);
-    std::vector<FieldSpecNode*> fields;
+    std::vector<FieldSpec*> fields;
     while (peek_kind() != TokenKind::Dedent && peek_kind() != TokenKind::Eof) {
       fields.push_back(parse_field_spec());
     }
@@ -273,23 +271,24 @@ private:
     return fields;
   }
 
-  auto parse_field_spec() -> FieldSpecNode* {
+  auto parse_field_spec() -> FieldSpec* {
     const auto& name_tok = consume(TokenKind::Identifier);
     consume(TokenKind::Colon);
     auto* type = parse_type();
     consume(TokenKind::Newline);
     Span span = span_from(name_tok.span);
-    return ctx_.alloc<FieldSpecNode>(span, name_tok.text, name_tok.span, type);
+    return ctx_.alloc<FieldSpec>(span, name_tok.text, name_tok.span, type);
   }
 
-  auto parse_alias_decl() -> AliasDeclNode* {
+  auto parse_alias_decl() -> Decl* {
     const auto& kw = consume(TokenKind::KwType);
     const auto& name_tok = consume(TokenKind::Identifier);
     consume(TokenKind::Eq);
     auto* type = parse_type();
     consume(TokenKind::Newline);
     Span span = span_from(kw.span);
-    return ctx_.alloc<AliasDeclNode>(span, name_tok.text, name_tok.span, type);
+    return ctx_.alloc<Decl>(
+        span, AliasDecl{name_tok.text, name_tok.span, type});
   }
 
   // -----------------------------------------------------------------------
@@ -358,17 +357,17 @@ private:
       auto* value = parse_expression();
       // Trailing newline may have been consumed by pipe continuation.
       match(TokenKind::Newline);
-      Span span = {.offset = expr->span().offset,
-                   .length = (value->span().offset + value->span().length) - expr->span().offset};
-      return ctx_.alloc<AssignmentNode>(span, expr, value);
+      Span span = {.offset = expr->span.offset,
+                   .length = (value->span.offset + value->span.length) - expr->span.offset};
+      return ctx_.alloc<Stmt>(span, Assignment{expr, value});
     }
 
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
-    return ctx_.alloc<ExpressionStatementNode>(expr->span(), expr);
+    return ctx_.alloc<Stmt>(expr->span, ExpressionStatement{expr});
   }
 
-  auto parse_let_statement() -> LetStatementNode* {
+  auto parse_let_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwLet);
     const auto& name_tok = consume(TokenKind::Identifier);
 
@@ -392,10 +391,11 @@ private:
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
     Span span = span_from(kw.span);
-    return ctx_.alloc<LetStatementNode>(span, name_tok.text, name_tok.span, type, init);
+    return ctx_.alloc<Stmt>(
+        span, LetStatement{name_tok.text, name_tok.span, type, init});
   }
 
-  auto parse_if_statement() -> IfStatementNode* {
+  auto parse_if_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwIf);
     auto* condition = parse_expression();
     consume(TokenKind::Colon);
@@ -409,19 +409,20 @@ private:
     }
 
     Span span = span_from(kw.span);
-    return ctx_.alloc<IfStatementNode>(span, condition, std::move(then_body), std::move(else_body));
+    return ctx_.alloc<Stmt>(
+        span, IfStatement{condition, std::move(then_body), std::move(else_body)});
   }
 
-  auto parse_while_statement() -> WhileStatementNode* {
+  auto parse_while_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwWhile);
     auto* condition = parse_expression();
     consume(TokenKind::Colon);
     auto body = parse_suite();
     Span span = span_from(kw.span);
-    return ctx_.alloc<WhileStatementNode>(span, condition, std::move(body));
+    return ctx_.alloc<Stmt>(span, WhileStatement{condition, std::move(body)});
   }
 
-  auto parse_for_statement() -> ForStatementNode* {
+  auto parse_for_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwFor);
     const auto& var_tok = consume(TokenKind::Identifier);
     consume(TokenKind::KwIn);
@@ -429,31 +430,35 @@ private:
     consume(TokenKind::Colon);
     auto body = parse_suite();
     Span span = span_from(kw.span);
-    return ctx_.alloc<ForStatementNode>(
-        span, var_tok.text, var_tok.span, iterable, std::move(body));
+    return ctx_.alloc<Stmt>(
+        span,
+        ForStatement{var_tok.text, var_tok.span, iterable, std::move(body)});
   }
 
-  auto parse_mode_block() -> ModeBlockNode* {
+  auto parse_mode_block() -> Stmt* {
     const auto& kw = consume(TokenKind::KwMode);
     const auto& name_tok = consume(TokenKind::Identifier);
     consume(TokenKind::FatArrow);
     auto body = parse_suite();
     Span span = span_from(kw.span);
-    return ctx_.alloc<ModeBlockNode>(span, name_tok.text, name_tok.span, std::move(body));
+    return ctx_.alloc<Stmt>(
+        span, ModeBlock{name_tok.text, name_tok.span, std::move(body)});
   }
 
-  auto parse_resource_block() -> ResourceBlockNode* {
+  auto parse_resource_block() -> Stmt* {
     const auto& kw = consume(TokenKind::KwResource);
     const auto& kind_tok = consume(TokenKind::Identifier);
     const auto& name_tok = consume(TokenKind::Identifier);
     consume(TokenKind::FatArrow);
     auto body = parse_suite();
     Span span = span_from(kw.span);
-    return ctx_.alloc<ResourceBlockNode>(
-        span, kind_tok.text, kind_tok.span, name_tok.text, name_tok.span, std::move(body));
+    return ctx_.alloc<Stmt>(
+        span,
+        ResourceBlock{kind_tok.text, kind_tok.span, name_tok.text,
+                      name_tok.span, std::move(body)});
   }
 
-  auto parse_return_statement() -> ReturnStatementNode* {
+  auto parse_return_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwReturn);
     Expr* value = nullptr;
     if (peek_kind() != TokenKind::Newline &&
@@ -464,7 +469,7 @@ private:
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
     Span span = span_from(kw.span);
-    return ctx_.alloc<ReturnStatementNode>(span, value);
+    return ctx_.alloc<Stmt>(span, ReturnStatement{value});
   }
 
   // -----------------------------------------------------------------------
@@ -500,9 +505,9 @@ private:
         right = parse_application();
         in_pipe_target_ = false;
       }
-      Span span = {.offset = left->span().offset,
-                   .length = (right->span().offset + right->span().length) - left->span().offset};
-      left = ctx_.alloc<PipeExprNode>(span, left, right);
+      Span span = {.offset = left->span.offset,
+                   .length = (right->span.offset + right->span.length) - left->span.offset};
+      left = ctx_.alloc<Expr>(span, PipeExpr{left, right});
     }
 
     // Consume matching DEDENTs for pipe continuation indents.
@@ -655,8 +660,8 @@ private:
       auto* operand = parse_unary();
       Span span = {.offset = op_tok.span.offset,
                    .length =
-                       (operand->span().offset + operand->span().length) - op_tok.span.offset};
-      return ctx_.alloc<UnaryExprNode>(span, op, operand);
+                       (operand->span.offset + operand->span.length) - op_tok.span.offset};
+      return ctx_.alloc<Expr>(span, UnaryExpr{op, operand});
     }
     return parse_application();
   }
@@ -677,10 +682,10 @@ private:
           args.push_back(parse_postfix());
         }
       }
-      Span span = {.offset = callee->span().offset,
-                   .length = (args.back()->span().offset + args.back()->span().length) -
-                             callee->span().offset};
-      return ctx_.alloc<CallExprNode>(span, callee, std::move(args));
+      Span span = {.offset = callee->span.offset,
+                   .length = (args.back()->span.offset + args.back()->span.length) -
+                             callee->span.offset};
+      return ctx_.alloc<Expr>(span, CallExpr{callee, std::move(args)});
     }
 
     return callee;
@@ -711,17 +716,17 @@ private:
           }
         }
         const auto& rparen = consume(TokenKind::RParen);
-        Span span = {.offset = expr->span().offset,
-                     .length = (rparen.span.offset + rparen.span.length) - expr->span().offset};
-        expr = ctx_.alloc<CallExprNode>(span, expr, std::move(args));
+        Span span = {.offset = expr->span.offset,
+                     .length = (rparen.span.offset + rparen.span.length) - expr->span.offset};
+        expr = ctx_.alloc<Expr>(span, CallExpr{expr, std::move(args)});
       } else if (peek_kind() == TokenKind::Dot) {
         // Field access: expr.field
         advance(); // .
         const auto& field_tok = consume(TokenKind::Identifier);
-        Span span = {.offset = expr->span().offset,
+        Span span = {.offset = expr->span.offset,
                      .length =
-                         (field_tok.span.offset + field_tok.span.length) - expr->span().offset};
-        expr = ctx_.alloc<FieldExprNode>(span, expr, field_tok.text, field_tok.span);
+                         (field_tok.span.offset + field_tok.span.length) - expr->span.offset};
+        expr = ctx_.alloc<Expr>(span, FieldExpr{expr, field_tok.text, field_tok.span});
       } else if (peek_kind() == TokenKind::LBracket) {
         // Index or type-parameter application: expr[args]
         advance(); // [
@@ -732,9 +737,9 @@ private:
           indices.push_back(parse_expression());
         }
         const auto& rbracket = consume(TokenKind::RBracket);
-        Span span = {.offset = expr->span().offset,
-                     .length = (rbracket.span.offset + rbracket.span.length) - expr->span().offset};
-        expr = ctx_.alloc<IndexExprNode>(span, expr, std::move(indices));
+        Span span = {.offset = expr->span.offset,
+                     .length = (rbracket.span.offset + rbracket.span.length) - expr->span.offset};
+        expr = ctx_.alloc<Expr>(span, IndexExpr{expr, std::move(indices)});
       } else {
         break;
       }
@@ -748,23 +753,23 @@ private:
     switch (peek_kind()) {
     case TokenKind::IntLiteral: {
       const auto& tok = advance();
-      return ctx_.alloc<IntLiteralNode>(tok.span, tok.text);
+      return ctx_.alloc<Expr>(tok.span, IntLiteral{tok.text});
     }
     case TokenKind::FloatLiteral: {
       const auto& tok = advance();
-      return ctx_.alloc<FloatLiteralNode>(tok.span, tok.text);
+      return ctx_.alloc<Expr>(tok.span, FloatLiteral{tok.text});
     }
     case TokenKind::StringLiteral: {
       const auto& tok = advance();
-      return ctx_.alloc<StringLiteralNode>(tok.span, tok.text);
+      return ctx_.alloc<Expr>(tok.span, StringLiteral{tok.text});
     }
     case TokenKind::KwTrue: {
       const auto& tok = advance();
-      return ctx_.alloc<BoolLiteralNode>(tok.span, true);
+      return ctx_.alloc<Expr>(tok.span, BoolLiteral{true});
     }
     case TokenKind::KwFalse: {
       const auto& tok = advance();
-      return ctx_.alloc<BoolLiteralNode>(tok.span, false);
+      return ctx_.alloc<Expr>(tok.span, BoolLiteral{false});
     }
     case TokenKind::LParen: {
       advance(); // (
@@ -782,7 +787,7 @@ private:
       error("expected expression");
       const auto& tok = advance();
       // Return an error placeholder.
-      return ctx_.alloc<IdentifierNode>(tok.span, tok.text);
+      return ctx_.alloc<Expr>(tok.span, IdentifierExpr{tok.text});
     }
   }
 
@@ -799,7 +804,7 @@ private:
     const auto& rbracket = consume(TokenKind::RBracket);
     Span span = {.offset = lbracket.span.offset,
                  .length = (rbracket.span.offset + rbracket.span.length) - lbracket.span.offset};
-    return ctx_.alloc<ListLiteralNode>(span, std::move(elements));
+    return ctx_.alloc<Expr>(span, ListLiteral{std::move(elements)});
   }
 
   auto parse_lambda() -> Expr* {
@@ -818,14 +823,14 @@ private:
     consume(TokenKind::Arrow);
     auto* body = parse_expression();
     Span span = {.offset = open_pipe.span.offset,
-                 .length = (body->span().offset + body->span().length) - open_pipe.span.offset};
-    return ctx_.alloc<LambdaNode>(span, std::move(params), body);
+                 .length = (body->span.offset + body->span.length) - open_pipe.span.offset};
+    return ctx_.alloc<Expr>(span, LambdaExpr{std::move(params), body});
   }
 
   auto parse_qualified_name_or_identifier() -> Expr* {
     const auto& first = consume(TokenKind::Identifier);
     if (peek_kind() != TokenKind::ColonColon) {
-      return ctx_.alloc<IdentifierNode>(first.span, first.text);
+      return ctx_.alloc<Expr>(first.span, IdentifierExpr{first.text});
     }
 
     // Qualified name: ident :: ident (:: ident)*
@@ -840,7 +845,7 @@ private:
       span.length = (seg.span.offset + seg.span.length) - span.offset;
     }
 
-    return ctx_.alloc<QualifiedNameNode>(span, std::move(segments));
+    return ctx_.alloc<Expr>(span, QualifiedName{std::move(segments)});
   }
 
   // -----------------------------------------------------------------------
@@ -852,14 +857,14 @@ private:
       const auto& star = advance();
       auto* pointee = parse_type();
       Span span = {.offset = star.span.offset,
-                   .length = (pointee->span().offset + pointee->span().length) - star.span.offset};
-      return ctx_.alloc<PointerTypeNode>(span, pointee);
+                   .length = (pointee->span.offset + pointee->span.length) - star.span.offset};
+      return ctx_.alloc<TypeNode>(span, PointerType{pointee});
     }
 
     return parse_named_type();
   }
 
-  auto parse_named_type() -> NamedTypeNode* {
+  auto parse_named_type() -> TypeNode* {
     auto path = parse_type_path();
 
     std::vector<TypeNode*> type_args;
@@ -874,7 +879,7 @@ private:
       path.span.length = (rbracket.span.offset + rbracket.span.length) - path.span.offset;
     }
 
-    return ctx_.alloc<NamedTypeNode>(path.span, std::move(path), std::move(type_args));
+    return ctx_.alloc<TypeNode>(path.span, NamedType{std::move(path), std::move(type_args)});
   }
 
   auto parse_type_path() -> QualifiedPath {
@@ -897,10 +902,10 @@ private:
   // Helpers
   // -----------------------------------------------------------------------
 
-  auto make_binary(BinaryOp op, Expr* left, Expr* right) -> BinaryExprNode* {
-    Span span = {.offset = left->span().offset,
-                 .length = (right->span().offset + right->span().length) - left->span().offset};
-    return ctx_.alloc<BinaryExprNode>(span, op, left, right);
+  auto make_binary(BinaryOp op, Expr* left, Expr* right) -> Expr* {
+    Span span = {.offset = left->span.offset,
+                 .length = (right->span.offset + right->span.length) - left->span.offset};
+    return ctx_.alloc<Expr>(span, BinaryExpr{op, left, right});
   }
 
   auto span_from(Span start) -> Span {

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -52,37 +52,39 @@ suite<"function_tests"> function_tests = [] {
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
     auto* file = output.parse_result.file;
     expect(file != nullptr);
-    expect(file->declarations().size() == 1_u);
+    expect(file->declarations.size() == 1_u);
 
-    auto* fn = static_cast<FunctionDeclNode*>(file->declarations()[0]);
-    expect(fn->kind() == NodeKind::FunctionDecl);
-    expect(fn->name() == "add");
-    expect(fn->params().size() == 2_u);
-    expect(fn->params()[0].name == "a");
-    expect(fn->params()[1].name == "b");
-    expect(fn->return_type() != nullptr);
-    expect(fn->is_expr_bodied());
-    expect(fn->expr_body() != nullptr);
-    expect(fn->expr_body()->kind() == NodeKind::BinaryExpr);
+    auto* decl0 = file->declarations[0];
+    const auto& fn = decl0->as<FunctionDecl>();
+    expect(decl0->kind() == NodeKind::FunctionDecl);
+    expect(fn.name == "add");
+    expect(fn.params.size() == 2_u);
+    expect(fn.params[0].name == "a");
+    expect(fn.params[1].name == "b");
+    expect(fn.return_type != nullptr);
+    expect(fn.is_expr_bodied());
+    expect(fn.expr_body != nullptr);
+    expect(fn.expr_body->kind() == NodeKind::BinaryExpr);
   };
 
   "block-bodied function"_test = [] {
     auto output = parse_string("fn main(): i32\n    0\n");
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
     auto* file = output.parse_result.file;
-    expect(file->declarations().size() == 1_u);
+    expect(file->declarations.size() == 1_u);
 
-    auto* fn = static_cast<FunctionDeclNode*>(file->declarations()[0]);
-    expect(!fn->is_expr_bodied());
-    expect(fn->body().size() == 1_u);
-    expect(fn->body()[0]->kind() == NodeKind::ExpressionStatement);
+    auto* decl0 = file->declarations[0];
+    const auto& fn = decl0->as<FunctionDecl>();
+    expect(!fn.is_expr_bodied());
+    expect(fn.body.size() == 1_u);
+    expect(fn.body[0]->kind() == NodeKind::ExpressionStatement);
   };
 
   "no-param function"_test = [] {
     auto output = parse_string("fn greet(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    expect(fn->params().empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.params.empty());
   };
 };
 
@@ -90,32 +92,32 @@ suite<"let_tests"> let_tests = [] {
   "let with type and initializer"_test = [] {
     auto output = parse_string("fn f(): i32\n    let x: i32 = 42\n    x\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    expect(fn->body().size() == 2_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.body.size() == 2_u);
 
-    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
-    expect(let_stmt->kind() == NodeKind::LetStatement);
-    expect(let_stmt->name() == "x");
-    expect(let_stmt->type() != nullptr);
-    expect(let_stmt->initializer() != nullptr);
+    const auto& let_stmt = fn.body[0]->as<LetStatement>();
+    expect(fn.body[0]->kind() == NodeKind::LetStatement);
+    expect(let_stmt.name == "x");
+    expect(let_stmt.type != nullptr);
+    expect(let_stmt.initializer != nullptr);
   };
 
   "let with type only"_test = [] {
     auto output = parse_string("fn f(): i32\n    let x: i32\n    x\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
-    expect(let_stmt->type() != nullptr);
-    expect(let_stmt->initializer() == nullptr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& let_stmt = fn.body[0]->as<LetStatement>();
+    expect(let_stmt.type != nullptr);
+    expect(let_stmt.initializer == nullptr);
   };
 
   "let with initializer only"_test = [] {
     auto output = parse_string("fn f(): i32\n    let x = 42\n    x\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* let_stmt = static_cast<LetStatementNode*>(fn->body()[0]);
-    expect(let_stmt->type() == nullptr);
-    expect(let_stmt->initializer() != nullptr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& let_stmt = fn.body[0]->as<LetStatement>();
+    expect(let_stmt.type == nullptr);
+    expect(let_stmt.initializer != nullptr);
   };
 };
 
@@ -123,39 +125,39 @@ suite<"control_flow_tests"> control_flow_tests = [] {
   "if statement"_test = [] {
     auto output = parse_string("fn f(): i32\n    if true:\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
-    expect(if_stmt->kind() == NodeKind::IfStatement);
-    expect(if_stmt->condition()->kind() == NodeKind::BoolLiteral);
-    expect(if_stmt->then_body().size() == 1_u);
-    expect(!if_stmt->has_else());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& if_stmt = fn.body[0]->as<IfStatement>();
+    expect(fn.body[0]->kind() == NodeKind::IfStatement);
+    expect(if_stmt.condition->kind() == NodeKind::BoolLiteral);
+    expect(if_stmt.then_body.size() == 1_u);
+    expect(!if_stmt.has_else());
   };
 
   "if-else statement"_test = [] {
     auto output = parse_string("fn f(): i32\n    if true:\n        0\n    else:\n        1\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* if_stmt = static_cast<IfStatementNode*>(fn->body()[0]);
-    expect(if_stmt->has_else());
-    expect(if_stmt->else_body().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& if_stmt = fn.body[0]->as<IfStatement>();
+    expect(if_stmt.has_else());
+    expect(if_stmt.else_body.size() == 1_u);
   };
 
   "while statement"_test = [] {
     auto output = parse_string("fn f(): i32\n    while true:\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* while_stmt = static_cast<WhileStatementNode*>(fn->body()[0]);
-    expect(while_stmt->kind() == NodeKind::WhileStatement);
-    expect(while_stmt->body().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& while_stmt = fn.body[0]->as<WhileStatement>();
+    expect(fn.body[0]->kind() == NodeKind::WhileStatement);
+    expect(while_stmt.body.size() == 1_u);
   };
 
   "for statement"_test = [] {
     auto output = parse_string("fn f(): i32\n    for i in items:\n        i\n    0\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* for_stmt = static_cast<ForStatementNode*>(fn->body()[0]);
-    expect(for_stmt->kind() == NodeKind::ForStatement);
-    expect(for_stmt->var() == "i");
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& for_stmt = fn.body[0]->as<ForStatement>();
+    expect(fn.body[0]->kind() == NodeKind::ForStatement);
+    expect(for_stmt.var == "i");
   };
 };
 
@@ -163,86 +165,86 @@ suite<"expression_tests"> expression_tests = [] {
   "binary operators"_test = [] {
     auto output = parse_string("fn f(): i32 -> 1 + 2 * 3\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
     // Should be BinaryExpr(+, 1, BinaryExpr(*, 2, 3)) — * binds tighter than +
-    auto* add = static_cast<BinaryExprNode*>(fn->expr_body());
-    expect(add->kind() == NodeKind::BinaryExpr);
-    expect(add->op() == BinaryOp::Add);
-    expect(add->left()->kind() == NodeKind::IntLiteral);
-    expect(add->right()->kind() == NodeKind::BinaryExpr);
-    auto* mul = static_cast<BinaryExprNode*>(add->right());
-    expect(mul->op() == BinaryOp::Mul);
+    const auto& add = fn.expr_body->as<BinaryExpr>();
+    expect(fn.expr_body->kind() == NodeKind::BinaryExpr);
+    expect(add.op == BinaryOp::Add);
+    expect(add.left->kind() == NodeKind::IntLiteral);
+    expect(add.right->kind() == NodeKind::BinaryExpr);
+    const auto& mul = add.right->as<BinaryExpr>();
+    expect(mul.op == BinaryOp::Mul);
   };
 
   "unary operators"_test = [] {
     auto output = parse_string("fn f(p: *i32): i32 -> *p\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* deref = static_cast<UnaryExprNode*>(fn->expr_body());
-    expect(deref->kind() == NodeKind::UnaryExpr);
-    expect(deref->op() == UnaryOp::Deref);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& deref = fn.expr_body->as<UnaryExpr>();
+    expect(fn.expr_body->kind() == NodeKind::UnaryExpr);
+    expect(deref.op == UnaryOp::Deref);
   };
 
   "function call"_test = [] {
     auto output = parse_string("fn f(): i32\n    foo(1, 2)\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
-    expect(call->kind() == NodeKind::CallExpr);
-    expect(call->args().size() == 2_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& call = expr_stmt.expr->as<CallExpr>();
+    expect(expr_stmt.expr->kind() == NodeKind::CallExpr);
+    expect(call.args.size() == 2_u);
   };
 
   "field access"_test = [] {
     auto output = parse_string("fn f(): i32\n    x.y.z\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* outer = static_cast<FieldExprNode*>(expr_stmt->expr());
-    expect(outer->kind() == NodeKind::FieldExpr);
-    expect(outer->field() == "z");
-    auto* inner = static_cast<FieldExprNode*>(outer->object());
-    expect(inner->field() == "y");
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& outer = expr_stmt.expr->as<FieldExpr>();
+    expect(expr_stmt.expr->kind() == NodeKind::FieldExpr);
+    expect(outer.field == "z");
+    const auto& inner = outer.object->as<FieldExpr>();
+    expect(inner.field == "y");
   };
 
   "index expression"_test = [] {
     auto output = parse_string("fn f(): i32\n    a[0]\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* idx = static_cast<IndexExprNode*>(expr_stmt->expr());
-    expect(idx->kind() == NodeKind::IndexExpr);
-    expect(idx->indices().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& idx = expr_stmt.expr->as<IndexExpr>();
+    expect(expr_stmt.expr->kind() == NodeKind::IndexExpr);
+    expect(idx.indices.size() == 1_u);
   };
 
   "multi-arg bracket"_test = [] {
     auto output = parse_string("fn f(): i32\n    Map[i32, string]()\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
-    expect(call->kind() == NodeKind::CallExpr);
-    auto* idx = static_cast<IndexExprNode*>(call->callee());
-    expect(idx->indices().size() == 2_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& call = expr_stmt.expr->as<CallExpr>();
+    expect(expr_stmt.expr->kind() == NodeKind::CallExpr);
+    const auto& idx = call.callee->as<IndexExpr>();
+    expect(idx.indices.size() == 2_u);
   };
 
   "comparison operators"_test = [] {
     auto output = parse_string("fn f(): i32 -> 1 == 2\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* eq = static_cast<BinaryExprNode*>(fn->expr_body());
-    expect(eq->op() == BinaryOp::EqEq);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& eq = fn.expr_body->as<BinaryExpr>();
+    expect(eq.op == BinaryOp::EqEq);
   };
 
   "logical operators"_test = [] {
     auto output = parse_string("fn f(): i32 -> true and false or true\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
     // or binds less tightly than and: or(and(true, false), true)
-    auto* or_expr = static_cast<BinaryExprNode*>(fn->expr_body());
-    expect(or_expr->op() == BinaryOp::Or);
-    auto* and_expr = static_cast<BinaryExprNode*>(or_expr->left());
-    expect(and_expr->op() == BinaryOp::And);
+    const auto& or_expr = fn.expr_body->as<BinaryExpr>();
+    expect(or_expr.op == BinaryOp::Or);
+    const auto& and_expr = or_expr.left->as<BinaryExpr>();
+    expect(and_expr.op == BinaryOp::And);
   };
 };
 
@@ -255,9 +257,9 @@ suite<"lambda_tests"> lambda_tests = [] {
   "lambda in pipe"_test = [] {
     auto output = parse_string("fn f(): i32\n    xs |> map |x| -> x * x\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    expect(expr_stmt->expr()->kind() == NodeKind::PipeExpr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    expect(expr_stmt.expr->kind() == NodeKind::PipeExpr);
   };
 };
 
@@ -265,20 +267,20 @@ suite<"pipe_tests"> pipe_tests = [] {
   "simple pipe"_test = [] {
     auto output = parse_string("fn f(): i32\n    x |> foo |> bar\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* outer = static_cast<PipeExprNode*>(expr_stmt->expr());
-    expect(outer->kind() == NodeKind::PipeExpr);
-    expect(outer->left()->kind() == NodeKind::PipeExpr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& outer = expr_stmt.expr->as<PipeExpr>();
+    expect(expr_stmt.expr->kind() == NodeKind::PipeExpr);
+    expect(outer.left->kind() == NodeKind::PipeExpr);
   };
 
   "multi-line pipe in suite"_test = [] {
     auto output = parse_string("fn f(): i32\n    xs\n        |> map |x| -> x\n    0\n");
     expect(output.parse_result.diagnostics.empty()) << "multi-line pipe in suite";
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    expect(fn->body().size() == 2_u) << "pipe expr + trailing 0";
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    expect(expr_stmt->expr()->kind() == NodeKind::PipeExpr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.body.size() == 2_u) << "pipe expr + trailing 0";
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    expect(expr_stmt.expr->kind() == NodeKind::PipeExpr);
   };
 };
 
@@ -286,22 +288,22 @@ suite<"mode_resource_tests"> mode_resource_tests = [] {
   "mode block"_test = [] {
     auto output = parse_string("fn f(): i32\n    mode unsafe =>\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* mode = static_cast<ModeBlockNode*>(fn->body()[0]);
-    expect(mode->kind() == NodeKind::ModeBlock);
-    expect(mode->mode_name() == "unsafe");
-    expect(mode->body().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& mode = fn.body[0]->as<ModeBlock>();
+    expect(fn.body[0]->kind() == NodeKind::ModeBlock);
+    expect(mode.mode_name == "unsafe");
+    expect(mode.body.size() == 1_u);
   };
 
   "resource block"_test = [] {
     auto output = parse_string("fn f(): i32\n    resource memory Search =>\n        0\n    1\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* res = static_cast<ResourceBlockNode*>(fn->body()[0]);
-    expect(res->kind() == NodeKind::ResourceBlock);
-    expect(res->resource_kind() == "memory");
-    expect(res->resource_name() == "Search");
-    expect(res->body().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& res = fn.body[0]->as<ResourceBlock>();
+    expect(fn.body[0]->kind() == NodeKind::ResourceBlock);
+    expect(res.resource_kind == "memory");
+    expect(res.resource_name == "Search");
+    expect(res.body.size() == 1_u);
   };
 };
 
@@ -309,28 +311,28 @@ suite<"type_tests"> type_tests = [] {
   "pointer type"_test = [] {
     auto output = parse_string("fn f(p: *i32): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* param_type = fn->params()[0].type;
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    auto* param_type = fn.params[0].type;
     expect(param_type->kind() == NodeKind::PointerType);
   };
 
   "parameterized type"_test = [] {
     auto output = parse_string("fn f(): List[i32] -> []\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
-    expect(ret->kind() == NodeKind::NamedType);
-    expect(ret->name().segments.size() == 1_u);
-    expect(ret->name().segments[0] == "List");
-    expect(ret->type_args().size() == 1_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& ret = fn.return_type->as<NamedType>();
+    expect(fn.return_type->kind() == NodeKind::NamedType);
+    expect(ret.name.segments.size() == 1_u);
+    expect(ret.name.segments[0] == "List");
+    expect(ret.type_args.size() == 1_u);
   };
 
   "multi-param type"_test = [] {
     auto output = parse_string("fn f(): Map[i32, string] -> []\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* ret = static_cast<NamedTypeNode*>(fn->return_type());
-    expect(ret->type_args().size() == 2_u);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& ret = fn.return_type->as<NamedType>();
+    expect(ret.type_args.size() == 2_u);
   };
 };
 
@@ -338,19 +340,19 @@ suite<"import_tests"> import_tests = [] {
   "simple import"_test = [] {
     auto output = parse_string("import foo\nfn f(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
-    expect(output.parse_result.file->imports().size() == 1_u);
-    auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
-    expect(imp->path().segments.size() == 1_u);
-    expect(imp->path().segments[0] == "foo");
+    expect(output.parse_result.file->imports.size() == 1_u);
+    auto* imp = output.parse_result.file->imports[0];
+    expect(imp->path.segments.size() == 1_u);
+    expect(imp->path.segments[0] == "foo");
   };
 
   "qualified import"_test = [] {
     auto output = parse_string("import net::http\nfn f(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* imp = static_cast<ImportNode*>(output.parse_result.file->imports()[0]);
-    expect(imp->path().segments.size() == 2_u);
-    expect(imp->path().segments[0] == "net");
-    expect(imp->path().segments[1] == "http");
+    auto* imp = output.parse_result.file->imports[0];
+    expect(imp->path.segments.size() == 2_u);
+    expect(imp->path.segments[0] == "net");
+    expect(imp->path.segments[1] == "http");
   };
 };
 
@@ -358,27 +360,27 @@ suite<"assignment_tests"> assignment_tests = [] {
   "simple assignment"_test = [] {
     auto output = parse_string("fn f(): i32\n    x = 42\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
-    expect(assign->kind() == NodeKind::Assignment);
-    expect(assign->target()->kind() == NodeKind::Identifier);
-    expect(assign->value()->kind() == NodeKind::IntLiteral);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& assign = fn.body[0]->as<Assignment>();
+    expect(fn.body[0]->kind() == NodeKind::Assignment);
+    expect(assign.target->kind() == NodeKind::Identifier);
+    expect(assign.value->kind() == NodeKind::IntLiteral);
   };
 
   "field assignment"_test = [] {
     auto output = parse_string("fn f(): i32\n    x.y = 42\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
-    expect(assign->target()->kind() == NodeKind::FieldExpr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& assign = fn.body[0]->as<Assignment>();
+    expect(assign.target->kind() == NodeKind::FieldExpr);
   };
 
   "index assignment"_test = [] {
     auto output = parse_string("fn f(): i32\n    a[0] = 42\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* assign = static_cast<AssignmentNode*>(fn->body()[0]);
-    expect(assign->target()->kind() == NodeKind::IndexExpr);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& assign = fn.body[0]->as<Assignment>();
+    expect(assign.target->kind() == NodeKind::IndexExpr);
   };
 
   "invalid assignment target"_test = [] {
@@ -391,10 +393,10 @@ suite<"return_tests"> return_tests = [] {
   "return statement"_test = [] {
     auto output = parse_string("fn f(): i32\n    return 42\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* ret = static_cast<ReturnStatementNode*>(fn->body()[0]);
-    expect(ret->kind() == NodeKind::ReturnStatement);
-    expect(ret->value()->kind() == NodeKind::IntLiteral);
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& ret = fn.body[0]->as<ReturnStatement>();
+    expect(fn.body[0]->kind() == NodeKind::ReturnStatement);
+    expect(ret.value->kind() == NodeKind::IntLiteral);
   };
 };
 
@@ -403,32 +405,33 @@ suite<"class_tests"> class_tests = [] {
     auto output = parse_string("class Point:\n    x: i32\n    y: i32\n");
     expect(output.parse_result.diagnostics.empty()) << "no parse errors";
     auto* file = output.parse_result.file;
-    expect(file->declarations().size() == 1_u);
+    expect(file->declarations.size() == 1_u);
 
-    auto* cls = static_cast<ClassDeclNode*>(file->declarations()[0]);
-    expect(cls->kind() == NodeKind::ClassDecl);
-    expect(cls->name() == "Point");
-    expect(cls->fields().size() == 2_u);
-    expect(cls->fields()[0]->name() == "x");
-    expect(cls->fields()[1]->name() == "y");
-    expect(cls->fields()[0]->type() != nullptr);
-    expect(cls->fields()[1]->type() != nullptr);
+    auto* decl0 = file->declarations[0];
+    const auto& cls = decl0->as<ClassDecl>();
+    expect(decl0->kind() == NodeKind::ClassDecl);
+    expect(cls.name == "Point");
+    expect(cls.fields.size() == 2_u);
+    expect(cls.fields[0]->name == "x");
+    expect(cls.fields[1]->name == "y");
+    expect(cls.fields[0]->type != nullptr);
+    expect(cls.fields[1]->type != nullptr);
   };
 
   "class with single field"_test = [] {
     auto output = parse_string("class Wrapper:\n    value: string\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* cls = static_cast<ClassDeclNode*>(output.parse_result.file->declarations()[0]);
-    expect(cls->fields().size() == 1_u);
-    expect(cls->fields()[0]->name() == "value");
+    const auto& cls = output.parse_result.file->declarations[0]->as<ClassDecl>();
+    expect(cls.fields.size() == 1_u);
+    expect(cls.fields[0]->name == "value");
   };
 
   "class followed by function"_test = [] {
     auto output = parse_string("class Point:\n    x: i32\n    y: i32\nfn f(): i32 -> 0\n");
     expect(output.parse_result.diagnostics.empty());
-    expect(output.parse_result.file->declarations().size() == 2_u);
-    expect(output.parse_result.file->declarations()[0]->kind() == NodeKind::ClassDecl);
-    expect(output.parse_result.file->declarations()[1]->kind() == NodeKind::FunctionDecl);
+    expect(output.parse_result.file->declarations.size() == 2_u);
+    expect(output.parse_result.file->declarations[0]->kind() == NodeKind::ClassDecl);
+    expect(output.parse_result.file->declarations[1]->kind() == NodeKind::FunctionDecl);
   };
 
   "let inside class body is rejected"_test = [] {
@@ -481,14 +484,14 @@ suite<"qualified_name_tests"> qualified_name_tests = [] {
   "qualified name in expression"_test = [] {
     auto output = parse_string("fn f(): i32\n    Foo::bar()\n");
     expect(output.parse_result.diagnostics.empty());
-    auto* fn = static_cast<FunctionDeclNode*>(output.parse_result.file->declarations()[0]);
-    auto* expr_stmt = static_cast<ExpressionStatementNode*>(fn->body()[0]);
-    auto* call = static_cast<CallExprNode*>(expr_stmt->expr());
-    expect(call->callee()->kind() == NodeKind::QualifiedName);
-    auto* qn = static_cast<QualifiedNameNode*>(call->callee());
-    expect(qn->segments().size() == 2_u);
-    expect(qn->segments()[0] == "Foo");
-    expect(qn->segments()[1] == "bar");
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& expr_stmt = fn.body[0]->as<ExpressionStatement>();
+    const auto& call = expr_stmt.expr->as<CallExpr>();
+    expect(call.callee->kind() == NodeKind::QualifiedName);
+    const auto& qn = call.callee->as<QualifiedName>();
+    expect(qn.segments.size() == 2_u);
+    expect(qn.segments[0] == "Foo");
+    expect(qn.segments[1] == "bar");
   };
 };
 

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -95,19 +95,18 @@ private:
 
   void collect_top_level(const FileNode& file) {
     // Register imports.
-    for (const auto* imp : file.imports()) {
-      const auto& import_node = static_cast<const ImportNode&>(*imp);
-      collect_import(import_node);
+    for (const auto* imp : file.imports) {
+      collect_import(*imp);
     }
 
     // Register top-level declarations.
-    for (const auto* decl : file.declarations()) {
+    for (const auto* decl : file.declarations) {
       collect_decl(*decl);
     }
   }
 
   void collect_import(const ImportNode& node) {
-    const auto& path = node.path();
+    const auto& path = node.path;
     if (path.segments.empty()) {
       return;
     }
@@ -140,23 +139,23 @@ private:
 
     switch (decl.kind()) {
     case NodeKind::FunctionDecl: {
-      const auto& fn = static_cast<const FunctionDeclNode&>(decl);
-      name = fn.name();
-      name_span = fn.name_span();
+      const auto& fn = decl.as<FunctionDecl>();
+      name = fn.name;
+      name_span = fn.name_span;
       kind = SymbolKind::Function;
       break;
     }
     case NodeKind::ClassDecl: {
-      const auto& st = static_cast<const ClassDeclNode&>(decl);
-      name = st.name();
-      name_span = st.name_span();
+      const auto& st = decl.as<ClassDecl>();
+      name = st.name;
+      name_span = st.name_span;
       kind = SymbolKind::Type;
       break;
     }
     case NodeKind::AliasDecl: {
-      const auto& alias = static_cast<const AliasDeclNode&>(decl);
-      name = alias.name();
-      name_span = alias.name_span();
+      const auto& alias = decl.as<AliasDecl>();
+      name = alias.name;
+      name_span = alias.name_span;
       kind = SymbolKind::Type;
       break;
     }
@@ -177,7 +176,7 @@ private:
   // --- Pass 2: Resolve bodies ---
 
   void resolve_bodies(const FileNode& file) {
-    for (const auto* decl : file.declarations()) {
+    for (const auto* decl : file.declarations) {
       resolve_decl(*decl, file_scope_);
     }
   }
@@ -185,30 +184,31 @@ private:
   void resolve_decl(const Decl& decl, Scope* scope) {
     switch (decl.kind()) {
     case NodeKind::FunctionDecl:
-      resolve_function(static_cast<const FunctionDeclNode&>(decl), scope);
+      resolve_function(decl, scope);
       break;
     case NodeKind::ClassDecl:
-      resolve_class(static_cast<const ClassDeclNode&>(decl), scope);
+      resolve_class(decl, scope);
       break;
     case NodeKind::AliasDecl:
-      resolve_alias(static_cast<const AliasDeclNode&>(decl), scope);
+      resolve_alias(decl, scope);
       break;
     default:
       break;
     }
   }
 
-  void resolve_function(const FunctionDeclNode& fn, Scope* parent) {
+  void resolve_function(const Decl& decl, Scope* parent) {
+    const auto& fn = decl.as<FunctionDecl>();
     auto* fn_scope = ctx_.make_scope(ScopeKind::Function, parent);
 
     // Declare parameters.
-    for (const auto& param : fn.params()) {
+    for (const auto& param : fn.params) {
       if (fn_scope->lookup_local(param.name) != nullptr) {
         diagnostics_.push_back(Diagnostic::error(
             param.name_span,
             "duplicate parameter '" + std::string(param.name) + "'"));
       } else {
-        auto* sym = ctx_.make_symbol(SymbolKind::Param, param.name, param.name_span, &fn);
+        auto* sym = ctx_.make_symbol(SymbolKind::Param, param.name, param.name_span, &decl);
         fn_scope->declare(param.name, sym);
       }
 
@@ -219,46 +219,48 @@ private:
     }
 
     // Resolve return type.
-    if (fn.return_type() != nullptr) {
-      resolve_type(*fn.return_type(), fn_scope);
+    if (fn.return_type != nullptr) {
+      resolve_type(*fn.return_type, fn_scope);
     }
 
     // Resolve body statements in a nested block scope so that let
     // bindings can shadow parameters without triggering duplicate errors.
     auto* body_scope = ctx_.make_scope(ScopeKind::Block, fn_scope);
-    for (const auto* stmt : fn.body()) {
+    for (const auto* stmt : fn.body) {
       resolve_stmt(*stmt, body_scope);
     }
 
     // Resolve expression body (same body scope).
-    if (fn.expr_body() != nullptr) {
-      resolve_expr(*fn.expr_body(), body_scope);
+    if (fn.expr_body != nullptr) {
+      resolve_expr(*fn.expr_body, body_scope);
     }
   }
 
-  void resolve_class(const ClassDeclNode& st, Scope* parent) {
+  void resolve_class(const Decl& decl, Scope* parent) {
+    const auto& st = decl.as<ClassDecl>();
     auto* struct_scope = ctx_.make_scope(ScopeKind::Struct, parent);
 
-    for (const auto* field : st.fields()) {
-      if (struct_scope->lookup_local(field->name()) != nullptr) {
+    for (const auto* field : st.fields) {
+      if (struct_scope->lookup_local(field->name) != nullptr) {
         diagnostics_.push_back(Diagnostic::error(
-            field->name_span(),
-            "duplicate declaration '" + std::string(field->name()) + "'"));
+            field->name_span,
+            "duplicate declaration '" + std::string(field->name) + "'"));
       } else {
         auto* sym =
-            ctx_.make_symbol(SymbolKind::Field, field->name(), field->name_span(), field);
-        struct_scope->declare(field->name(), sym);
+            ctx_.make_symbol(SymbolKind::Field, field->name, field->name_span, field);
+        struct_scope->declare(field->name, sym);
       }
 
-      if (field->type() != nullptr) {
-        resolve_type(*field->type(), struct_scope);
+      if (field->type != nullptr) {
+        resolve_type(*field->type, struct_scope);
       }
     }
   }
 
-  void resolve_alias(const AliasDeclNode& alias, Scope* scope) {
-    if (alias.type() != nullptr) {
-      resolve_type(*alias.type(), scope);
+  void resolve_alias(const Decl& decl, Scope* scope) {
+    const auto& alias = decl.as<AliasDecl>();
+    if (alias.type != nullptr) {
+      resolve_type(*alias.type, scope);
     }
   }
 
@@ -267,104 +269,104 @@ private:
   void resolve_stmt(const Stmt& stmt, Scope* scope) {
     switch (stmt.kind()) {
     case NodeKind::LetStatement: {
-      const auto& let_stmt = static_cast<const LetStatementNode&>(stmt);
+      const auto& let_stmt = stmt.as<LetStatement>();
 
       // Resolve type and initializer BEFORE declaring (prevents self-reference).
-      if (let_stmt.type() != nullptr) {
-        resolve_type(*let_stmt.type(), scope);
+      if (let_stmt.type != nullptr) {
+        resolve_type(*let_stmt.type, scope);
       }
-      if (let_stmt.initializer() != nullptr) {
-        resolve_expr(*let_stmt.initializer(), scope);
+      if (let_stmt.initializer != nullptr) {
+        resolve_expr(*let_stmt.initializer, scope);
       }
 
       // Declare the local variable (visible after this point).
-      if (scope->lookup_local(let_stmt.name()) != nullptr) {
+      if (scope->lookup_local(let_stmt.name) != nullptr) {
         diagnostics_.push_back(Diagnostic::error(
-            let_stmt.name_span(),
-            "duplicate declaration '" + std::string(let_stmt.name()) + "'"));
+            let_stmt.name_span,
+            "duplicate declaration '" + std::string(let_stmt.name) + "'"));
       } else {
         auto* sym =
-            ctx_.make_symbol(SymbolKind::Local, let_stmt.name(), let_stmt.name_span(), &let_stmt);
-        scope->declare(let_stmt.name(), sym);
+            ctx_.make_symbol(SymbolKind::Local, let_stmt.name, let_stmt.name_span, &stmt);
+        scope->declare(let_stmt.name, sym);
       }
       break;
     }
     case NodeKind::Assignment: {
-      const auto& assign = static_cast<const AssignmentNode&>(stmt);
-      resolve_expr(*assign.target(), scope);
-      resolve_expr(*assign.value(), scope);
+      const auto& assign = stmt.as<Assignment>();
+      resolve_expr(*assign.target, scope);
+      resolve_expr(*assign.value, scope);
       break;
     }
     case NodeKind::IfStatement: {
-      const auto& if_stmt = static_cast<const IfStatementNode&>(stmt);
-      resolve_expr(*if_stmt.condition(), scope);
+      const auto& if_stmt = stmt.as<IfStatement>();
+      resolve_expr(*if_stmt.condition, scope);
 
       auto* then_scope = ctx_.make_scope(ScopeKind::Block, scope);
-      for (const auto* s : if_stmt.then_body()) {
+      for (const auto* s : if_stmt.then_body) {
         resolve_stmt(*s, then_scope);
       }
 
       if (if_stmt.has_else()) {
         auto* else_scope = ctx_.make_scope(ScopeKind::Block, scope);
-        for (const auto* s : if_stmt.else_body()) {
+        for (const auto* s : if_stmt.else_body) {
           resolve_stmt(*s, else_scope);
         }
       }
       break;
     }
     case NodeKind::WhileStatement: {
-      const auto& while_stmt = static_cast<const WhileStatementNode&>(stmt);
-      resolve_expr(*while_stmt.condition(), scope);
+      const auto& while_stmt = stmt.as<WhileStatement>();
+      resolve_expr(*while_stmt.condition, scope);
 
       auto* while_scope = ctx_.make_scope(ScopeKind::Block, scope);
-      for (const auto* s : while_stmt.body()) {
+      for (const auto* s : while_stmt.body) {
         resolve_stmt(*s, while_scope);
       }
       break;
     }
     case NodeKind::ForStatement: {
-      const auto& for_stmt = static_cast<const ForStatementNode&>(stmt);
+      const auto& for_stmt = stmt.as<ForStatement>();
 
       // Resolve iterable in the outer scope.
-      resolve_expr(*for_stmt.iterable(), scope);
+      resolve_expr(*for_stmt.iterable, scope);
 
       // Create block scope for the loop body; declare the loop variable.
       auto* for_scope = ctx_.make_scope(ScopeKind::Block, scope);
       auto* sym = ctx_.make_symbol(
-          SymbolKind::Local, for_stmt.var(), for_stmt.var_span(), &for_stmt);
-      for_scope->declare(for_stmt.var(), sym);
+          SymbolKind::Local, for_stmt.var, for_stmt.var_span, &stmt);
+      for_scope->declare(for_stmt.var, sym);
 
-      for (const auto* s : for_stmt.body()) {
+      for (const auto* s : for_stmt.body) {
         resolve_stmt(*s, for_scope);
       }
       break;
     }
     case NodeKind::ModeBlock: {
-      const auto& mode = static_cast<const ModeBlockNode&>(stmt);
+      const auto& mode = stmt.as<ModeBlock>();
       auto* mode_scope = ctx_.make_scope(ScopeKind::Block, scope);
-      for (const auto* s : mode.body()) {
+      for (const auto* s : mode.body) {
         resolve_stmt(*s, mode_scope);
       }
       break;
     }
     case NodeKind::ResourceBlock: {
-      const auto& res = static_cast<const ResourceBlockNode&>(stmt);
+      const auto& res = stmt.as<ResourceBlock>();
       auto* res_scope = ctx_.make_scope(ScopeKind::Block, scope);
-      for (const auto* s : res.body()) {
+      for (const auto* s : res.body) {
         resolve_stmt(*s, res_scope);
       }
       break;
     }
     case NodeKind::ReturnStatement: {
-      const auto& ret = static_cast<const ReturnStatementNode&>(stmt);
-      if (ret.value() != nullptr) {
-        resolve_expr(*ret.value(), scope);
+      const auto& ret = stmt.as<ReturnStatement>();
+      if (ret.value != nullptr) {
+        resolve_expr(*ret.value, scope);
       }
       break;
     }
     case NodeKind::ExpressionStatement: {
-      const auto& expr_stmt = static_cast<const ExpressionStatementNode&>(stmt);
-      resolve_expr(*expr_stmt.expr(), scope);
+      const auto& expr_stmt = stmt.as<ExpressionStatement>();
+      resolve_expr(*expr_stmt.expr, scope);
       break;
     }
     default:
@@ -377,28 +379,28 @@ private:
   void resolve_expr(const Expr& expr, Scope* scope) {
     switch (expr.kind()) {
     case NodeKind::Identifier: {
-      const auto& ident = static_cast<const IdentifierNode&>(expr);
-      auto* sym = scope->lookup(ident.name());
+      const auto& ident = expr.as<IdentifierExpr>();
+      auto* sym = scope->lookup(ident.name);
       if (sym != nullptr) {
-        uses_[expr.span().offset] = sym;
+        uses_[expr.span.offset] = sym;
       } else {
         diagnostics_.push_back(Diagnostic::error(
-            expr.span(),
-            "unknown name '" + std::string(ident.name()) + "'"));
+            expr.span,
+            "unknown name '" + std::string(ident.name) + "'"));
       }
       break;
     }
     case NodeKind::QualifiedName: {
-      const auto& qn = static_cast<const QualifiedNameNode&>(expr);
-      if (qn.segments().empty()) {
+      const auto& qn = expr.as<QualifiedName>();
+      if (qn.segments.empty()) {
         break;
       }
 
       // Resolve first segment against the scope chain — must be a
       // module/import binding per TASK_6_RESOLVE.md.
-      auto first_seg = qn.segments().front();
+      auto first_seg = qn.segments.front();
       auto seg_len = static_cast<uint32_t>(first_seg.size());
-      Span seg_span{.offset = expr.span().offset, .length = seg_len};
+      Span seg_span{.offset = expr.span.offset, .length = seg_len};
       auto* sym = scope->lookup(first_seg);
 
       if (sym == nullptr) {
@@ -411,72 +413,72 @@ private:
             "'" + std::string(first_seg) + "' is not a module"));
       } else {
         // Record the first segment's resolution.
-        uses_[expr.span().offset] = sym;
+        uses_[expr.span.offset] = sym;
         // Trailing segments are unresolvable in Task 6 (no cross-file
         // module resolution) — left without entries in the uses table.
       }
       break;
     }
     case NodeKind::BinaryExpr: {
-      const auto& bin = static_cast<const BinaryExprNode&>(expr);
-      resolve_expr(*bin.left(), scope);
-      resolve_expr(*bin.right(), scope);
+      const auto& bin = expr.as<BinaryExpr>();
+      resolve_expr(*bin.left, scope);
+      resolve_expr(*bin.right, scope);
       break;
     }
     case NodeKind::UnaryExpr: {
-      const auto& unary = static_cast<const UnaryExprNode&>(expr);
-      resolve_expr(*unary.operand(), scope);
+      const auto& unary = expr.as<UnaryExpr>();
+      resolve_expr(*unary.operand, scope);
       break;
     }
     case NodeKind::CallExpr: {
-      const auto& call = static_cast<const CallExprNode&>(expr);
-      resolve_expr(*call.callee(), scope);
-      for (const auto* arg : call.args()) {
+      const auto& call = expr.as<CallExpr>();
+      resolve_expr(*call.callee, scope);
+      for (const auto* arg : call.args) {
         resolve_expr(*arg, scope);
       }
       break;
     }
     case NodeKind::IndexExpr: {
-      const auto& idx = static_cast<const IndexExprNode&>(expr);
-      resolve_expr(*idx.object(), scope);
-      for (const auto* i : idx.indices()) {
+      const auto& idx = expr.as<IndexExpr>();
+      resolve_expr(*idx.object, scope);
+      for (const auto* i : idx.indices) {
         resolve_expr(*i, scope);
       }
       break;
     }
     case NodeKind::FieldExpr: {
-      const auto& field = static_cast<const FieldExprNode&>(expr);
-      resolve_expr(*field.object(), scope);
+      const auto& field = expr.as<FieldExpr>();
+      resolve_expr(*field.object, scope);
       // Field member access is not resolved in Task 6 (needs type info).
       break;
     }
     case NodeKind::PipeExpr: {
-      const auto& pipe = static_cast<const PipeExprNode&>(expr);
-      resolve_expr(*pipe.left(), scope);
-      resolve_expr(*pipe.right(), scope);
+      const auto& pipe = expr.as<PipeExpr>();
+      resolve_expr(*pipe.left, scope);
+      resolve_expr(*pipe.right, scope);
       break;
     }
     case NodeKind::Lambda: {
-      const auto& lam = static_cast<const LambdaNode&>(expr);
+      const auto& lam = expr.as<LambdaExpr>();
 
       // Create a block scope for the lambda body.
       auto* lam_scope = ctx_.make_scope(ScopeKind::Block, scope);
-      for (const auto& [name, span] : lam.params()) {
+      for (const auto& [name, span] : lam.params) {
         if (lam_scope->lookup_local(name) != nullptr) {
           diagnostics_.push_back(Diagnostic::error(
               span,
               "duplicate parameter '" + std::string(name) + "'"));
         } else {
-          auto* sym = ctx_.make_symbol(SymbolKind::LambdaParam, name, span, &lam);
+          auto* sym = ctx_.make_symbol(SymbolKind::LambdaParam, name, span, &expr);
           lam_scope->declare(name, sym);
         }
       }
-      resolve_expr(*lam.body(), lam_scope);
+      resolve_expr(*lam.body, lam_scope);
       break;
     }
     case NodeKind::ListLiteral: {
-      const auto& list = static_cast<const ListLiteralNode&>(expr);
-      for (const auto* elem : list.elements()) {
+      const auto& list = expr.as<ListLiteral>();
+      for (const auto* elem : list.elements) {
         resolve_expr(*elem, scope);
       }
       break;
@@ -497,8 +499,8 @@ private:
   void resolve_type(const TypeNode& type, Scope* scope) {
     switch (type.kind()) {
     case NodeKind::NamedType: {
-      const auto& named = static_cast<const NamedTypeNode&>(type);
-      const auto& path = named.name();
+      const auto& named = type.as<NamedType>();
+      const auto& path = named.name;
 
       if (path.segments.empty()) {
         break;
@@ -526,14 +528,14 @@ private:
       }
 
       // Resolve type arguments recursively.
-      for (const auto* arg : named.type_args()) {
+      for (const auto* arg : named.type_args) {
         resolve_type(*arg, scope);
       }
       break;
     }
     case NodeKind::PointerType: {
-      const auto& ptr = static_cast<const PointerTypeNode&>(type);
-      resolve_type(*ptr.pointee(), scope);
+      const auto& ptr = type.as<PointerType>();
+      resolve_type(*ptr.pointee, scope);
       break;
     }
     default:

--- a/compiler/frontend/resolve/resolve_context.h
+++ b/compiler/frontend/resolve/resolve_context.h
@@ -24,7 +24,7 @@ public:
   auto make_symbol(SymbolKind kind,
                    std::string_view name,
                    Span decl_span,
-                   const AstNode* decl) -> Symbol* {
+                   const void* decl) -> Symbol* {
     symbols_.push_back(
         std::make_unique<Symbol>(Symbol{.kind = kind, .name = name, .decl_span = decl_span, .decl = decl}));
     return symbols_.back().get();

--- a/compiler/frontend/resolve/symbol.h
+++ b/compiler/frontend/resolve/symbol.h
@@ -3,10 +3,18 @@
 
 #include "frontend/diagnostics/source.h"
 
+#include <cassert>
 #include <cstdint>
 #include <string_view>
 
 namespace dao {
+
+// Forward declarations for typed decl accessors.
+struct Decl;
+struct Stmt;
+struct Expr;
+struct ImportNode;
+struct FieldSpec;
 
 enum class SymbolKind : std::uint8_t {
   Function,    // top-level fn
@@ -27,6 +35,41 @@ struct Symbol {
   std::string_view name;
   Span decl_span;            // where the symbol was declared (zero for builtins)
   const void* decl;          // declaration node (nullptr for builtins)
+
+  // --- Typed accessors --------------------------------------------------
+  // Each accessor asserts the SymbolKind matches the expected pointer type,
+  // concentrating the void* → typed* cast at a single checked choke point.
+
+  [[nodiscard]] auto decl_as_decl() const -> const Decl* {
+    assert((kind == SymbolKind::Function || kind == SymbolKind::Type ||
+            kind == SymbolKind::Param) &&
+           "decl_as_decl requires Function, Type, or Param symbol");
+    return static_cast<const Decl*>(decl);
+  }
+
+  [[nodiscard]] auto decl_as_stmt() const -> const Stmt* {
+    assert(kind == SymbolKind::Local &&
+           "decl_as_stmt requires Local symbol");
+    return static_cast<const Stmt*>(decl);
+  }
+
+  [[nodiscard]] auto decl_as_expr() const -> const Expr* {
+    assert(kind == SymbolKind::LambdaParam &&
+           "decl_as_expr requires LambdaParam symbol");
+    return static_cast<const Expr*>(decl);
+  }
+
+  [[nodiscard]] auto decl_as_import() const -> const ImportNode* {
+    assert(kind == SymbolKind::Module &&
+           "decl_as_import requires Module symbol");
+    return static_cast<const ImportNode*>(decl);
+  }
+
+  [[nodiscard]] auto decl_as_field() const -> const FieldSpec* {
+    assert(kind == SymbolKind::Field &&
+           "decl_as_field requires Field symbol");
+    return static_cast<const FieldSpec*>(decl);
+  }
 };
 
 } // namespace dao

--- a/compiler/frontend/resolve/symbol.h
+++ b/compiler/frontend/resolve/symbol.h
@@ -1,7 +1,6 @@
 #ifndef DAO_FRONTEND_RESOLVE_SYMBOL_H
 #define DAO_FRONTEND_RESOLVE_SYMBOL_H
 
-#include "frontend/ast/ast.h"
 #include "frontend/diagnostics/source.h"
 
 #include <cstdint>
@@ -26,8 +25,8 @@ auto symbol_kind_name(SymbolKind kind) -> const char*;
 struct Symbol {
   SymbolKind kind;
   std::string_view name;
-  Span decl_span;          // where the symbol was declared (zero for builtins)
-  const AstNode* decl;     // declaration node (nullptr for builtins)
+  Span decl_span;            // where the symbol was declared (zero for builtins)
+  const void* decl;          // declaration node (nullptr for builtins)
 };
 
 } // namespace dao

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -117,7 +117,7 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
     if (sym->decl == nullptr) {
       break;
     }
-    const auto& fn = static_cast<const Decl*>(sym->decl)->as<FunctionDecl>();
+    const auto& fn = sym->decl_as_decl()->as<FunctionDecl>();
     std::vector<const Type*> param_types;
     bool valid = true;
     for (const auto& param : fn.params) {
@@ -144,7 +144,7 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
     }
     // The decl for a param points to the Decl (FunctionDecl payload).
     // We need to find the matching param by name.
-    const auto& fn = static_cast<const Decl*>(sym->decl)->as<FunctionDecl>();
+    const auto& fn = sym->decl_as_decl()->as<FunctionDecl>();
     for (const auto& p : fn.params) {
       if (p.name == sym->name) {
         result = resolve_type_node(p.type);

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -27,7 +27,7 @@ auto TypeChecker::check(const FileNode& file) -> TypeCheckResult {
   register_declarations(file);
 
   // Pass 2: check all declaration bodies.
-  for (const auto* decl : file.declarations()) {
+  for (const auto* decl : file.declarations) {
     check_declaration(decl);
   }
 
@@ -45,10 +45,10 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
 
   switch (node->kind()) {
   case NodeKind::NamedType: {
-    const auto* named = static_cast<const NamedTypeNode*>(node);
-    const auto& path = named->name();
+    const auto& named = node->as<NamedType>();
+    const auto& path = named.name;
     if (path.segments.size() != 1) {
-      error(node->span(), "qualified type names are not yet supported");
+      error(node->span, "qualified type names are not yet supported");
       return nullptr;
     }
     auto name = path.segments[0];
@@ -70,18 +70,18 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
     }
 
     // Look up user-defined types via resolver symbols.
-    auto it = resolve_.uses.find(node->span().offset);
+    auto it = resolve_.uses.find(node->span.offset);
     if (it != resolve_.uses.end()) {
       return resolve_symbol_type(it->second);
     }
 
-    error(node->span(), "unknown type '" + std::string(name) + "'");
+    error(node->span, "unknown type '" + std::string(name) + "'");
     return nullptr;
   }
 
   case NodeKind::PointerType: {
-    const auto* ptr = static_cast<const PointerTypeNode*>(node);
-    const auto* pointee = resolve_type_node(ptr->pointee());
+    const auto& ptr = node->as<PointerType>();
+    const auto* pointee = resolve_type_node(ptr.pointee);
     if (pointee == nullptr) {
       return nullptr;
     }
@@ -89,7 +89,7 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
   }
 
   default:
-    error(node->span(), "unsupported type syntax");
+    error(node->span, "unsupported type syntax");
     return nullptr;
   }
 }
@@ -117,18 +117,18 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
     if (sym->decl == nullptr) {
       break;
     }
-    const auto* fn = static_cast<const FunctionDeclNode*>(sym->decl);
+    const auto& fn = static_cast<const Decl*>(sym->decl)->as<FunctionDecl>();
     std::vector<const Type*> param_types;
     bool valid = true;
-    for (const auto& param : fn->params()) {
+    for (const auto& param : fn.params) {
       const auto* pt = resolve_type_node(param.type);
       if (pt == nullptr) {
         valid = false;
       }
       param_types.push_back(pt);
     }
-    const auto* ret = fn->return_type() != nullptr
-                          ? resolve_type_node(fn->return_type())
+    const auto* ret = fn.return_type != nullptr
+                          ? resolve_type_node(fn.return_type)
                           : types_.void_type();
     if (!valid || ret == nullptr) {
       break;
@@ -142,10 +142,10 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
     if (sym->decl == nullptr) {
       break;
     }
-    // The decl for a param points to the FunctionDeclNode. We need to find
-    // the matching param by name.
-    const auto* fn = static_cast<const FunctionDeclNode*>(sym->decl);
-    for (const auto& p : fn->params()) {
+    // The decl for a param points to the Decl (FunctionDecl payload).
+    // We need to find the matching param by name.
+    const auto& fn = static_cast<const Decl*>(sym->decl)->as<FunctionDecl>();
+    for (const auto& p : fn.params) {
       if (p.name == sym->name) {
         result = resolve_type_node(p.type);
         break;
@@ -219,12 +219,12 @@ auto TypeChecker::resolve_symbol_type_for_type_decl(const Symbol* sym) -> const 
 void TypeChecker::register_declarations(const FileNode& file) {
   // Pass 1a: register type aliases first so that functions and structs
   // can reference them regardless of source order.
-  for (const auto* decl : file.declarations()) {
+  for (const auto* decl : file.declarations) {
     if (decl->kind() != NodeKind::AliasDecl) {
       continue;
     }
-    const auto* alias = static_cast<const AliasDeclNode*>(decl);
-    auto decl_it = decl_symbols_.find(alias->name_span().offset);
+    const auto& alias = decl->as<AliasDecl>();
+    auto decl_it = decl_symbols_.find(alias.name_span.offset);
     if (decl_it == decl_symbols_.end()) {
       continue;
     }
@@ -232,20 +232,20 @@ void TypeChecker::register_declarations(const FileNode& file) {
 
     // Resolve the aliased type and cache it so later lookups of the
     // alias name transparently return the underlying type.
-    const auto* aliased_type = resolve_type_node(alias->type());
+    const auto* aliased_type = resolve_type_node(alias.type);
     if (aliased_type != nullptr) {
       symbol_types_[sym] = aliased_type;
-      typed_.set_decl_type(alias, aliased_type);
+      typed_.set_decl_type(decl, aliased_type);
     }
   }
 
   // Pass 1b: register functions and structs, which may reference aliases.
-  for (const auto* decl : file.declarations()) {
+  for (const auto* decl : file.declarations) {
     switch (decl->kind()) {
     case NodeKind::FunctionDecl: {
-      const auto* fn = static_cast<const FunctionDeclNode*>(decl);
+      const auto& fn = decl->as<FunctionDecl>();
       // Find the symbol for this function via declaration map.
-      auto decl_it = decl_symbols_.find(fn->name_span().offset);
+      auto decl_it = decl_symbols_.find(fn.name_span.offset);
       if (decl_it == decl_symbols_.end()) {
         break;
       }
@@ -254,28 +254,28 @@ void TypeChecker::register_declarations(const FileNode& file) {
       // Build function type.
       std::vector<const Type*> param_types;
       bool valid = true;
-      for (const auto& param : fn->params()) {
+      for (const auto& param : fn.params) {
         const auto* pt = resolve_type_node(param.type);
         if (pt == nullptr) {
           valid = false;
         }
         param_types.push_back(pt);
       }
-      const auto* ret = fn->return_type() != nullptr
-                            ? resolve_type_node(fn->return_type())
+      const auto* ret = fn.return_type != nullptr
+                            ? resolve_type_node(fn.return_type)
                             : types_.void_type();
       if (valid && ret != nullptr) {
         const auto* fn_type = types_.function_type(std::move(param_types), ret);
         symbol_types_[sym] = fn_type;
-        typed_.set_decl_type(fn, fn_type);
+        typed_.set_decl_type(decl, fn_type);
       }
       break;
     }
 
     case NodeKind::ClassDecl: {
-      const auto* st = static_cast<const ClassDeclNode*>(decl);
+      const auto& st = decl->as<ClassDecl>();
       // Find symbol via declaration map.
-      auto decl_it = decl_symbols_.find(st->name_span().offset);
+      auto decl_it = decl_symbols_.find(st.name_span.offset);
       if (decl_it == decl_symbols_.end()) {
         break;
       }
@@ -283,16 +283,16 @@ void TypeChecker::register_declarations(const FileNode& file) {
 
       // Build struct type from field specifiers.
       std::vector<StructField> fields;
-      for (const auto* field : st->fields()) {
-        const auto* field_type = resolve_type_node(field->type());
+      for (const auto* field : st.fields) {
+        const auto* field_type = resolve_type_node(field->type);
         if (field_type != nullptr) {
-          fields.push_back({field->name(), field_type});
+          fields.push_back({field->name, field_type});
         }
       }
       const auto* struct_type =
-          types_.make_struct(sym, st->name(), std::move(fields));
+          types_.make_struct(sym, st.name, std::move(fields));
       symbol_types_[sym] = struct_type;
-      typed_.set_decl_type(st, struct_type);
+      typed_.set_decl_type(decl, struct_type);
       break;
     }
 
@@ -309,10 +309,10 @@ void TypeChecker::register_declarations(const FileNode& file) {
 void TypeChecker::check_declaration(const Decl* decl) {
   switch (decl->kind()) {
   case NodeKind::FunctionDecl:
-    check_function(static_cast<const FunctionDeclNode*>(decl));
+    check_function(decl);
     break;
   case NodeKind::ClassDecl:
-    check_class(static_cast<const ClassDeclNode*>(decl));
+    check_class(decl);
     break;
   default:
     // AliasDecl — no body checking needed yet.
@@ -320,14 +320,16 @@ void TypeChecker::check_declaration(const Decl* decl) {
   }
 }
 
-void TypeChecker::check_function(const FunctionDeclNode* fn) {
+void TypeChecker::check_function(const Decl* decl) {
+  const auto& fn = decl->as<FunctionDecl>();
+
   // Determine return type.
-  const auto* ret_type = fn->return_type() != nullptr
-                             ? resolve_type_node(fn->return_type())
+  const auto* ret_type = fn.return_type != nullptr
+                             ? resolve_type_node(fn.return_type)
                              : types_.void_type();
 
   // Set up param types in symbol cache.
-  for (const auto& param : fn->params()) {
+  for (const auto& param : fn.params) {
     auto decl_it = decl_symbols_.find(param.name_span.offset);
     if (decl_it != decl_symbols_.end()) {
       const auto* pt = resolve_type_node(param.type);
@@ -341,27 +343,27 @@ void TypeChecker::check_function(const FunctionDeclNode* fn) {
   auto saved_ctx = ctx_;
   ctx_.return_type = ret_type;
 
-  if (fn->is_expr_bodied()) {
+  if (fn.is_expr_bodied()) {
     // Expression-bodied: -> expr
-    const auto* expr_type = check_expr(fn->expr_body());
+    const auto* expr_type = check_expr(fn.expr_body);
     if (expr_type != nullptr && ret_type != nullptr &&
         !is_assignable(expr_type, ret_type)) {
-      error(fn->expr_body()->span(),
+      error(fn.expr_body->span,
             "expression body type '" + print_type(expr_type) +
                 "' does not match return type '" + print_type(ret_type) + "'");
     }
   } else {
     // Block-bodied: check statements.
-    check_body(fn->body());
+    check_body(fn.body);
   }
 
   ctx_ = saved_ctx;
 }
 
-void TypeChecker::check_class(const ClassDeclNode* st) {
+void TypeChecker::check_class(const Decl* decl) {
   // Class members are validated during pass 1 (field types resolved).
   // Nothing further to check in bodies for now.
-  (void)st;
+  (void)decl;
 }
 
 // ---------------------------------------------------------------------------
@@ -377,149 +379,164 @@ void TypeChecker::check_body(const std::vector<Stmt*>& body) {
 void TypeChecker::check_statement(const Stmt* stmt) {
   switch (stmt->kind()) {
   case NodeKind::LetStatement:
-    check_let(static_cast<const LetStatementNode*>(stmt));
+    check_let(stmt);
     break;
   case NodeKind::Assignment:
-    check_assignment(static_cast<const AssignmentNode*>(stmt));
+    check_assignment(stmt);
     break;
   case NodeKind::IfStatement:
-    check_if(static_cast<const IfStatementNode*>(stmt));
+    check_if(stmt);
     break;
   case NodeKind::WhileStatement:
-    check_while(static_cast<const WhileStatementNode*>(stmt));
+    check_while(stmt);
     break;
   case NodeKind::ForStatement:
-    check_for(static_cast<const ForStatementNode*>(stmt));
+    check_for(stmt);
     break;
   case NodeKind::ModeBlock:
-    check_mode_block(static_cast<const ModeBlockNode*>(stmt));
+    check_mode_block(stmt);
     break;
   case NodeKind::ResourceBlock:
-    check_resource_block(static_cast<const ResourceBlockNode*>(stmt));
+    check_resource_block(stmt);
     break;
   case NodeKind::ReturnStatement:
-    check_return(static_cast<const ReturnStatementNode*>(stmt));
+    check_return(stmt);
     break;
   case NodeKind::ExpressionStatement:
-    check_expr_stmt(static_cast<const ExpressionStatementNode*>(stmt));
+    check_expr_stmt(stmt);
     break;
   default:
     break;
   }
 }
 
-void TypeChecker::check_let(const LetStatementNode* let) {
+void TypeChecker::check_let(const Stmt* stmt) {
+  const auto& let = stmt->as<LetStatement>();
+
   const Type* declared_type = nullptr;
-  if (let->type() != nullptr) {
-    declared_type = resolve_type_node(let->type());
+  if (let.type != nullptr) {
+    declared_type = resolve_type_node(let.type);
   }
 
   const Type* init_type = nullptr;
-  if (let->initializer() != nullptr) {
-    init_type = check_expr(let->initializer());
+  if (let.initializer != nullptr) {
+    init_type = check_expr(let.initializer);
   }
 
   if (declared_type != nullptr && init_type != nullptr) {
     // let x: T = expr — check assignability.
     if (!is_assignable(init_type, declared_type)) {
-      error(let->initializer()->span(),
+      error(let.initializer->span,
             "initializer type '" + print_type(init_type) +
                 "' is not assignable to '" + print_type(declared_type) + "'");
     }
-    typed_.set_local_type(let, declared_type);
+    typed_.set_local_type(stmt, declared_type);
   } else if (declared_type != nullptr) {
     // let x: T — type without initializer.
-    typed_.set_local_type(let, declared_type);
+    typed_.set_local_type(stmt, declared_type);
   } else if (init_type != nullptr) {
     // let x = expr — infer from initializer.
-    typed_.set_local_type(let, init_type);
+    typed_.set_local_type(stmt, init_type);
   } else {
     // let x — no type, no initializer.
-    error(let->span(),
+    error(stmt->span,
           "declaration without type annotation requires an initializer");
   }
 
   // Cache in symbol table for later identifier lookups.
-  const auto* local_type = typed_.local_type(let);
+  const auto* local_type = typed_.local_type(stmt);
   if (local_type != nullptr) {
-    auto decl_it = decl_symbols_.find(let->name_span().offset);
+    auto decl_it = decl_symbols_.find(let.name_span.offset);
     if (decl_it != decl_symbols_.end()) {
       symbol_types_[decl_it->second] = local_type;
     }
   }
 }
 
-void TypeChecker::check_assignment(const AssignmentNode* assign) {
-  if (!is_lvalue(assign->target())) {
-    error(assign->target()->span(), "invalid assignment target");
+void TypeChecker::check_assignment(const Stmt* stmt) {
+  const auto& assign = stmt->as<Assignment>();
+
+  if (!is_lvalue(assign.target)) {
+    error(assign.target->span, "invalid assignment target");
   }
 
-  const auto* target_type = check_expr(assign->target());
-  const auto* value_type = check_expr(assign->value());
+  const auto* target_type = check_expr(assign.target);
+  const auto* value_type = check_expr(assign.value);
 
   if (target_type != nullptr && value_type != nullptr &&
       !is_assignable(value_type, target_type)) {
-    error(assign->value()->span(),
+    error(assign.value->span,
           "cannot assign '" + print_type(value_type) + "' to '" +
               print_type(target_type) + "'");
   }
 }
 
-void TypeChecker::check_if(const IfStatementNode* ifn) {
-  const auto* cond_type = check_expr(ifn->condition());
+void TypeChecker::check_if(const Stmt* stmt) {
+  const auto& ifn = stmt->as<IfStatement>();
+
+  const auto* cond_type = check_expr(ifn.condition);
   if (cond_type != nullptr && !is_assignable(cond_type, types_.bool_type())) {
-    error(ifn->condition()->span(),
+    error(ifn.condition->span,
           "condition must be 'bool', got '" + print_type(cond_type) + "'");
   }
-  check_body(ifn->then_body());
-  if (ifn->has_else()) {
-    check_body(ifn->else_body());
+  check_body(ifn.then_body);
+  if (ifn.has_else()) {
+    check_body(ifn.else_body);
   }
 }
 
-void TypeChecker::check_while(const WhileStatementNode* wh) {
-  const auto* cond_type = check_expr(wh->condition());
+void TypeChecker::check_while(const Stmt* stmt) {
+  const auto& wh = stmt->as<WhileStatement>();
+
+  const auto* cond_type = check_expr(wh.condition);
   if (cond_type != nullptr && !is_assignable(cond_type, types_.bool_type())) {
-    error(wh->condition()->span(),
+    error(wh.condition->span,
           "condition must be 'bool', got '" + print_type(cond_type) + "'");
   }
-  check_body(wh->body());
+  check_body(wh.body);
 }
 
-void TypeChecker::check_for(const ForStatementNode* fo) {
+void TypeChecker::check_for(const Stmt* stmt) {
+  const auto& fo = stmt->as<ForStatement>();
+
   // For now, iteration semantics are not frozen. Accept the iterable
   // expression but do not enforce element type derivation.
-  const auto* iter_type = check_expr(fo->iterable());
+  const auto* iter_type = check_expr(fo.iterable);
   (void)iter_type;
 
   // Bind loop variable — for now treat as untyped placeholder.
-  auto decl_it = decl_symbols_.find(fo->var_span().offset);
+  auto decl_it = decl_symbols_.find(fo.var_span.offset);
   if (decl_it != decl_symbols_.end()) {
     // TODO: derive element type from iterable once iteration is frozen.
     // For now, leave as nullptr (untyped).
     (void)decl_it;
   }
 
-  check_body(fo->body());
+  check_body(fo.body);
 }
 
-void TypeChecker::check_mode_block(const ModeBlockNode* mb) {
+void TypeChecker::check_mode_block(const Stmt* stmt) {
+  const auto& mb = stmt->as<ModeBlock>();
+
   auto saved_ctx = ctx_;
-  ctx_.active_modes.insert(mb->mode_name());
-  check_body(mb->body());
+  ctx_.active_modes.insert(mb.mode_name);
+  check_body(mb.body);
   ctx_ = saved_ctx;
 }
 
-void TypeChecker::check_resource_block(const ResourceBlockNode* rb) {
-  check_body(rb->body());
+void TypeChecker::check_resource_block(const Stmt* stmt) {
+  const auto& rb = stmt->as<ResourceBlock>();
+  check_body(rb.body);
 }
 
-void TypeChecker::check_return(const ReturnStatementNode* ret) {
-  if (ret->value() != nullptr) {
-    const auto* val_type = check_expr(ret->value());
+void TypeChecker::check_return(const Stmt* stmt) {
+  const auto& ret = stmt->as<ReturnStatement>();
+
+  if (ret.value != nullptr) {
+    const auto* val_type = check_expr(ret.value);
     if (val_type != nullptr && ctx_.return_type != nullptr &&
         !is_assignable(val_type, ctx_.return_type)) {
-      error(ret->value()->span(),
+      error(ret.value->span,
             "return type '" + print_type(val_type) +
                 "' does not match function return type '" +
                 print_type(ctx_.return_type) + "'");
@@ -528,15 +545,16 @@ void TypeChecker::check_return(const ReturnStatementNode* ret) {
     // Bare return — only valid for void functions.
     if (ctx_.return_type != nullptr &&
         ctx_.return_type->kind() != TypeKind::Void) {
-      error(ret->span(),
+      error(stmt->span,
             "bare return in function returning '" +
                 print_type(ctx_.return_type) + "'");
     }
   }
 }
 
-void TypeChecker::check_expr_stmt(const ExpressionStatementNode* es) {
-  check_expr(es->expr());
+void TypeChecker::check_expr_stmt(const Stmt* stmt) {
+  const auto& es = stmt->as<ExpressionStatement>();
+  check_expr(es.expr);
 }
 
 // ---------------------------------------------------------------------------
@@ -557,46 +575,46 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
 
   switch (expr->kind()) {
   case NodeKind::Identifier:
-    result = check_identifier(static_cast<const IdentifierNode*>(expr));
+    result = check_identifier(expr);
     break;
   case NodeKind::IntLiteral:
-    result = check_int_literal(static_cast<const IntLiteralNode*>(expr));
+    result = check_int_literal(expr);
     break;
   case NodeKind::FloatLiteral:
-    result = check_float_literal(static_cast<const FloatLiteralNode*>(expr));
+    result = check_float_literal(expr);
     break;
   case NodeKind::StringLiteral:
-    result = check_string_literal(static_cast<const StringLiteralNode*>(expr));
+    result = check_string_literal(expr);
     break;
   case NodeKind::BoolLiteral:
-    result = check_bool_literal(static_cast<const BoolLiteralNode*>(expr));
+    result = check_bool_literal(expr);
     break;
   case NodeKind::BinaryExpr:
-    result = check_binary(static_cast<const BinaryExprNode*>(expr));
+    result = check_binary(expr);
     break;
   case NodeKind::UnaryExpr:
-    result = check_unary(static_cast<const UnaryExprNode*>(expr));
+    result = check_unary(expr);
     break;
   case NodeKind::CallExpr:
-    result = check_call(static_cast<const CallExprNode*>(expr));
+    result = check_call(expr);
     break;
   case NodeKind::PipeExpr:
-    result = check_pipe(static_cast<const PipeExprNode*>(expr));
+    result = check_pipe(expr);
     break;
   case NodeKind::FieldExpr:
-    result = check_field(static_cast<const FieldExprNode*>(expr));
+    result = check_field(expr);
     break;
   case NodeKind::IndexExpr:
-    result = check_index(static_cast<const IndexExprNode*>(expr));
+    result = check_index(expr);
     break;
   case NodeKind::Lambda:
-    result = check_lambda(static_cast<const LambdaNode*>(expr), expected);
+    result = check_lambda(expr, expected);
     break;
   case NodeKind::ListLiteral:
-    result = check_list_literal(static_cast<const ListLiteralNode*>(expr));
+    result = check_list_literal(expr);
     break;
   default:
-    error(expr->span(), "unsupported expression in type checker");
+    error(expr->span, "unsupported expression in type checker");
     break;
   }
 
@@ -611,10 +629,11 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
 // Identifier
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_identifier(const IdentifierNode* id) -> const Type* {
-  auto it = resolve_.uses.find(id->span().offset);
+auto TypeChecker::check_identifier(const Expr* expr) -> const Type* {
+  const auto& id = expr->as<IdentifierExpr>();
+  auto it = resolve_.uses.find(expr->span.offset);
   if (it == resolve_.uses.end()) {
-    error(id->span(), "unresolved identifier '" + std::string(id->name()) + "'");
+    error(expr->span, "unresolved identifier '" + std::string(id.name) + "'");
     return nullptr;
   }
   return resolve_symbol_type(it->second);
@@ -624,19 +643,19 @@ auto TypeChecker::check_identifier(const IdentifierNode* id) -> const Type* {
 // Literals
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_int_literal(const IntLiteralNode* /*lit*/) -> const Type* {
+auto TypeChecker::check_int_literal(const Expr* /*expr*/) -> const Type* {
   return types_.i32(); // default integer literal type
 }
 
-auto TypeChecker::check_float_literal(const FloatLiteralNode* /*lit*/) -> const Type* {
+auto TypeChecker::check_float_literal(const Expr* /*expr*/) -> const Type* {
   return types_.f64(); // default float literal type
 }
 
-auto TypeChecker::check_string_literal(const StringLiteralNode* /*lit*/) -> const Type* {
+auto TypeChecker::check_string_literal(const Expr* /*expr*/) -> const Type* {
   return types_.named_type(nullptr, "string", {});
 }
 
-auto TypeChecker::check_bool_literal(const BoolLiteralNode* /*lit*/) -> const Type* {
+auto TypeChecker::check_bool_literal(const Expr* /*expr*/) -> const Type* {
   return types_.bool_type();
 }
 
@@ -644,14 +663,15 @@ auto TypeChecker::check_bool_literal(const BoolLiteralNode* /*lit*/) -> const Ty
 // Binary expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
-  const auto* lhs = check_expr(bin->left());
-  const auto* rhs = check_expr(bin->right());
+auto TypeChecker::check_binary(const Expr* expr) -> const Type* {
+  const auto& bin = expr->as<BinaryExpr>();
+  const auto* lhs = check_expr(bin.left);
+  const auto* rhs = check_expr(bin.right);
   if (lhs == nullptr || rhs == nullptr) {
     return nullptr;
   }
 
-  switch (bin->op()) {
+  switch (bin.op) {
   // Arithmetic: same numeric type required.
   case BinaryOp::Add:
   case BinaryOp::Sub:
@@ -659,12 +679,12 @@ auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
   case BinaryOp::Div:
   case BinaryOp::Mod: {
     if (!is_numeric(lhs)) {
-      error(bin->left()->span(),
+      error(bin.left->span,
             "arithmetic requires numeric type, got '" + print_type(lhs) + "'");
       return nullptr;
     }
     if (!is_assignable(lhs, rhs)) {
-      error(bin->span(),
+      error(expr->span,
             "mismatched types in arithmetic: '" + print_type(lhs) +
                 "' and '" + print_type(rhs) + "'");
       return nullptr;
@@ -678,12 +698,12 @@ auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
   case BinaryOp::Gt:
   case BinaryOp::GtEq: {
     if (!is_numeric(lhs)) {
-      error(bin->left()->span(),
+      error(bin.left->span,
             "comparison requires numeric type, got '" + print_type(lhs) + "'");
       return nullptr;
     }
     if (!is_assignable(lhs, rhs)) {
-      error(bin->span(),
+      error(expr->span,
             "mismatched types in comparison: '" + print_type(lhs) +
                 "' and '" + print_type(rhs) + "'");
       return nullptr;
@@ -695,7 +715,7 @@ auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
   case BinaryOp::EqEq:
   case BinaryOp::BangEq: {
     if (!is_assignable(lhs, rhs)) {
-      error(bin->span(),
+      error(expr->span,
             "mismatched types in equality: '" + print_type(lhs) +
                 "' and '" + print_type(rhs) + "'");
       return nullptr;
@@ -707,12 +727,12 @@ auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
   case BinaryOp::And:
   case BinaryOp::Or: {
     if (!is_assignable(lhs, types_.bool_type())) {
-      error(bin->left()->span(),
+      error(bin.left->span,
             "logical operator requires 'bool', got '" + print_type(lhs) + "'");
       return nullptr;
     }
     if (!is_assignable(rhs, types_.bool_type())) {
-      error(bin->right()->span(),
+      error(bin.right->span,
             "logical operator requires 'bool', got '" + print_type(rhs) + "'");
       return nullptr;
     }
@@ -727,16 +747,17 @@ auto TypeChecker::check_binary(const BinaryExprNode* bin) -> const Type* {
 // Unary expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_unary(const UnaryExprNode* un) -> const Type* {
-  const auto* operand = check_expr(un->operand());
+auto TypeChecker::check_unary(const Expr* expr) -> const Type* {
+  const auto& un = expr->as<UnaryExpr>();
+  const auto* operand = check_expr(un.operand);
   if (operand == nullptr) {
     return nullptr;
   }
 
-  switch (un->op()) {
+  switch (un.op) {
   case UnaryOp::Negate: {
     if (!is_numeric(operand)) {
-      error(un->operand()->span(),
+      error(un.operand->span,
             "negation requires numeric type, got '" + print_type(operand) + "'");
       return nullptr;
     }
@@ -745,7 +766,7 @@ auto TypeChecker::check_unary(const UnaryExprNode* un) -> const Type* {
 
   case UnaryOp::Not: {
     if (!is_assignable(operand, types_.bool_type())) {
-      error(un->operand()->span(),
+      error(un.operand->span,
             "logical not requires 'bool', got '" + print_type(operand) + "'");
       return nullptr;
     }
@@ -755,11 +776,11 @@ auto TypeChecker::check_unary(const UnaryExprNode* un) -> const Type* {
   case UnaryOp::Deref: {
     // Dereference requires mode unsafe.
     if (ctx_.active_modes.find("unsafe") == ctx_.active_modes.end()) {
-      error(un->span(), "dereference requires 'mode unsafe =>'");
+      error(expr->span, "dereference requires 'mode unsafe =>'");
       return nullptr;
     }
     if (operand->kind() != TypeKind::Pointer) {
-      error(un->operand()->span(),
+      error(un.operand->span,
             "cannot dereference non-pointer type '" + print_type(operand) + "'");
       return nullptr;
     }
@@ -768,8 +789,8 @@ auto TypeChecker::check_unary(const UnaryExprNode* un) -> const Type* {
 
   case UnaryOp::AddrOf: {
     // Address-of requires an lvalue.
-    if (!is_lvalue(un->operand())) {
-      error(un->operand()->span(), "cannot take address of non-lvalue");
+    if (!is_lvalue(un.operand)) {
+      error(un.operand->span, "cannot take address of non-lvalue");
       return nullptr;
     }
     return types_.pointer_to(operand);
@@ -783,14 +804,15 @@ auto TypeChecker::check_unary(const UnaryExprNode* un) -> const Type* {
 // Call expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_call(const CallExprNode* call) -> const Type* {
-  const auto* callee_type = check_expr(call->callee());
+auto TypeChecker::check_call(const Expr* expr) -> const Type* {
+  const auto& call = expr->as<CallExpr>();
+  const auto* callee_type = check_expr(call.callee);
   if (callee_type == nullptr) {
     return nullptr;
   }
 
   if (callee_type->kind() != TypeKind::Function) {
-    error(call->callee()->span(),
+    error(call.callee->span,
           "cannot call non-function type '" + print_type(callee_type) + "'");
     return nullptr;
   }
@@ -798,18 +820,18 @@ auto TypeChecker::check_call(const CallExprNode* call) -> const Type* {
   const auto* fn_type = static_cast<const TypeFunction*>(callee_type);
   const auto& params = fn_type->param_types();
 
-  if (call->args().size() != params.size()) {
-    error(call->span(),
+  if (call.args.size() != params.size()) {
+    error(expr->span,
           "expected " + std::to_string(params.size()) + " argument(s), got " +
-              std::to_string(call->args().size()));
+              std::to_string(call.args.size()));
     return nullptr;
   }
 
   for (size_t i = 0; i < params.size(); ++i) {
-    const auto* arg_type = check_expr(call->args()[i]);
+    const auto* arg_type = check_expr(call.args[i]);
     if (arg_type != nullptr && params[i] != nullptr &&
         !is_assignable(arg_type, params[i])) {
-      error(call->args()[i]->span(),
+      error(call.args[i]->span,
             "argument type '" + print_type(arg_type) +
                 "' is not assignable to parameter type '" +
                 print_type(params[i]) + "'");
@@ -823,20 +845,21 @@ auto TypeChecker::check_call(const CallExprNode* call) -> const Type* {
 // Pipe expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_pipe(const PipeExprNode* pipe) -> const Type* {
-  const auto* lhs_type = check_expr(pipe->left());
+auto TypeChecker::check_pipe(const Expr* expr) -> const Type* {
+  const auto& pipe = expr->as<PipeExpr>();
+  const auto* lhs_type = check_expr(pipe.left);
   if (lhs_type == nullptr) {
     return nullptr;
   }
 
   // The RHS of a pipe is typically a callable. Check it as an expression.
-  const auto* rhs_type = check_expr(pipe->right());
+  const auto* rhs_type = check_expr(pipe.right);
   if (rhs_type == nullptr) {
     return nullptr;
   }
 
   if (rhs_type->kind() != TypeKind::Function) {
-    error(pipe->right()->span(),
+    error(pipe.right->span,
           "pipe target must be callable, got '" + print_type(rhs_type) + "'");
     return nullptr;
   }
@@ -845,14 +868,14 @@ auto TypeChecker::check_pipe(const PipeExprNode* pipe) -> const Type* {
   const auto& params = fn_type->param_types();
 
   if (params.empty()) {
-    error(pipe->right()->span(),
+    error(pipe.right->span,
           "pipe target must accept at least one argument");
     return nullptr;
   }
 
   // LHS becomes first argument.
   if (!is_assignable(lhs_type, params[0])) {
-    error(pipe->left()->span(),
+    error(pipe.left->span,
           "pipe source type '" + print_type(lhs_type) +
               "' is not assignable to first parameter type '" +
               print_type(params[0]) + "'");
@@ -866,27 +889,28 @@ auto TypeChecker::check_pipe(const PipeExprNode* pipe) -> const Type* {
 // Field access
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_field(const FieldExprNode* field) -> const Type* {
-  const auto* obj_type = check_expr(field->object());
+auto TypeChecker::check_field(const Expr* expr) -> const Type* {
+  const auto& field = expr->as<FieldExpr>();
+  const auto* obj_type = check_expr(field.object);
   if (obj_type == nullptr) {
     return nullptr;
   }
 
   if (obj_type->kind() != TypeKind::Struct) {
-    error(field->object()->span(),
+    error(field.object->span,
           "field access on non-class type '" + print_type(obj_type) + "'");
     return nullptr;
   }
 
   const auto* st = static_cast<const TypeStruct*>(obj_type);
   for (const auto& f : st->fields()) {
-    if (f.name == field->field()) {
+    if (f.name == field.field) {
       return f.type;
     }
   }
 
-  error(field->field_span(),
-        "no field '" + std::string(field->field()) + "' on type '" +
+  error(field.field_span,
+        "no field '" + std::string(field.field) + "' on type '" +
             print_type(obj_type) + "'");
   return nullptr;
 }
@@ -895,18 +919,19 @@ auto TypeChecker::check_field(const FieldExprNode* field) -> const Type* {
 // Index expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_index(const IndexExprNode* idx) -> const Type* {
-  const auto* obj_type = check_expr(idx->object());
+auto TypeChecker::check_index(const Expr* expr) -> const Type* {
+  const auto& idx = expr->as<IndexExpr>();
+  const auto* obj_type = check_expr(idx.object);
   if (obj_type == nullptr) {
     return nullptr;
   }
 
   // Type-check index expressions but don't enforce semantics yet.
-  for (const auto* index : idx->indices()) {
+  for (const auto* index : idx.indices) {
     check_expr(index);
   }
 
-  error(idx->span(), "indexing is not yet supported in the type checker");
+  error(expr->span, "indexing is not yet supported in the type checker");
   return nullptr;
 }
 
@@ -914,38 +939,40 @@ auto TypeChecker::check_index(const IndexExprNode* idx) -> const Type* {
 // Lambda expressions
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_lambda(const LambdaNode* lam, const Type* expected)
+auto TypeChecker::check_lambda(const Expr* expr, const Type* expected)
     -> const Type* {
+  const auto& lam = expr->as<LambdaExpr>();
+
   // Lambdas require a contextual expected function type.
   if (expected == nullptr || expected->kind() != TypeKind::Function) {
-    error(lam->span(), "lambda requires expected function type context");
+    error(expr->span, "lambda requires expected function type context");
     return nullptr;
   }
 
   const auto* fn_expected = static_cast<const TypeFunction*>(expected);
   const auto& expected_params = fn_expected->param_types();
 
-  if (lam->params().size() != expected_params.size()) {
-    error(lam->span(),
-          "lambda has " + std::to_string(lam->params().size()) +
+  if (lam.params.size() != expected_params.size()) {
+    error(expr->span,
+          "lambda has " + std::to_string(lam.params.size()) +
               " parameter(s), expected " +
               std::to_string(expected_params.size()));
     return nullptr;
   }
 
   // Bind lambda param types from context and register them.
-  for (size_t i = 0; i < lam->params().size(); ++i) {
-    auto use_it = resolve_.uses.find(lam->params()[i].second.offset);
+  for (size_t i = 0; i < lam.params.size(); ++i) {
+    auto use_it = resolve_.uses.find(lam.params[i].second.offset);
     if (use_it != resolve_.uses.end()) {
       symbol_types_[use_it->second] = expected_params[i];
     }
   }
 
   // Check body expression against expected return type.
-  const auto* body_type = check_expr(lam->body());
+  const auto* body_type = check_expr(lam.body);
   if (body_type != nullptr && fn_expected->return_type() != nullptr &&
       !is_assignable(body_type, fn_expected->return_type())) {
-    error(lam->body()->span(),
+    error(lam.body->span,
           "lambda body type '" + print_type(body_type) +
               "' does not match expected return type '" +
               print_type(fn_expected->return_type()) + "'");
@@ -958,18 +985,20 @@ auto TypeChecker::check_lambda(const LambdaNode* lam, const Type* expected)
 // List literal
 // ---------------------------------------------------------------------------
 
-auto TypeChecker::check_list_literal(const ListLiteralNode* list) -> const Type* {
+auto TypeChecker::check_list_literal(const Expr* expr) -> const Type* {
+  const auto& list = expr->as<ListLiteral>();
+
   // Type-check elements but list typing is not yet frozen.
-  for (const auto* elem : list->elements()) {
+  for (const auto* elem : list.elements) {
     check_expr(elem);
   }
 
-  if (!list->elements().empty()) {
+  if (!list.elements.empty()) {
     // All elements must have the same type (if we can check them).
     // For now, just validate they type-check.
   }
 
-  error(list->span(), "list literal typing is not yet supported");
+  error(expr->span, "list literal typing is not yet supported");
   return nullptr;
 }
 
@@ -998,8 +1027,8 @@ auto TypeChecker::is_lvalue(const Expr* expr) -> bool {
     return true;
   case NodeKind::UnaryExpr: {
     // Dereferenced pointer is an lvalue.
-    const auto* un = static_cast<const UnaryExprNode*>(expr);
-    return un->op() == UnaryOp::Deref;
+    const auto& un = expr->as<UnaryExpr>();
+    return un.op == UnaryOp::Deref;
   }
   default:
     return false;

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -78,21 +78,21 @@ private:
 
   void register_declarations(const FileNode& file);
   void check_declaration(const Decl* decl);
-  void check_function(const FunctionDeclNode* fn);
-  void check_class(const ClassDeclNode* st);
+  void check_function(const Decl* decl);
+  void check_class(const Decl* decl);
 
   // --- Statement checking ---
 
   void check_statement(const Stmt* stmt);
-  void check_let(const LetStatementNode* let);
-  void check_assignment(const AssignmentNode* assign);
-  void check_if(const IfStatementNode* ifn);
-  void check_while(const WhileStatementNode* wh);
-  void check_for(const ForStatementNode* fo);
-  void check_mode_block(const ModeBlockNode* mb);
-  void check_resource_block(const ResourceBlockNode* rb);
-  void check_return(const ReturnStatementNode* ret);
-  void check_expr_stmt(const ExpressionStatementNode* es);
+  void check_let(const Stmt* stmt);
+  void check_assignment(const Stmt* stmt);
+  void check_if(const Stmt* stmt);
+  void check_while(const Stmt* stmt);
+  void check_for(const Stmt* stmt);
+  void check_mode_block(const Stmt* stmt);
+  void check_resource_block(const Stmt* stmt);
+  void check_return(const Stmt* stmt);
+  void check_expr_stmt(const Stmt* stmt);
 
   void check_body(const std::vector<Stmt*>& body);
 
@@ -101,19 +101,19 @@ private:
   auto check_expr(const Expr* expr) -> const Type*;
   auto check_expr(const Expr* expr, const Type* expected) -> const Type*;
 
-  auto check_identifier(const IdentifierNode* id) -> const Type*;
-  auto check_int_literal(const IntLiteralNode* lit) -> const Type*;
-  auto check_float_literal(const FloatLiteralNode* lit) -> const Type*;
-  auto check_string_literal(const StringLiteralNode* lit) -> const Type*;
-  auto check_bool_literal(const BoolLiteralNode* lit) -> const Type*;
-  auto check_binary(const BinaryExprNode* bin) -> const Type*;
-  auto check_unary(const UnaryExprNode* un) -> const Type*;
-  auto check_call(const CallExprNode* call) -> const Type*;
-  auto check_pipe(const PipeExprNode* pipe) -> const Type*;
-  auto check_field(const FieldExprNode* field) -> const Type*;
-  auto check_index(const IndexExprNode* idx) -> const Type*;
-  auto check_lambda(const LambdaNode* lam, const Type* expected) -> const Type*;
-  auto check_list_literal(const ListLiteralNode* list) -> const Type*;
+  auto check_identifier(const Expr* expr) -> const Type*;
+  auto check_int_literal(const Expr* expr) -> const Type*;
+  auto check_float_literal(const Expr* expr) -> const Type*;
+  auto check_string_literal(const Expr* expr) -> const Type*;
+  auto check_bool_literal(const Expr* expr) -> const Type*;
+  auto check_binary(const Expr* expr) -> const Type*;
+  auto check_unary(const Expr* expr) -> const Type*;
+  auto check_call(const Expr* expr) -> const Type*;
+  auto check_pipe(const Expr* expr) -> const Type*;
+  auto check_field(const Expr* expr) -> const Type*;
+  auto check_index(const Expr* expr) -> const Type*;
+  auto check_lambda(const Expr* expr, const Type* expected) -> const Type*;
+  auto check_list_literal(const Expr* expr) -> const Type*;
 
   // --- Diagnostics ---
 

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -73,10 +73,9 @@ struct TypecheckPipeline {
     if (parse_result.file == nullptr) {
       return nullptr;
     }
-    for (const auto* decl : parse_result.file->declarations()) {
+    for (const auto* decl : parse_result.file->declarations) {
       if (decl->kind() == NodeKind::FunctionDecl) {
-        return check_result.typed.decl_type(
-            static_cast<const Decl*>(decl));
+        return check_result.typed.decl_type(decl);
       }
     }
     return nullptr;

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -28,14 +28,14 @@ HirBuilder::HirBuilder(HirContext& ctx, const ResolveResult& resolve,
 
 auto HirBuilder::build(const FileNode& file) -> HirBuildResult {
   std::vector<HirDecl*> decls;
-  for (const auto* decl : file.declarations()) {
+  for (const auto* decl : file.declarations) {
     auto* hir_decl = lower_decl(decl);
     if (hir_decl != nullptr) {
       decls.push_back(hir_decl);
     }
   }
 
-  auto* mod = ctx_.alloc<HirModule>(file.span(), std::move(decls));
+  auto* mod = ctx_.alloc<HirModule>(file.span, std::move(decls));
   return {.module = mod, .diagnostics = std::move(diagnostics_)};
 }
 
@@ -46,30 +46,31 @@ auto HirBuilder::build(const FileNode& file) -> HirBuildResult {
 auto HirBuilder::lower_decl(const Decl* decl) -> HirDecl* {
   switch (decl->kind()) {
   case NodeKind::FunctionDecl:
-    return lower_function(static_cast<const FunctionDeclNode*>(decl));
+    return lower_function(decl);
   case NodeKind::ClassDecl:
-    return lower_class(static_cast<const ClassDeclNode*>(decl));
+    return lower_class(decl);
   default:
     return nullptr;
   }
 }
 
-auto HirBuilder::lower_function(const FunctionDeclNode* fn) -> HirDecl* {
-  const auto* sym = find_symbol_at_decl(fn->name_span().offset);
+auto HirBuilder::lower_function(const Decl* decl) -> HirDecl* {
+  const auto& fn = decl->as<FunctionDecl>();
+  const auto* sym = find_symbol_at_decl(fn.name_span.offset);
 
   // Build params.
   std::vector<HirParam> hir_params;
-  for (const auto& param : fn->params()) {
+  for (const auto& param : fn.params) {
     const auto* param_sym = find_symbol_at_decl(param.name_span.offset);
     const Type* param_type = nullptr;
 
     if (param_sym != nullptr) {
-      const auto* fn_type_raw = typed_.typed.decl_type(fn);
+      const auto* fn_type_raw = typed_.typed.decl_type(decl);
       if (fn_type_raw != nullptr &&
           fn_type_raw->kind() == TypeKind::Function) {
         const auto* fn_type =
             static_cast<const TypeFunction*>(fn_type_raw);
-        auto idx = static_cast<size_t>(&param - fn->params().data());
+        auto idx = static_cast<size_t>(&param - fn.params.data());
         if (idx < fn_type->param_types().size()) {
           param_type = fn_type->param_types()[idx];
         }
@@ -81,42 +82,43 @@ auto HirBuilder::lower_function(const FunctionDeclNode* fn) -> HirDecl* {
 
   // Return type.
   const Type* ret_type = nullptr;
-  const auto* fn_type_raw = typed_.typed.decl_type(fn);
+  const auto* fn_type_raw = typed_.typed.decl_type(decl);
   if (fn_type_raw != nullptr && fn_type_raw->kind() == TypeKind::Function) {
     ret_type = static_cast<const TypeFunction*>(fn_type_raw)->return_type();
   }
 
   // Body: extern functions have no body to lower.
   std::vector<HirStmt*> hir_body;
-  if (fn->is_extern()) {
+  if (fn.is_extern) {
     // No body for extern declarations.
-  } else if (fn->is_expr_bodied()) {
-    auto* expr = lower_expr(fn->expr_body());
+  } else if (fn.is_expr_bodied()) {
+    auto* expr = lower_expr(fn.expr_body);
     if (expr != nullptr) {
-      auto* ret = ctx_.alloc<HirStmt>(fn->expr_body()->span(),
+      auto* ret = ctx_.alloc<HirStmt>(fn.expr_body->span,
                                        HirReturn{expr});
       hir_body.push_back(ret);
     }
   } else {
-    hir_body = lower_body(fn->body());
+    hir_body = lower_body(fn.body);
   }
 
   return ctx_.alloc<HirDecl>(
-      fn->span(),
+      decl->span,
       HirFunction{sym, std::move(hir_params), ret_type,
-                  std::move(hir_body), fn->is_extern()});
+                  std::move(hir_body), fn.is_extern});
 }
 
-auto HirBuilder::lower_class(const ClassDeclNode* st) -> HirDecl* {
-  const auto* sym = find_symbol_at_decl(st->name_span().offset);
+auto HirBuilder::lower_class(const Decl* decl) -> HirDecl* {
+  const auto& st = decl->as<ClassDecl>();
+  const auto* sym = find_symbol_at_decl(st.name_span.offset);
 
   const TypeStruct* struct_type = nullptr;
-  const auto* decl_type = typed_.typed.decl_type(st);
+  const auto* decl_type = typed_.typed.decl_type(decl);
   if (decl_type != nullptr && decl_type->kind() == TypeKind::Struct) {
     struct_type = static_cast<const TypeStruct*>(decl_type);
   }
 
-  return ctx_.alloc<HirDecl>(st->span(), HirClassDecl{sym, struct_type});
+  return ctx_.alloc<HirDecl>(decl->span, HirClassDecl{sym, struct_type});
 }
 
 // ---------------------------------------------------------------------------
@@ -139,80 +141,80 @@ auto HirBuilder::lower_body(const std::vector<Stmt*>& body)
 auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
   switch (stmt->kind()) {
   case NodeKind::LetStatement: {
-    const auto* let = static_cast<const LetStatementNode*>(stmt);
-    const auto* sym = find_symbol_at_decl(let->name_span().offset);
-    const auto* type = typed_.typed.local_type(let);
+    const auto& let = stmt->as<LetStatement>();
+    const auto* sym = find_symbol_at_decl(let.name_span.offset);
+    const auto* type = typed_.typed.local_type(stmt);
     HirExpr* init = nullptr;
-    if (let->initializer() != nullptr) {
-      init = lower_expr(let->initializer());
+    if (let.initializer != nullptr) {
+      init = lower_expr(let.initializer);
     }
-    return ctx_.alloc<HirStmt>(let->span(), HirLet{sym, type, init});
+    return ctx_.alloc<HirStmt>(stmt->span, HirLet{sym, type, init});
   }
 
   case NodeKind::Assignment: {
-    const auto* assign = static_cast<const AssignmentNode*>(stmt);
-    auto* target = lower_expr(assign->target());
-    auto* value = lower_expr(assign->value());
-    return ctx_.alloc<HirStmt>(assign->span(), HirAssign{target, value});
+    const auto& assign = stmt->as<Assignment>();
+    auto* target = lower_expr(assign.target);
+    auto* value = lower_expr(assign.value);
+    return ctx_.alloc<HirStmt>(stmt->span, HirAssign{target, value});
   }
 
   case NodeKind::IfStatement: {
-    const auto* ifn = static_cast<const IfStatementNode*>(stmt);
-    auto* cond = lower_expr(ifn->condition());
-    auto then_body = lower_body(ifn->then_body());
-    auto else_body = lower_body(ifn->else_body());
+    const auto& ifn = stmt->as<IfStatement>();
+    auto* cond = lower_expr(ifn.condition);
+    auto then_body = lower_body(ifn.then_body);
+    auto else_body = lower_body(ifn.else_body);
     return ctx_.alloc<HirStmt>(
-        ifn->span(),
+        stmt->span,
         HirIf{cond, std::move(then_body), std::move(else_body)});
   }
 
   case NodeKind::WhileStatement: {
-    const auto* wh = static_cast<const WhileStatementNode*>(stmt);
-    auto* cond = lower_expr(wh->condition());
-    auto body = lower_body(wh->body());
-    return ctx_.alloc<HirStmt>(wh->span(),
+    const auto& wh = stmt->as<WhileStatement>();
+    auto* cond = lower_expr(wh.condition);
+    auto body = lower_body(wh.body);
+    return ctx_.alloc<HirStmt>(stmt->span,
                                 HirWhile{cond, std::move(body)});
   }
 
   case NodeKind::ForStatement: {
-    const auto* fo = static_cast<const ForStatementNode*>(stmt);
-    const auto* var_sym = find_symbol_at_decl(fo->var_span().offset);
-    auto* iterable = lower_expr(fo->iterable());
-    auto body = lower_body(fo->body());
+    const auto& fo = stmt->as<ForStatement>();
+    const auto* var_sym = find_symbol_at_decl(fo.var_span.offset);
+    auto* iterable = lower_expr(fo.iterable);
+    auto body = lower_body(fo.body);
     return ctx_.alloc<HirStmt>(
-        fo->span(), HirFor{var_sym, iterable, std::move(body)});
+        stmt->span, HirFor{var_sym, iterable, std::move(body)});
   }
 
   case NodeKind::ModeBlock: {
-    const auto* mb = static_cast<const ModeBlockNode*>(stmt);
-    auto mode = hir_mode_kind_from_name(mb->mode_name());
-    auto body = lower_body(mb->body());
+    const auto& mb = stmt->as<ModeBlock>();
+    auto mode = hir_mode_kind_from_name(mb.mode_name);
+    auto body = lower_body(mb.body);
     return ctx_.alloc<HirStmt>(
-        mb->span(), HirMode{mode, mb->mode_name(), std::move(body)});
+        stmt->span, HirMode{mode, mb.mode_name, std::move(body)});
   }
 
   case NodeKind::ResourceBlock: {
-    const auto* rb = static_cast<const ResourceBlockNode*>(stmt);
-    auto body = lower_body(rb->body());
+    const auto& rb = stmt->as<ResourceBlock>();
+    auto body = lower_body(rb.body);
     return ctx_.alloc<HirStmt>(
-        rb->span(),
-        HirResource{rb->resource_kind(), rb->resource_name(),
+        stmt->span,
+        HirResource{rb.resource_kind, rb.resource_name,
                     std::move(body)});
   }
 
   case NodeKind::ReturnStatement: {
-    const auto* ret = static_cast<const ReturnStatementNode*>(stmt);
+    const auto& ret = stmt->as<ReturnStatement>();
     HirExpr* value = nullptr;
-    if (ret->value() != nullptr) {
-      value = lower_expr(ret->value());
+    if (ret.value != nullptr) {
+      value = lower_expr(ret.value);
     }
-    return ctx_.alloc<HirStmt>(ret->span(), HirReturn{value});
+    return ctx_.alloc<HirStmt>(stmt->span, HirReturn{value});
   }
 
   case NodeKind::ExpressionStatement: {
-    const auto* es = static_cast<const ExpressionStatementNode*>(stmt);
-    auto* expr = lower_expr(es->expr());
-    return ctx_.alloc<HirStmt>(es->span(), HirExprStmt{expr});
+    const auto& es = stmt->as<ExpressionStatement>();
+    auto* expr = lower_expr(es.expr);
+    return ctx_.alloc<HirStmt>(stmt->span, HirExprStmt{expr});
   }
 
   default:
@@ -231,57 +233,57 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
   }
 
   const auto* type = expr_type(expr);
-  auto span = expr->span();
+  auto span = expr->span;
 
   switch (expr->kind()) {
   case NodeKind::IntLiteral: {
-    const auto* lit = static_cast<const IntLiteralNode*>(expr);
+    const auto& lit = expr->as<IntLiteral>();
     int64_t val = 0;
-    auto text = lit->text();
+    auto text = lit.text;
     std::from_chars(text.data(), text.data() + text.size(), val);
     return ctx_.alloc<HirExpr>(span, type, HirIntLiteral{val});
   }
 
   case NodeKind::FloatLiteral: {
-    const auto* lit = static_cast<const FloatLiteralNode*>(expr);
-    double val = std::strtod(std::string(lit->text()).c_str(), nullptr);
+    const auto& lit = expr->as<FloatLiteral>();
+    double val = std::strtod(std::string(lit.text).c_str(), nullptr);
     return ctx_.alloc<HirExpr>(span, type, HirFloatLiteral{val});
   }
 
   case NodeKind::StringLiteral: {
-    const auto* lit = static_cast<const StringLiteralNode*>(expr);
-    return ctx_.alloc<HirExpr>(span, type, HirStringLiteral{lit->text()});
+    const auto& lit = expr->as<StringLiteral>();
+    return ctx_.alloc<HirExpr>(span, type, HirStringLiteral{lit.text});
   }
 
   case NodeKind::BoolLiteral: {
-    const auto* lit = static_cast<const BoolLiteralNode*>(expr);
-    return ctx_.alloc<HirExpr>(span, type, HirBoolLiteral{lit->value()});
+    const auto& lit = expr->as<BoolLiteral>();
+    return ctx_.alloc<HirExpr>(span, type, HirBoolLiteral{lit.value});
   }
 
   case NodeKind::Identifier: {
-    const auto* sym = find_symbol_at_use(expr->span().offset);
+    const auto* sym = find_symbol_at_use(expr->span.offset);
     return ctx_.alloc<HirExpr>(span, type, HirSymbolRef{sym});
   }
 
   case NodeKind::UnaryExpr: {
-    const auto* un = static_cast<const UnaryExprNode*>(expr);
-    auto* operand = lower_expr(un->operand());
-    return ctx_.alloc<HirExpr>(span, type, HirUnary{un->op(), operand});
+    const auto& un = expr->as<UnaryExpr>();
+    auto* operand = lower_expr(un.operand);
+    return ctx_.alloc<HirExpr>(span, type, HirUnary{un.op, operand});
   }
 
   case NodeKind::BinaryExpr: {
-    const auto* bin = static_cast<const BinaryExprNode*>(expr);
-    auto* left = lower_expr(bin->left());
-    auto* right = lower_expr(bin->right());
+    const auto& bin = expr->as<BinaryExpr>();
+    auto* left = lower_expr(bin.left);
+    auto* right = lower_expr(bin.right);
     return ctx_.alloc<HirExpr>(span, type,
-                                HirBinary{bin->op(), left, right});
+                                HirBinary{bin.op, left, right});
   }
 
   case NodeKind::CallExpr: {
-    const auto* call = static_cast<const CallExprNode*>(expr);
-    auto* callee = lower_expr(call->callee());
+    const auto& call = expr->as<CallExpr>();
+    auto* callee = lower_expr(call.callee);
     std::vector<HirExpr*> args;
-    for (const auto* arg : call->args()) {
+    for (const auto* arg : call.args) {
       args.push_back(lower_expr(arg));
     }
     return ctx_.alloc<HirExpr>(span, type,
@@ -289,24 +291,24 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
   }
 
   case NodeKind::PipeExpr: {
-    const auto* pipe = static_cast<const PipeExprNode*>(expr);
-    auto* left = lower_expr(pipe->left());
-    auto* right = lower_expr(pipe->right());
+    const auto& pipe = expr->as<PipeExpr>();
+    auto* left = lower_expr(pipe.left);
+    auto* right = lower_expr(pipe.right);
     return ctx_.alloc<HirExpr>(span, type, HirPipe{left, right});
   }
 
   case NodeKind::FieldExpr: {
-    const auto* field = static_cast<const FieldExprNode*>(expr);
-    auto* object = lower_expr(field->object());
+    const auto& field = expr->as<FieldExpr>();
+    auto* object = lower_expr(field.object);
     return ctx_.alloc<HirExpr>(span, type,
-                                HirField{object, field->field()});
+                                HirField{object, field.field});
   }
 
   case NodeKind::IndexExpr: {
-    const auto* idx = static_cast<const IndexExprNode*>(expr);
-    auto* object = lower_expr(idx->object());
+    const auto& idx = expr->as<IndexExpr>();
+    auto* object = lower_expr(idx.object);
     std::vector<HirExpr*> indices;
-    for (const auto* i : idx->indices()) {
+    for (const auto* i : idx.indices) {
       indices.push_back(lower_expr(i));
     }
     return ctx_.alloc<HirExpr>(span, type,
@@ -314,14 +316,14 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
   }
 
   case NodeKind::Lambda: {
-    const auto* lam = static_cast<const LambdaNode*>(expr);
+    const auto& lam = expr->as<LambdaExpr>();
     std::vector<HirParam> params;
     const TypeFunction* fn_type = nullptr;
     if (type != nullptr && type->kind() == TypeKind::Function) {
       fn_type = static_cast<const TypeFunction*>(type);
     }
-    for (size_t i = 0; i < lam->params().size(); ++i) {
-      const auto& [name, param_span] = lam->params()[i];
+    for (size_t i = 0; i < lam.params.size(); ++i) {
+      const auto& [name, param_span] = lam.params[i];
       const auto* param_sym = find_symbol_at_decl(param_span.offset);
       const Type* param_type = nullptr;
       if (fn_type != nullptr && i < fn_type->param_types().size()) {
@@ -329,13 +331,13 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
       }
       params.push_back({param_sym, param_type, param_span});
     }
-    auto* body = lower_expr(lam->body());
+    auto* body = lower_expr(lam.body);
     return ctx_.alloc<HirExpr>(span, type,
                                 HirLambda{std::move(params), body});
   }
 
   default:
-    error(expr->span(), "unsupported expression in HIR builder");
+    error(expr->span, "unsupported expression in HIR builder");
     return nullptr;
   }
 }

--- a/compiler/ir/hir/hir_builder.h
+++ b/compiler/ir/hir/hir_builder.h
@@ -49,8 +49,8 @@ private:
   // --- Declaration lowering ---
 
   auto lower_decl(const Decl* decl) -> HirDecl*;
-  auto lower_function(const FunctionDeclNode* fn) -> HirDecl*;
-  auto lower_class(const ClassDeclNode* st) -> HirDecl*;
+  auto lower_function(const Decl* decl) -> HirDecl*;
+  auto lower_class(const Decl* decl) -> HirDecl*;
 
   // --- Statement lowering ---
 


### PR DESCRIPTION
## Summary

Replace ~30 leaf AST node classes (inheriting from `AstNode`) with 4 flat variant-based container structs (`Decl`, `Stmt`, `Expr`, `TypeNode`), each holding a `Span` + typed `std::variant` payload. This eliminates virtual dispatch, simplifies node construction via aggregate init, and reduces total AST code by ~450 lines.

## Highlights

- **4 container structs** with `kind()`, `as<T>()`, `is<T>()` methods replace the full OOP hierarchy
- **Direct public member access** on payload structs replaces accessor methods (e.g. `fn.name` instead of `fn->name()`)
- **`std::visit(overloaded{...})`** dispatch in `ast.cpp` and `ast_printer.cpp` replaces `switch` on `NodeKind`
- **`Symbol::decl` changed to `const void*`** since there is no common `AstNode` base class
- **`resolve_context.h`** parameter updated from `const AstNode*` to `const void*`
- **15 files updated** across parser, printer, resolve, typecheck, semantic tokens, HIR builder, driver, and tests
- **Net -450 lines** — simpler, flatter, more maintainable AST layer

## Test plan

- [x] Full build passes (`cmake --build . -j4`)
- [x] All 10 test suites pass (`ctest --output-on-failure`)
- [ ] Verify playground still works end-to-end with sample programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)