### PR TITLE
feat(frontend): ✨ add class construction syntax through full pipeline

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -846,6 +846,17 @@ auto LlvmBackend::lower_construct(const MirConstruct& p, const MirInst& inst,
     return false;
   }
 
+  // Validate field count matches struct layout.
+  size_t value_count =
+      p.field_values != nullptr ? p.field_values->size() : 0;
+  if (value_count != p.struct_type->fields().size()) {
+    emit_diagnostic(inst.span,
+                    "construct field count mismatch: expected " +
+                        std::to_string(p.struct_type->fields().size()) +
+                        ", got " + std::to_string(value_count));
+    return false;
+  }
+
   llvm::Value* agg = llvm::UndefValue::get(llvm_type);
   if (p.field_values != nullptr) {
     for (unsigned i = 0; i < p.field_values->size(); ++i) {

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -270,6 +270,7 @@ auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
       [&](const MirLoad& p)        { return lower_load(p, inst, fn, state); },
       [&](const MirFnRef& p)       { return lower_fn_ref(p, inst, state); },
       [&](const MirCall& p)        { return lower_call(p, inst, state); },
+      [&](const MirConstruct& p)   { return lower_construct(p, inst, state); },
       [&](const MirReturn& p)      { return lower_return(p, inst, state); },
       [&](const MirBr& p)          { return lower_br(p, inst, state); },
       [&](const MirCondBr& p)      { return lower_cond_br(p, inst, state); },
@@ -824,6 +825,42 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
     state.values[inst.result.id] = call;
     state.value_types[inst.result.id] = inst.type;
   }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Struct construction
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_construct(const MirConstruct& p, const MirInst& inst,
+                                    FunctionState& state) -> bool {
+  if (p.struct_type == nullptr) {
+    emit_diagnostic(inst.span, "construct with null struct type");
+    return false;
+  }
+
+  auto* llvm_type = types_.lower(p.struct_type);
+  if (llvm_type == nullptr) {
+    emit_diagnostic(inst.span,
+                    "cannot lower construct type: " + types_.error());
+    return false;
+  }
+
+  llvm::Value* agg = llvm::UndefValue::get(llvm_type);
+  if (p.field_values != nullptr) {
+    for (unsigned i = 0; i < p.field_values->size(); ++i) {
+      auto* val = get_value((*p.field_values)[i], state);
+      if (val == nullptr) {
+        emit_diagnostic(inst.span, "construct field value not found");
+        return false;
+      }
+      agg = state.builder->CreateInsertValue(
+          agg, val, i, "ctor." + std::to_string(i));
+    }
+  }
+
+  state.values[inst.result.id] = agg;
+  state.value_types[inst.result.id] = inst.type;
   return true;
 }
 

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -108,6 +108,8 @@ private:
                     FunctionState& state) -> bool;
   auto lower_call(const MirCall& p, const MirInst& inst,
                   FunctionState& state) -> bool;
+  auto lower_construct(const MirConstruct& p, const MirInst& inst,
+                       FunctionState& state) -> bool;
   auto lower_return(const MirReturn& p, const MirInst& inst,
                     FunctionState& state) -> bool;
   auto lower_br(const MirBr& p, const MirInst& inst,

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -495,6 +495,91 @@ suite<"unsupported_constructs"> unsupported_constructs = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Class construction
+// ---------------------------------------------------------------------------
+
+suite<"construction"> construction = [] {
+  "basic construction produces struct value"_test = [] {
+    LlvmTestPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "\n"
+        "fn make(): Point\n"
+        "  return Point(1, 2)\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "%dao.Point")) << ir;
+    expect(contains(ir, "ret %dao.Point")) << ir;
+  };
+
+  "construction and field access roundtrip"_test = [] {
+    LlvmTestPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "\n"
+        "fn get_x(): i32\n"
+        "  let p: Point = Point(10, 20)\n"
+        "  return p.x\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "store %dao.Point")) << ir;
+    expect(contains(ir, "extractvalue")) << ir;
+  };
+
+  "nested construction"_test = [] {
+    LlvmTestPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "\n"
+        "class Rect:\n"
+        "  tl: Point\n"
+        "  br: Point\n"
+        "\n"
+        "fn make(): Rect\n"
+        "  return Rect(Point(0, 0), Point(1, 1))\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "%dao.Rect")) << ir;
+    expect(contains(ir, "%dao.Point")) << ir;
+    expect(contains(ir, "ret %dao.Rect")) << ir;
+  };
+
+  "pass constructed value to function"_test = [] {
+    LlvmTestPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "\n"
+        "fn get_x(p: Point): i32\n"
+        "  return p.x\n"
+        "\n"
+        "fn main(): i32\n"
+        "  return get_x(Point(42, 0))\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "%dao.Point")) << ir;
+    expect(contains(ir, "call i32 @get_x")) << ir;
+  };
+
+  "construction with non-constant args uses insertvalue"_test = [] {
+    LlvmTestPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "\n"
+        "fn make(a: i32, b: i32): Point\n"
+        "  return Point(a, b)\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "insertvalue")) << ir;
+    expect(contains(ir, "%dao.Point")) << ir;
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -811,10 +811,17 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
-  // Constructor call: callee resolves to a struct type.
-  if (callee_type->kind() == TypeKind::Struct) {
-    return check_construct(expr,
-                           static_cast<const TypeStruct*>(callee_type));
+  // Constructor call: callee must be an identifier that resolves to a
+  // Type symbol (e.g. `Point`), not merely any expression whose type
+  // happens to be a struct (e.g. `p` where `p: Point`).
+  if (callee_type->kind() == TypeKind::Struct &&
+      call.callee->is<IdentifierExpr>()) {
+    auto sym_it = resolve_.uses.find(call.callee->span.offset);
+    if (sym_it != resolve_.uses.end() &&
+        sym_it->second->kind == SymbolKind::Type) {
+      return check_construct(expr,
+                             static_cast<const TypeStruct*>(callee_type));
+    }
   }
 
   if (callee_type->kind() != TypeKind::Function) {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -811,6 +811,12 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
+  // Constructor call: callee resolves to a struct type.
+  if (callee_type->kind() == TypeKind::Struct) {
+    return check_construct(expr,
+                           static_cast<const TypeStruct*>(callee_type));
+  }
+
   if (callee_type->kind() != TypeKind::Function) {
     error(call.callee->span,
           "cannot call non-function type '" + print_type(callee_type) + "'");
@@ -839,6 +845,38 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
   }
 
   return fn_type->return_type();
+}
+
+// ---------------------------------------------------------------------------
+// Constructor expressions (Point(1, 2))
+// ---------------------------------------------------------------------------
+
+auto TypeChecker::check_construct(const Expr* expr,
+                                  const TypeStruct* struct_type)
+    -> const Type* {
+  const auto& call = expr->as<CallExpr>();
+  const auto& fields = struct_type->fields();
+
+  if (call.args.size() != fields.size()) {
+    error(expr->span,
+          "'" + std::string(struct_type->name()) + "' expects " +
+              std::to_string(fields.size()) + " field(s), got " +
+              std::to_string(call.args.size()));
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < fields.size(); ++i) {
+    const auto* arg_type = check_expr(call.args[i]);
+    if (arg_type != nullptr && fields[i].type != nullptr &&
+        !is_assignable(arg_type, fields[i].type)) {
+      error(call.args[i]->span,
+            "field '" + std::string(fields[i].name) + "' expects type '" +
+                print_type(fields[i].type) + "', got '" +
+                print_type(arg_type) + "'");
+    }
+  }
+
+  return struct_type;
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -109,6 +109,8 @@ private:
   auto check_binary(const Expr* expr) -> const Type*;
   auto check_unary(const Expr* expr) -> const Type*;
   auto check_call(const Expr* expr) -> const Type*;
+  auto check_construct(const Expr* expr, const TypeStruct* struct_type)
+      -> const Type*;
   auto check_pipe(const Expr* expr) -> const Type*;
   auto check_field(const Expr* expr) -> const Type*;
   auto check_index(const Expr* expr) -> const Type*;

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -451,6 +451,17 @@ suite<"typecheck_construct"> typecheck_construct = [] {
         "fn get_x(): i32 -> Point(1, 2).x\n");
     expect(is_ok(result)) << "field access on construction should typecheck";
   };
+
+  "value of struct type is not a constructor"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn bad(p: Point): Point -> p(1, 2)\n");
+    expect(has_error_containing(result, "cannot call non-function"))
+        << "calling a struct value should not be treated as construction";
+  };
 };
 
 // NOLINTEND(readability-magic-numbers)

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -381,6 +381,78 @@ suite<"type_alias"> type_alias = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Class construction
+// ---------------------------------------------------------------------------
+
+suite<"typecheck_construct"> typecheck_construct = [] {
+  "basic construction"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn make(): Point -> Point(1, 2)\n");
+    expect(is_ok(result)) << "basic construction should typecheck";
+  };
+
+  "construction with wrong arity"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn make(): Point -> Point(1)\n");
+    expect(has_error_containing(result, "expects 2 field(s), got 1"));
+  };
+
+  "construction with wrong field type"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn make(): Point -> Point(1, true)\n");
+    expect(has_error_containing(result, "field 'y' expects type"));
+  };
+
+  "construction in let binding"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn make(): i32\n"
+        "    let p: Point = Point(1, 2)\n"
+        "    p.x\n");
+    expect(is_ok(result)) << "let with construction should typecheck";
+  };
+
+  "nested construction"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "class Rect:\n"
+        "    tl: Point\n"
+        "    br: Point\n"
+        "\n"
+        "fn make(): Rect -> Rect(Point(0, 0), Point(1, 1))\n");
+    expect(is_ok(result)) << "nested construction should typecheck";
+  };
+
+  "field access on constructed value"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "\n"
+        "fn get_x(): i32 -> Point(1, 2).x\n");
+    expect(is_ok(result)) << "field access on construction should typecheck";
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/ir/hir/hir.cpp
+++ b/compiler/ir/hir/hir.cpp
@@ -38,6 +38,7 @@ auto HirExpr::kind() const -> HirKind {
       [](const HirUnary&) { return HirKind::Unary; },
       [](const HirBinary&) { return HirKind::Binary; },
       [](const HirCall&) { return HirKind::Call; },
+      [](const HirConstruct&) { return HirKind::Construct; },
       [](const HirField&) { return HirKind::Field; },
       [](const HirIndex&) { return HirKind::Index; },
       [](const HirPipe&) { return HirKind::Pipe; },
@@ -71,6 +72,7 @@ auto hir_kind_name(HirKind kind) -> const char* {
   case HirKind::Unary:         return "Unary";
   case HirKind::Binary:        return "Binary";
   case HirKind::Call:          return "Call";
+  case HirKind::Construct:     return "Construct";
   case HirKind::Field:         return "Field";
   case HirKind::Index:         return "Index";
   case HirKind::Pipe:          return "Pipe";

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -141,6 +141,11 @@ struct HirCall {
   std::vector<HirExpr*> args;
 };
 
+struct HirConstruct {
+  const TypeStruct* struct_type;
+  std::vector<HirExpr*> args;
+};
+
 struct HirField {
   HirExpr* object;
   std::string_view field_name;
@@ -163,7 +168,7 @@ struct HirLambda {
 
 using HirExprPayload = std::variant<
     HirIntLiteral, HirFloatLiteral, HirStringLiteral, HirBoolLiteral,
-    HirSymbolRef, HirUnary, HirBinary, HirCall,
+    HirSymbolRef, HirUnary, HirBinary, HirCall, HirConstruct,
     HirField, HirIndex, HirPipe, HirLambda>;
 
 // ---------------------------------------------------------------------------

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -282,17 +282,22 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
   case NodeKind::CallExpr: {
     const auto& call = expr->as<CallExpr>();
 
-    // Constructor call: callee type is a struct.
+    // Constructor call: callee must be a Type symbol whose type is a
+    // struct, not any expression that happens to have struct type.
     const auto* callee_type = expr_type(call.callee);
-    if (callee_type != nullptr && callee_type->kind() == TypeKind::Struct) {
-      const auto* struct_type =
-          static_cast<const TypeStruct*>(callee_type);
-      std::vector<HirExpr*> args;
-      for (const auto* arg : call.args) {
-        args.push_back(lower_expr(arg));
+    if (callee_type != nullptr && callee_type->kind() == TypeKind::Struct &&
+        call.callee->is<IdentifierExpr>()) {
+      const auto* sym = find_symbol_at_use(call.callee->span.offset);
+      if (sym != nullptr && sym->kind == SymbolKind::Type) {
+        const auto* struct_type =
+            static_cast<const TypeStruct*>(callee_type);
+        std::vector<HirExpr*> args;
+        for (const auto* arg : call.args) {
+          args.push_back(lower_expr(arg));
+        }
+        return ctx_.alloc<HirExpr>(
+            span, type, HirConstruct{struct_type, std::move(args)});
       }
-      return ctx_.alloc<HirExpr>(span, type,
-                                  HirConstruct{struct_type, std::move(args)});
     }
 
     // Normal function call.

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -281,6 +281,21 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
 
   case NodeKind::CallExpr: {
     const auto& call = expr->as<CallExpr>();
+
+    // Constructor call: callee type is a struct.
+    const auto* callee_type = expr_type(call.callee);
+    if (callee_type != nullptr && callee_type->kind() == TypeKind::Struct) {
+      const auto* struct_type =
+          static_cast<const TypeStruct*>(callee_type);
+      std::vector<HirExpr*> args;
+      for (const auto* arg : call.args) {
+        args.push_back(lower_expr(arg));
+      }
+      return ctx_.alloc<HirExpr>(span, type,
+                                  HirConstruct{struct_type, std::move(args)});
+    }
+
+    // Normal function call.
     auto* callee = lower_expr(call.callee);
     std::vector<HirExpr*> args;
     for (const auto* arg : call.args) {

--- a/compiler/ir/hir/hir_kind.h
+++ b/compiler/ir/hir/hir_kind.h
@@ -37,6 +37,7 @@ enum class HirKind : std::uint8_t {
   Unary,
   Binary,
   Call,
+  Construct,
   Field,
   Index,
   Pipe,

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -327,6 +327,24 @@ private:
             }
           }
         },
+        [&](const HirConstruct& node) {
+          indent();
+          out_ << "Construct ";
+          if (node.struct_type != nullptr) {
+            out_ << node.struct_type->name();
+          }
+          print_type_annotation(expr.type);
+          out_ << "\n";
+          if (!node.args.empty()) {
+            Scope scope(depth_);
+            indent();
+            out_ << "Args\n";
+            Scope args_scope(depth_);
+            for (const auto* arg : node.args) {
+              print_expr(*arg);
+            }
+          }
+        },
         [&](const HirField& node) {
           indent();
           out_ << "Field ." << node.field_name;

--- a/compiler/ir/mir/mir.cpp
+++ b/compiler/ir/mir/mir.cpp
@@ -23,6 +23,7 @@ auto MirInst::kind() const -> MirInstKind {
       [](const MirIndexAccess&)   { return MirInstKind::IndexAccess; },
       [](const MirFnRef&)         { return MirInstKind::FnRef; },
       [](const MirCall&)          { return MirInstKind::Call; },
+      [](const MirConstruct&)     { return MirInstKind::Construct; },
       [](const MirIterInit&)      { return MirInstKind::IterInit; },
       [](const MirIterHasNext&)   { return MirInstKind::IterHasNext; },
       [](const MirIterNext&)      { return MirInstKind::IterNext; },
@@ -56,6 +57,7 @@ auto mir_inst_kind_name(MirInstKind kind) -> const char* {
   case MirInstKind::IndexAccess:    return "index";
   case MirInstKind::FnRef:          return "fn_ref";
   case MirInstKind::Call:           return "call";
+  case MirInstKind::Construct:     return "construct";
   case MirInstKind::IterInit:       return "iter_init";
   case MirInstKind::IterHasNext:    return "iter_has_next";
   case MirInstKind::IterNext:       return "iter_next";

--- a/compiler/ir/mir/mir.h
+++ b/compiler/ir/mir/mir.h
@@ -92,6 +92,7 @@ struct MirIndexAccess { MirValueId object; MirValueId index; };
 
 struct MirFnRef { const Symbol* symbol; };
 struct MirCall  { MirValueId callee; std::vector<MirValueId>* args; };
+struct MirConstruct { const TypeStruct* struct_type; std::vector<MirValueId>* field_values; };
 
 struct MirIterInit    { MirValueId iter_operand; };
 struct MirIterHasNext { MirValueId iter_operand; };
@@ -118,7 +119,7 @@ using MirPayload = std::variant<
     MirUnary, MirBinary,
     MirStore, MirLoad, MirAddrOf,
     MirFieldAccess, MirIndexAccess,
-    MirFnRef, MirCall,
+    MirFnRef, MirCall, MirConstruct,
     MirIterInit, MirIterHasNext, MirIterNext,
     MirModeEnter, MirModeExit, MirResourceEnter, MirResourceExit,
     MirLambdaInst,

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -377,6 +377,13 @@ auto MirBuilder::lower_expr_value(const HirExpr& expr) -> MirValueId {
         }
         return emit_value(expr, MirCall{callee_val, args});
       },
+      [&](const HirConstruct& ctor) -> MirValueId {
+        auto* field_vals = ctx_.alloc<std::vector<MirValueId>>();
+        for (const auto* arg : ctor.args) {
+          field_vals->push_back(lower_expr_value(*arg));
+        }
+        return emit_value(expr, MirConstruct{ctor.struct_type, field_vals});
+      },
       [&](const HirPipe& pipe) -> MirValueId {
         auto left_val = lower_expr_value(*pipe.left);
         auto callee_val = lower_expr_value(*pipe.right);

--- a/compiler/ir/mir/mir_kind.h
+++ b/compiler/ir/mir/mir_kind.h
@@ -31,6 +31,9 @@ enum class MirInstKind : std::uint8_t {
   // Calls
   Call,
 
+  // Construction
+  Construct,
+
   // Iteration (narrow model)
   IterInit,
   IterHasNext,

--- a/compiler/ir/mir/mir_printer.cpp
+++ b/compiler/ir/mir/mir_printer.cpp
@@ -138,6 +138,22 @@ private:
           }
           out_ << ")";
         },
+        [&](const MirConstruct& p) {
+          out_ << "construct ";
+          if (p.struct_type != nullptr) {
+            out_ << p.struct_type->name();
+          }
+          out_ << "(";
+          if (p.field_values != nullptr) {
+            for (size_t i = 0; i < p.field_values->size(); ++i) {
+              if (i > 0) {
+                out_ << ", ";
+              }
+              out_ << "%" << (*p.field_values)[i].id;
+            }
+          }
+          out_ << ")";
+        },
         [&](const MirIterInit& p) {
           out_ << "iter_init %" << p.iter_operand.id;
         },


### PR DESCRIPTION
## Summary

Adds support for `Point(1, 2)` class construction expressions, flowing through the entire compiler pipeline from typecheck to LLVM IR emission. No parser or resolver changes needed — `Point(1, 2)` already parses as a `CallExpr` and `Point` resolves to a `SymbolKind::Type` symbol.

## Highlights

- **Typecheck**: new `check_construct` method validates field count and field types when callee resolves to a `TypeStruct`
- **HIR**: new `HirConstruct` node separates construction from function calls at the semantic level
- **MIR**: new `MirConstruct` instruction carries struct type + field value list
- **LLVM backend**: `lower_construct` emits `insertvalue` chain from `undef` (constant-folded by LLVM when all args are literals)
- **11 new tests**: 6 typecheck (basic, wrong arity, wrong type, let binding, nested, field access) + 5 LLVM backend (struct value, roundtrip, nested, pass-to-function, non-constant args)

## Test plan

- [x] Full build passes (`cmake --build . -j4`)
- [x] All 10 test suites pass (`ctest --output-on-failure`)
- [x] New typecheck tests cover positive and negative cases
- [x] New LLVM backend tests verify IR output for constant and non-constant construction
- [ ] Verify playground handles construction expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)