### PR TITLE
feat(frontend): ✨ implement generic type parameter parsing and resolution

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -504,6 +504,8 @@ auto resolve_use_category(SymbolKind kind) -> std::string_view {
     return "use.module";
   case SymbolKind::LambdaParam:
     return "use.variable.param"; // reuse param category for lambda params
+  case SymbolKind::GenericParam:
+    return "use.type"; // generic type parameters classify as type uses
   case SymbolKind::Builtin:
   case SymbolKind::Predeclared:
     return ""; // type-position symbols — classified by visit_type(), not here

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -25,6 +25,9 @@ using namespace dao;
 
 namespace {
 
+// Sentinel declaration identity for testing.
+const int kDeclSentinel = 1;
+
 /// Full pipeline: source → MIR → LLVM IR.
 struct LlvmTestPipeline {
   SourceBuffer source;
@@ -140,7 +143,7 @@ suite<"type_lowering"> type_lowering = [] {
     LlvmTypeLowering lowering(ctx);
     TypeContext types;
 
-    auto* gp = types.generic_param("T", 0);
+    auto* gp = types.generic_param(&kDeclSentinel, "T", 0);
     expect(lowering.lower(gp) == nullptr);
     expect(contains(lowering.error(), "generic"));
   };

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -108,6 +108,12 @@ struct Param {
   TypeNode* type;
 };
 
+struct GenericParam {
+  std::string_view name;
+  Span name_span;
+  std::vector<TypeNode*> constraints; // concept bounds from `: Concept + Concept`
+};
+
 // ---------------------------------------------------------------------------
 // Binary / Unary operator tags
 // ---------------------------------------------------------------------------
@@ -168,6 +174,7 @@ struct FieldSpec {
 struct FunctionDecl {
   std::string_view name;
   Span name_span;
+  std::vector<GenericParam> type_params;
   std::vector<Param> params;
   TypeNode* return_type;       // nullable
   std::vector<Stmt*> body;     // empty if expression-bodied or extern
@@ -182,6 +189,7 @@ struct FunctionDecl {
 struct ClassDecl {
   std::string_view name;
   Span name_span;
+  std::vector<GenericParam> type_params;
   std::vector<FieldSpec*> fields;
 };
 

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -72,13 +72,38 @@ private:
     }, decl.payload);
   }
 
+  void print_type_params(const std::vector<GenericParam>& type_params) {
+    if (type_params.empty()) {
+      return;
+    }
+    out_ << "<";
+    for (size_t i = 0; i < type_params.size(); ++i) {
+      if (i > 0) {
+        out_ << ", ";
+      }
+      out_ << type_params[i].name;
+      if (!type_params[i].constraints.empty()) {
+        out_ << ": ";
+        for (size_t j = 0; j < type_params[i].constraints.size(); ++j) {
+          if (j > 0) {
+            out_ << " + ";
+          }
+          print_type_inline(*type_params[i].constraints[j]);
+        }
+      }
+    }
+    out_ << ">";
+  }
+
   void print_function_decl(const FunctionDecl& fn) {
     indent();
     if (fn.is_extern) {
-      out_ << "ExternFunctionDecl " << fn.name << "\n";
+      out_ << "ExternFunctionDecl " << fn.name;
     } else {
-      out_ << "FunctionDecl " << fn.name << "\n";
+      out_ << "FunctionDecl " << fn.name;
     }
+    print_type_params(fn.type_params);
+    out_ << "\n";
     Scope scope(depth_);
 
     for (const auto& param : fn.params) {
@@ -111,7 +136,9 @@ private:
 
   void print_class_decl(const ClassDecl& node) {
     indent();
-    out_ << "ClassDecl " << node.name << "\n";
+    out_ << "ClassDecl " << node.name;
+    print_type_params(node.type_params);
+    out_ << "\n";
     Scope scope(depth_);
     for (const auto* field : node.fields) {
       indent();
@@ -428,14 +455,14 @@ private:
         [&](const NamedType& named) {
           print_qualified_path(named.name);
           if (!named.type_args.empty()) {
-            out_ << "[";
+            out_ << "<";
             for (size_t i = 0; i < named.type_args.size(); ++i) {
               if (i > 0) {
                 out_ << ", ";
               }
               print_type_inline(*named.type_args[i]);
             }
-            out_ << "]";
+            out_ << ">";
           }
         },
         [&](const PointerType& ptr) {

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -159,7 +159,7 @@ private:
         auto fields = parse_field_list();
         Span span = span_from(peek().span);
         return ctx_.alloc<Decl>(
-            span, ClassDecl{name_tok.text, name_tok.span, std::move(fields)});
+            span, ClassDecl{name_tok.text, name_tok.span, {}, std::move(fields)});
       }
       error("expected declaration (fn, extern, class, or type)");
       advance(); // skip problematic token
@@ -176,9 +176,41 @@ private:
     return parse_function_decl(/*is_extern=*/true);
   }
 
+  auto parse_type_params() -> std::vector<GenericParam> {
+    std::vector<GenericParam> params;
+    if (peek_kind() != TokenKind::Lt) {
+      return params;
+    }
+    advance(); // <
+
+    auto parse_one = [&]() -> GenericParam {
+      const auto& name_tok = consume(TokenKind::Identifier);
+      GenericParam param{.name = name_tok.text, .name_span = name_tok.span};
+      if (peek_kind() == TokenKind::Colon) {
+        advance(); // :
+        param.constraints.push_back(parse_type());
+        while (peek_kind() == TokenKind::Plus) {
+          advance(); // +
+          param.constraints.push_back(parse_type());
+        }
+      }
+      return param;
+    };
+
+    params.push_back(parse_one());
+    while (peek_kind() == TokenKind::Comma) {
+      advance(); // ,
+      params.push_back(parse_one());
+    }
+    consume(TokenKind::Gt);
+    return params;
+  }
+
   auto parse_function_decl(bool is_extern) -> Decl* {
     const auto& kw = consume(TokenKind::KwFn);
     const auto& name_tok = consume(TokenKind::Identifier);
+
+    auto type_params = parse_type_params();
 
     consume(TokenKind::LParen);
     auto params = parse_params();
@@ -223,8 +255,9 @@ private:
     Span span = span_from(kw.span);
     return ctx_.alloc<Decl>(
         span,
-        FunctionDecl{name_tok.text, name_tok.span, std::move(params),
-                     return_type, std::move(body), expr_body, is_extern});
+        FunctionDecl{name_tok.text, name_tok.span, std::move(type_params),
+                     std::move(params), return_type, std::move(body),
+                     expr_body, is_extern});
   }
 
   auto parse_params() -> std::vector<Param> {
@@ -250,11 +283,13 @@ private:
   auto parse_class_decl() -> Decl* {
     const auto& kw = consume(TokenKind::KwClass);
     const auto& name_tok = consume(TokenKind::Identifier);
+    auto type_params = parse_type_params();
     consume(TokenKind::Colon);
     auto fields = parse_field_list();
     Span span = span_from(kw.span);
     return ctx_.alloc<Decl>(
-        span, ClassDecl{name_tok.text, name_tok.span, std::move(fields)});
+        span, ClassDecl{name_tok.text, name_tok.span,
+                        std::move(type_params), std::move(fields)});
   }
 
   auto parse_field_list() -> std::vector<FieldSpec*> {
@@ -868,15 +903,15 @@ private:
     auto path = parse_type_path();
 
     std::vector<TypeNode*> type_args;
-    if (peek_kind() == TokenKind::LBracket) {
-      advance(); // [
+    if (peek_kind() == TokenKind::Lt) {
+      advance(); // <
       type_args.push_back(parse_type());
       while (peek_kind() == TokenKind::Comma) {
         advance();
         type_args.push_back(parse_type());
       }
-      const auto& rbracket = consume(TokenKind::RBracket);
-      path.span.length = (rbracket.span.offset + rbracket.span.length) - path.span.offset;
+      const auto& gt = consume(TokenKind::Gt);
+      path.span.length = (gt.span.offset + gt.span.length) - path.span.offset;
     }
 
     return ctx_.alloc<TypeNode>(path.span, NamedType{std::move(path), std::move(type_args)});

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -317,7 +317,7 @@ suite<"type_tests"> type_tests = [] {
   };
 
   "parameterized type"_test = [] {
-    auto output = parse_string("fn f(): List[i32] -> []\n");
+    auto output = parse_string("fn f(): List<i32> -> []\n");
     expect(output.parse_result.diagnostics.empty());
     const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
     const auto& ret = fn.return_type->as<NamedType>();
@@ -328,11 +328,66 @@ suite<"type_tests"> type_tests = [] {
   };
 
   "multi-param type"_test = [] {
-    auto output = parse_string("fn f(): Map[i32, string] -> []\n");
+    auto output = parse_string("fn f(): Map<i32, string> -> []\n");
     expect(output.parse_result.diagnostics.empty());
     const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
     const auto& ret = fn.return_type->as<NamedType>();
     expect(ret.type_args.size() == 2_u);
+  };
+};
+
+suite<"generic_tests"> generic_tests = [] {
+  "generic function with one type param"_test = [] {
+    auto output = parse_string("fn identity<T>(x: T): T -> x\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.name == "identity");
+    expect(fn.type_params.size() == 1_u);
+    expect(fn.type_params[0].name == "T");
+    expect(fn.type_params[0].constraints.empty());
+  };
+
+  "generic function with constrained type param"_test = [] {
+    auto output = parse_string("fn print<T: Printable>(value: T): void -> value\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.type_params.size() == 1_u);
+    expect(fn.type_params[0].name == "T");
+    expect(fn.type_params[0].constraints.size() == 1_u);
+  };
+
+  "generic function with multiple constraints"_test = [] {
+    auto output = parse_string("fn sort<T: Comparable + Printable>(x: T): T -> x\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.type_params.size() == 1_u);
+    expect(fn.type_params[0].constraints.size() == 2_u);
+  };
+
+  "generic function with multiple type params"_test = [] {
+    auto output = parse_string("fn pair<A, B>(a: A, b: B): i32 -> 0\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.type_params.size() == 2_u);
+    expect(fn.type_params[0].name == "A");
+    expect(fn.type_params[1].name == "B");
+  };
+
+  "generic class"_test = [] {
+    auto output = parse_string("class Box<T>:\n    value: T\n");
+    expect(output.parse_result.diagnostics.empty()) << "no parse errors";
+    const auto& cls = output.parse_result.file->declarations[0]->as<ClassDecl>();
+    expect(cls.name == "Box");
+    expect(cls.type_params.size() == 1_u);
+    expect(cls.type_params[0].name == "T");
+    expect(cls.fields.size() == 1_u);
+  };
+
+  "non-generic function has empty type params"_test = [] {
+    auto output = parse_string("fn add(a: i32, b: i32): i32 -> a + b\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    expect(fn.type_params.empty());
   };
 };
 

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -25,6 +25,8 @@ auto symbol_kind_name(SymbolKind kind) -> const char* {
     return "Predeclared";
   case SymbolKind::LambdaParam:
     return "LambdaParam";
+  case SymbolKind::GenericParam:
+    return "GenericParam";
   }
   return "Unknown";
 }
@@ -197,9 +199,31 @@ private:
     }
   }
 
+  void declare_type_params(const std::vector<GenericParam>& type_params,
+                           Scope* scope, const Decl& decl) {
+    for (const auto& tp : type_params) {
+      if (scope->lookup_local(tp.name) != nullptr) {
+        diagnostics_.push_back(Diagnostic::error(
+            tp.name_span,
+            "duplicate type parameter '" + std::string(tp.name) + "'"));
+      } else {
+        auto* sym = ctx_.make_symbol(
+            SymbolKind::GenericParam, tp.name, tp.name_span, &decl);
+        scope->declare(tp.name, sym);
+      }
+      // Resolve constraint types.
+      for (const auto* constraint : tp.constraints) {
+        resolve_type(*constraint, scope);
+      }
+    }
+  }
+
   void resolve_function(const Decl& decl, Scope* parent) {
     const auto& fn = decl.as<FunctionDecl>();
     auto* fn_scope = ctx_.make_scope(ScopeKind::Function, parent);
+
+    // Declare generic type parameters (visible to params, return type, body).
+    declare_type_params(fn.type_params, fn_scope, decl);
 
     // Declare parameters.
     for (const auto& param : fn.params) {
@@ -239,6 +263,9 @@ private:
   void resolve_class(const Decl& decl, Scope* parent) {
     const auto& st = decl.as<ClassDecl>();
     auto* struct_scope = ctx_.make_scope(ScopeKind::Struct, parent);
+
+    // Declare generic type parameters (visible to field types).
+    declare_type_params(st.type_params, struct_scope, decl);
 
     for (const auto* field : st.fields) {
       if (struct_scope->lookup_local(field->name) != nullptr) {

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -340,6 +340,52 @@ suite<"resolve_corpus"> resolve_corpus = [] {
   };
 };
 
+suite<"resolve_generics"> resolve_generics = [] {
+  "generic type param resolves in param type"_test = [] {
+    auto result = resolve_source("test",
+                                 "fn identity<T>(x: T): T -> x");
+    expect(result.resolve_result.diagnostics.empty())
+        << "no resolve errors for generic function";
+
+    // 'T' in the param type position should resolve to GenericParam.
+    // The first 'T' is the declaration; the second is in 'x: T'.
+    auto t_param_offset = find_offset(result, "T", 1);
+    expect(use_resolves_to(result, t_param_offset, SymbolKind::GenericParam))
+        << "T in param type resolves to GenericParam";
+  };
+
+  "generic type param resolves in return type"_test = [] {
+    auto result = resolve_source("test",
+                                 "fn identity<T>(x: T): T -> x");
+    expect(result.resolve_result.diagnostics.empty());
+
+    // 'T' in return type position (third occurrence).
+    auto t_ret_offset = find_offset(result, "T", 2);
+    expect(use_resolves_to(result, t_ret_offset, SymbolKind::GenericParam))
+        << "T in return type resolves to GenericParam";
+  };
+
+  "generic class type param resolves in field type"_test = [] {
+    auto result = resolve_source("test",
+                                 "class Box<T>:\n"
+                                 "    value: T\n");
+    expect(result.resolve_result.diagnostics.empty())
+        << "no resolve errors for generic class";
+
+    // 'T' in the field type should resolve to GenericParam.
+    auto t_field_offset = find_offset(result, "T", 1);
+    expect(use_resolves_to(result, t_field_offset, SymbolKind::GenericParam))
+        << "T in field type resolves to GenericParam";
+  };
+
+  "duplicate type param is an error"_test = [] {
+    auto result = resolve_source("test",
+                                 "fn bad<T, T>(x: T): T -> x");
+    expect(has_diagnostic_containing(result.resolve_result, "duplicate type parameter"))
+        << "duplicate type parameter should be an error";
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {

--- a/compiler/frontend/resolve/symbol.h
+++ b/compiler/frontend/resolve/symbol.h
@@ -25,7 +25,8 @@ enum class SymbolKind : std::uint8_t {
   Module,      // import binding
   Builtin,      // built-in scalar type (i32, f64, bool)
   Predeclared,  // compiler-known predeclared named type (string, void)
-  LambdaParam,  // lambda |x| parameter
+  LambdaParam,    // lambda |x| parameter
+  GenericParam,   // type parameter in generic function/class
 };
 
 auto symbol_kind_name(SymbolKind kind) -> const char*;

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -77,7 +77,7 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
       if (sym->kind == SymbolKind::GenericParam) {
         // Find the parameter index from the enclosing declaration.
         uint32_t index = find_generic_param_index(sym);
-        return types_.generic_param(sym->name, index);
+        return types_.generic_param(sym->decl, sym->name, index);
       }
       return resolve_symbol_type(sym);
     }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -72,7 +72,14 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
     // Look up user-defined types via resolver symbols.
     auto it = resolve_.uses.find(node->span.offset);
     if (it != resolve_.uses.end()) {
-      return resolve_symbol_type(it->second);
+      const auto* sym = it->second;
+      // Generic type parameters resolve to TypeGenericParam.
+      if (sym->kind == SymbolKind::GenericParam) {
+        // Find the parameter index from the enclosing declaration.
+        uint32_t index = find_generic_param_index(sym);
+        return types_.generic_param(sym->name, index);
+      }
+      return resolve_symbol_type(sym);
     }
 
     error(node->span, "unknown type '" + std::string(name) + "'");
@@ -188,6 +195,13 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
 
   case SymbolKind::LambdaParam:
     // Lambda params are typed contextually; handled in check_lambda.
+    break;
+
+  case SymbolKind::GenericParam:
+    // Generic type parameters resolve to TypeGenericParam. The index
+    // is derived from the parameter's position in the declaration.
+    // For now, return nullptr — generic params aren't yet type-checkable
+    // as values (they are types, not values).
     break;
 
   case SymbolKind::Field:
@@ -1078,6 +1092,30 @@ auto TypeChecker::is_lvalue(const Expr* expr) -> bool {
   default:
     return false;
   }
+}
+
+auto TypeChecker::find_generic_param_index(const Symbol* sym) -> uint32_t {
+  // The symbol's decl points to the enclosing Decl (FunctionDecl or ClassDecl).
+  if (sym->decl == nullptr) {
+    return 0;
+  }
+  const auto* decl = static_cast<const Decl*>(sym->decl);
+
+  const std::vector<GenericParam>* type_params = nullptr;
+  if (decl->is<FunctionDecl>()) {
+    type_params = &decl->as<FunctionDecl>().type_params;
+  } else if (decl->is<ClassDecl>()) {
+    type_params = &decl->as<ClassDecl>().type_params;
+  }
+
+  if (type_params != nullptr) {
+    for (uint32_t i = 0; i < type_params->size(); ++i) {
+      if ((*type_params)[i].name == sym->name) {
+        return i;
+      }
+    }
+  }
+  return 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -124,6 +124,7 @@ private:
   // --- Helpers ---
 
   auto is_lvalue(const Expr* expr) -> bool;
+  auto find_generic_param_index(const Symbol* sym) -> uint32_t;
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -80,6 +80,20 @@ struct TypecheckPipeline {
     }
     return nullptr;
   }
+
+  /// Collect typed function types for all FunctionDecls in order.
+  [[nodiscard]] auto fn_types() const -> std::vector<const Type*> {
+    std::vector<const Type*> result;
+    if (parse_result.file == nullptr) {
+      return result;
+    }
+    for (const auto* decl : parse_result.file->declarations) {
+      if (decl->kind() == NodeKind::FunctionDecl) {
+        result.push_back(check_result.typed.decl_type(decl));
+      }
+    }
+    return result;
+  }
 };
 
 } // namespace
@@ -475,6 +489,32 @@ suite<"typecheck_generics"> typecheck_generics = [] {
         "class Box<T>:\n"
         "    value: T\n");
     expect(result.diagnostics.empty()) << "generic class should typecheck";
+  };
+
+  "separate declarations with same T produce distinct types"_test = [] {
+    TypecheckPipeline pipe(
+        "fn identity<T>(x: T): T -> x\n"
+        "fn wrap<T>(x: T): T -> x\n");
+    expect(is_ok(pipe.check_result))
+        << "both generic functions should typecheck";
+
+    auto fns = pipe.fn_types();
+    expect(fns.size() == 2_ul) << "must find two function decls";
+
+    const auto* fn_identity = static_cast<const TypeFunction*>(fns[0]);
+    const auto* fn_wrap = static_cast<const TypeFunction*>(fns[1]);
+    expect(fn_identity != nullptr);
+    expect(fn_wrap != nullptr);
+
+    // Both have fn(T): T shape, but the T types must be distinct objects
+    // because they belong to different binder declarations.
+    expect(fn_identity->param_types().size() == 1_ul);
+    expect(fn_wrap->param_types().size() == 1_ul);
+
+    const auto* t_from_identity = fn_identity->param_types()[0];
+    const auto* t_from_wrap = fn_wrap->param_types()[0];
+    expect(t_from_identity != t_from_wrap)
+        << "T from identity and T from wrap must be distinct TypeGenericParam objects";
   };
 };
 

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -464,6 +464,20 @@ suite<"typecheck_construct"> typecheck_construct = [] {
   };
 };
 
+suite<"typecheck_generics"> typecheck_generics = [] {
+  "generic function type uses TypeGenericParam"_test = [] {
+    auto result = check_source("fn identity<T>(x: T): T -> x\n");
+    expect(result.diagnostics.empty()) << "generic function should typecheck";
+  };
+
+  "generic class with type param field"_test = [] {
+    auto result = check_source(
+        "class Box<T>:\n"
+        "    value: T\n");
+    expect(result.diagnostics.empty()) << "generic class should typecheck";
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/types/type.h
+++ b/compiler/frontend/types/type.h
@@ -120,9 +120,12 @@ private:
 
 class TypeGenericParam : public Type {
 public:
-  TypeGenericParam(std::string_view name, uint32_t index)
-      : Type(TypeKind::GenericParam), name_(name), index_(index) {}
+  TypeGenericParam(const void* binder, std::string_view name, uint32_t index)
+      : Type(TypeKind::GenericParam), binder_(binder), name_(name),
+        index_(index) {}
 
+  /// The declaration (Decl*) that introduces this type parameter.
+  [[nodiscard]] auto binder() const -> const void* { return binder_; }
   [[nodiscard]] auto name() const -> std::string_view { return name_; }
   [[nodiscard]] auto index() const -> uint32_t { return index_; }
 
@@ -131,6 +134,7 @@ public:
   }
 
 private:
+  const void* binder_;
   std::string_view name_;
   uint32_t index_;
 };

--- a/compiler/frontend/types/type_context.cpp
+++ b/compiler/frontend/types/type_context.cpp
@@ -40,7 +40,7 @@ auto TypeContext::NamedKeyHash::operator()(const NamedKey& key) const -> size_t 
 
 auto TypeContext::GenericParamKeyHash::operator()(const GenericParamKey& key) const
     -> size_t {
-  size_t h = std::hash<std::string_view>{}(key.name);
+  size_t h = std::hash<const void*>{}(key.binder);
   return hash_combine(h, std::hash<uint32_t>{}(key.index));
 }
 
@@ -108,12 +108,12 @@ auto TypeContext::named_type(const void* decl_id, std::string_view name,
   return it->second;
 }
 
-auto TypeContext::generic_param(std::string_view name, uint32_t index)
-    -> const TypeGenericParam* {
-  GenericParamKey key{name, index};
+auto TypeContext::generic_param(const void* binder, std::string_view name,
+                                uint32_t index) -> const TypeGenericParam* {
+  GenericParamKey key{binder, index};
   auto [it, inserted] = generic_param_map_.try_emplace(key, nullptr);
   if (inserted) {
-    it->second = arena_.alloc<TypeGenericParam>(name, index);
+    it->second = arena_.alloc<TypeGenericParam>(binder, name, index);
   }
   return it->second;
 }

--- a/compiler/frontend/types/type_context.h
+++ b/compiler/frontend/types/type_context.h
@@ -56,8 +56,8 @@ public:
   auto named_type(const void* decl_id, std::string_view name,
                   std::vector<const Type*> type_args) -> const TypeNamed*;
 
-  auto generic_param(std::string_view name, uint32_t index)
-      -> const TypeGenericParam*;
+  auto generic_param(const void* binder, std::string_view name,
+                     uint32_t index) -> const TypeGenericParam*;
 
   // --- Nominal constructors (not interned — each call allocates) ---
 
@@ -105,9 +105,10 @@ private:
 
   std::unordered_map<NamedKey, const TypeNamed*, NamedKeyHash> named_map_;
 
-  // Generic param key: (name, index).
+  // Generic param key: (binder, index). The binder pointer
+  // distinguishes T@0 from fn f<T> vs T@0 from fn g<T>.
   struct GenericParamKey {
-    std::string_view name;
+    const void* binder;
     uint32_t index;
 
     auto operator==(const GenericParamKey& other) const -> bool = default;

--- a/compiler/frontend/types/type_printer.cpp
+++ b/compiler/frontend/types/type_printer.cpp
@@ -44,14 +44,14 @@ void print_type(std::ostream& out, const Type* type) {
     const auto* n = static_cast<const TypeNamed*>(type);
     out << n->name();
     if (!n->type_args().empty()) {
-      out << '[';
+      out << '<';
       bool first = true;
       for (const auto* arg : n->type_args()) {
         if (!first) out << ", ";
         first = false;
         print_type(out, arg);
       }
-      out << ']';
+      out << '>';
     }
     break;
   }

--- a/compiler/frontend/types/type_test.cpp
+++ b/compiler/frontend/types/type_test.cpp
@@ -185,24 +185,33 @@ suite<"type_named"> type_named = [] {
 suite<"type_generic_param"> type_generic_param = [] {
   "generic param creation"_test = [] {
     TypeContext ctx;
-    auto* t = ctx.generic_param("T", 0);
+    auto* t = ctx.generic_param(&kDeclA, "T", 0);
     expect(t != nullptr);
     expect(t->name() == "T");
     expect(t->index() == 0u);
+    expect(t->binder() == &kDeclA);
   };
 
-  "same generic param canonicalizes"_test = [] {
+  "same binder same index canonicalizes"_test = [] {
     TypeContext ctx;
-    auto* t1 = ctx.generic_param("T", 0);
-    auto* t2 = ctx.generic_param("T", 0);
+    auto* t1 = ctx.generic_param(&kDeclA, "T", 0);
+    auto* t2 = ctx.generic_param(&kDeclA, "T", 0);
     expect(t1 == t2);
   };
 
-  "different generic params are distinct"_test = [] {
+  "different index at same binder is distinct"_test = [] {
     TypeContext ctx;
-    auto* t1 = ctx.generic_param("T", 0);
-    auto* t2 = ctx.generic_param("U", 1);
+    auto* t1 = ctx.generic_param(&kDeclA, "T", 0);
+    auto* t2 = ctx.generic_param(&kDeclA, "U", 1);
     expect(t1 != t2);
+  };
+
+  "same name and index at different binders are distinct"_test = [] {
+    TypeContext ctx;
+    auto* t1 = ctx.generic_param(&kDeclA, "T", 0);
+    auto* t2 = ctx.generic_param(&kDeclB, "T", 0);
+    expect(t1 != t2)
+        << "T@0 from different declarations must not collapse";
   };
 };
 
@@ -289,7 +298,7 @@ suite<"type_printer"> type_printer = [] {
 
   "print generic param"_test = [] {
     TypeContext ctx;
-    auto* t = ctx.generic_param("T", 0);
+    auto* t = ctx.generic_param(&kDeclA, "T", 0);
     expect(print_type(t) == "T");
   };
 

--- a/compiler/frontend/types/type_test.cpp
+++ b/compiler/frontend/types/type_test.cpp
@@ -284,7 +284,7 @@ suite<"type_printer"> type_printer = [] {
   "print named type with args"_test = [] {
     TypeContext ctx;
     auto* t = ctx.named_type(&kDeclA, "List", {ctx.i32()});
-    expect(print_type(t) == "List[i32]");
+    expect(print_type(t) == "List<i32>");
   };
 
   "print generic param"_test = [] {

--- a/docs/task_specs/TASK_12_TRAITS_AND_GENERICS.md
+++ b/docs/task_specs/TASK_12_TRAITS_AND_GENERICS.md
@@ -8,8 +8,8 @@ Every significant Phase 5 deliverable depends on a concept and
 generics system:
 
 - `print` that works on any type without compiler builtins
-- `Iterator[T]` protocol for for-loops
-- `List[T]`, `Map[K,V]` for stdlib collections
+- `Iterator<T>` protocol for for-loops
+- `List<T>`, `Map<K, V>` for stdlib collections
 - `Printable`, `Equatable`, `Hashable` for value-type behavior
 
 Without this, the language cannot express its own primitives. The

--- a/spec/syntax_probes/astar.dao
+++ b/spec/syntax_probes/astar.dao
@@ -8,7 +8,7 @@ fn reconstruct_path(came_from: i32, start: i32, goal: i32): i32 -> 0
 
 fn heuristic(a: NodeId, b: NodeId): f64 -> 0.0
 
-fn a_star(g: Graph, start: NodeId, goal: NodeId): List[NodeId]
+fn a_star(g: Graph, start: NodeId, goal: NodeId): List<NodeId>
     resource memory Search =>
         let open = PriorityQueue[NodeId, f64]()
         let came_from = Map[NodeId, NodeId]()

--- a/spec/syntax_probes/modes_and_resources.dao
+++ b/spec/syntax_probes/modes_and_resources.dao
@@ -2,7 +2,7 @@ type NodeId = i32
 type List = i32
 type PriorityQueue = i32
 
-fn search(start: NodeId, goal: NodeId): List[NodeId]
+fn search(start: NodeId, goal: NodeId): List<NodeId>
     resource memory Search =>
         mode parallel =>
             let frontier = PriorityQueue[NodeId]()

--- a/spec/syntax_probes/pipelines.dao
+++ b/spec/syntax_probes/pipelines.dao
@@ -3,7 +3,7 @@ type List = i32
 fn filter(pred: i32): i32 -> 0
 fn map(f: i32): i32 -> 0
 
-fn positive_squares(xs: List[i32]): List[i32]
+fn positive_squares(xs: List<i32>): List<i32>
     return xs
     |> filter |x| -> x > 0
     |> map |x| -> x * x

--- a/testdata/ast/probes_astar.ast
+++ b/testdata/ast/probes_astar.ast
@@ -21,7 +21,7 @@ File
     Param g: Graph
     Param start: NodeId
     Param goal: NodeId
-    ReturnType: List[NodeId]
+    ReturnType: List<NodeId>
     ResourceBlock memory Search
       LetStatement open
         CallExpr

--- a/testdata/ast/probes_modes_and_resources.ast
+++ b/testdata/ast/probes_modes_and_resources.ast
@@ -5,7 +5,7 @@ File
   FunctionDecl search
     Param start: NodeId
     Param goal: NodeId
-    ReturnType: List[NodeId]
+    ReturnType: List<NodeId>
     ResourceBlock memory Search
       ModeBlock parallel
         LetStatement frontier

--- a/testdata/ast/probes_pipelines.ast
+++ b/testdata/ast/probes_pipelines.ast
@@ -11,8 +11,8 @@ File
     ExprBody
       IntLiteral 0
   FunctionDecl positive_squares
-    Param xs: List[i32]
-    ReturnType: List[i32]
+    Param xs: List<i32>
+    ReturnType: List<i32>
     ReturnStatement
       PipeExpr
         Identifier xs


### PR DESCRIPTION
## Summary

Implements TASK_12 §11.1 steps 1–2: parsing and resolving generic type parameters on functions and classes. Also switches type argument syntax from `[]` to `<>` to align with the frozen contract surface.

## Highlights

- **AST**: New `GenericParam` struct with name, span, and concept constraint list; `FunctionDecl` and `ClassDecl` gain `type_params` field
- **Parser**: New `parse_type_params()` method parses `<T>`, `<T: Concept>`, `<T: A + B>`, and `<A, B>` after function/class names
- **Type args `[]` → `<>`**: Type argument parsing in type position switches from square brackets to angle brackets per CONTRACT_SYNTAX_SURFACE
- **Resolver**: New `SymbolKind::GenericParam`; generic type params are declared in function/class scope and resolve in param types, return types, and field types
- **Type checker**: `resolve_type_node` produces `TypeGenericParam` for generic param symbols; `find_generic_param_index` derives parameter position from enclosing declaration
- **Tests**: 6 new parser tests, 4 new resolver tests, 2 new typecheck tests; updated existing tests and golden files for `<>` syntax

## Test plan

- [x] All 10 existing test suites pass (100%)
- [x] New parser tests: single/multi/constrained type params, generic classes
- [x] New resolver tests: type param resolution in param/return/field positions, duplicate detection
- [x] New typecheck tests: generic function and generic class type-check without errors
- [x] Syntax probes and AST golden files updated for `<>` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)