### PR TITLE
feat(ir): ✨ implement yield and for-in generator desugaring in HIR/MIR

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -341,6 +341,10 @@ auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
         emit_diagnostic(inst.span, "iteration lowering not yet implemented");
         return false;
       },
+      [&](const MirYieldInst&) -> bool {
+        emit_diagnostic(inst.span, "yield/coroutine lowering not yet implemented");
+        return false;
+      },
       [&](const MirLambdaInst&) -> bool {
         emit_diagnostic(inst.span, "lambda lowering not yet implemented");
         return false;

--- a/compiler/ir/hir/hir.cpp
+++ b/compiler/ir/hir/hir.cpp
@@ -22,6 +22,7 @@ auto HirStmt::kind() const -> HirKind {
       [](const HirWhile&) { return HirKind::While; },
       [](const HirFor&) { return HirKind::For; },
       [](const HirReturn&) { return HirKind::Return; },
+      [](const HirYield&) { return HirKind::Yield; },
       [](const HirExprStmt&) { return HirKind::ExprStmt; },
       [](const HirMode&) { return HirKind::Mode; },
       [](const HirResource&) { return HirKind::Resource; },
@@ -61,6 +62,7 @@ auto hir_kind_name(HirKind kind) -> const char* {
   case HirKind::While:         return "While";
   case HirKind::For:           return "For";
   case HirKind::Return:        return "Return";
+  case HirKind::Yield:         return "Yield";
   case HirKind::ExprStmt:      return "ExprStmt";
   case HirKind::Mode:          return "Mode";
   case HirKind::Resource:      return "Resource";

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -95,6 +95,10 @@ struct HirReturn {
   HirExpr* value; // nullable for bare return
 };
 
+struct HirYield {
+  HirExpr* value;
+};
+
 struct HirExprStmt {
   HirExpr* expr;
 };
@@ -113,7 +117,7 @@ struct HirResource {
 
 using HirStmtPayload = std::variant<
     HirLet, HirAssign, HirIf, HirWhile, HirFor,
-    HirReturn, HirExprStmt, HirMode, HirResource>;
+    HirReturn, HirYield, HirExprStmt, HirMode, HirResource>;
 
 // ---------------------------------------------------------------------------
 // Expression payloads

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -202,6 +202,12 @@ auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
                     std::move(body)});
   }
 
+  case NodeKind::YieldStatement: {
+    const auto& yield = stmt->as<YieldStatement>();
+    auto* value = lower_expr(yield.value);
+    return ctx_.alloc<HirStmt>(stmt->span, HirYield{value});
+  }
+
   case NodeKind::ReturnStatement: {
     const auto& ret = stmt->as<ReturnStatement>();
     HirExpr* value = nullptr;

--- a/compiler/ir/hir/hir_kind.h
+++ b/compiler/ir/hir/hir_kind.h
@@ -24,6 +24,7 @@ enum class HirKind : std::uint8_t {
   While,
   For,
   Return,
+  Yield,
   ExprStmt,
   Mode,
   Resource,

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -198,6 +198,12 @@ private:
             print_expr(*node.value);
           }
         },
+        [&](const HirYield& node) {
+          indent();
+          out_ << "Yield\n";
+          Scope scope(depth_);
+          print_expr(*node.value);
+        },
         [&](const HirExprStmt& node) {
           indent();
           out_ << "ExprStmt\n";

--- a/compiler/ir/hir/hir_test.cpp
+++ b/compiler/ir/hir/hir_test.cpp
@@ -357,6 +357,40 @@ suite<"hir_edge"> hir_edge = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Generator / yield
+// ---------------------------------------------------------------------------
+
+suite<"hir_generator"> hir_generator = [] {
+  "yield lowers to HirYield"_test = [] {
+    HirTestPipeline p(
+        "fn range(n: i32): Generator<i32>\n"
+        "    let i = 0\n"
+        "    while i < n:\n"
+        "        yield i\n"
+        "        i = i + 1\n");
+    auto dump = p.dump();
+    expect(contains(dump, "Function range : Generator<i32>")) << dump;
+    expect(contains(dump, "Yield")) << dump;
+    expect(contains(dump, "SymbolRef i : i32")) << dump;
+  };
+
+  "for-in over generator lowers to HirFor"_test = [] {
+    HirTestPipeline p(
+        "fn range(n: i32): Generator<i32>\n"
+        "    yield n\n"
+        "fn main(): i32\n"
+        "    let total = 0\n"
+        "    for x in range(10):\n"
+        "        total = total + x\n"
+        "    return total\n");
+    auto dump = p.dump();
+    expect(contains(dump, "For x")) << dump;
+    expect(contains(dump, "Iterable")) << dump;
+    expect(contains(dump, "Call : Generator<i32>")) << dump;
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/ir/hir/hir_test.cpp
+++ b/compiler/ir/hir/hir_test.cpp
@@ -160,8 +160,10 @@ suite<"hir_control_flow"> hir_control_flow = [] {
 
   "for statement"_test = [] {
     HirTestPipeline p(
-        "fn test(xs: i32): i32\n"
-        "    for item in xs:\n"
+        "fn gen(n: i32): Generator<i32>\n"
+        "    yield n\n"
+        "fn test(): i32\n"
+        "    for item in gen(10):\n"
         "        let y: i32 = item\n"
         "    return 0\n");
     auto dump = p.dump();

--- a/compiler/ir/mir/mir.cpp
+++ b/compiler/ir/mir/mir.cpp
@@ -27,6 +27,7 @@ auto MirInst::kind() const -> MirInstKind {
       [](const MirIterInit&)      { return MirInstKind::IterInit; },
       [](const MirIterHasNext&)   { return MirInstKind::IterHasNext; },
       [](const MirIterNext&)      { return MirInstKind::IterNext; },
+      [](const MirYieldInst&)     { return MirInstKind::Yield; },
       [](const MirModeEnter&)     { return MirInstKind::ModeEnter; },
       [](const MirModeExit&)      { return MirInstKind::ModeExit; },
       [](const MirResourceEnter&) { return MirInstKind::ResourceEnter; },
@@ -61,6 +62,7 @@ auto mir_inst_kind_name(MirInstKind kind) -> const char* {
   case MirInstKind::IterInit:       return "iter_init";
   case MirInstKind::IterHasNext:    return "iter_has_next";
   case MirInstKind::IterNext:       return "iter_next";
+  case MirInstKind::Yield:          return "yield";
   case MirInstKind::ModeEnter:      return "mode_enter";
   case MirInstKind::ModeExit:       return "mode_exit";
   case MirInstKind::ResourceEnter:  return "resource_enter";

--- a/compiler/ir/mir/mir.h
+++ b/compiler/ir/mir/mir.h
@@ -98,6 +98,8 @@ struct MirIterInit    { MirValueId iter_operand; };
 struct MirIterHasNext { MirValueId iter_operand; };
 struct MirIterNext    { MirValueId iter_operand; };
 
+struct MirYieldInst   { MirValueId value; };
+
 struct MirModeEnter     { HirModeKind mode_kind; std::string_view region_name; };
 struct MirModeExit      { HirModeKind mode_kind; };
 struct MirResourceEnter { std::string_view region_kind; std::string_view region_name; };
@@ -121,6 +123,7 @@ using MirPayload = std::variant<
     MirFieldAccess, MirIndexAccess,
     MirFnRef, MirCall, MirConstruct,
     MirIterInit, MirIterHasNext, MirIterNext,
+    MirYieldInst,
     MirModeEnter, MirModeExit, MirResourceEnter, MirResourceExit,
     MirLambdaInst,
     MirBr, MirCondBr, MirReturn>;

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -238,7 +238,12 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         auto iter_val = emit_value(
             hir_for.iterable->type, stmt.span, MirIterInit{iter_src});
 
+        // Extract element type T from Generator<T>.
         const Type* var_type = hir_for.iterable->type;
+        if (var_type != nullptr && var_type->kind() == TypeKind::Generator) {
+          var_type =
+              static_cast<const TypeGenerator*>(var_type)->yield_type();
+        }
         auto var_local =
             declare_local(hir_for.var_symbol, var_type, stmt.span);
 
@@ -270,6 +275,10 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         }
 
         switch_to_block(exit_bb);
+      },
+      [&](const HirYield& yield) {
+        auto val = lower_expr_value(*yield.value);
+        emit_effect(stmt.span, MirYieldInst{val});
       },
       [&](const HirReturn& ret) {
         MirValueId ret_val;

--- a/compiler/ir/mir/mir_kind.h
+++ b/compiler/ir/mir/mir_kind.h
@@ -39,6 +39,9 @@ enum class MirInstKind : std::uint8_t {
   IterHasNext,
   IterNext,
 
+  // Coroutine
+  Yield,
+
   // Mode/resource regions
   ModeEnter,
   ModeExit,

--- a/compiler/ir/mir/mir_printer.cpp
+++ b/compiler/ir/mir/mir_printer.cpp
@@ -163,6 +163,9 @@ private:
         [&](const MirIterNext& p) {
           out_ << "iter_next %" << p.iter_operand.id;
         },
+        [&](const MirYieldInst& p) {
+          out_ << "yield %" << p.value.id;
+        },
         [&](const MirModeEnter& p) {
           out_ << "mode_enter " << p.region_name;
         },

--- a/compiler/ir/mir/mir_test.cpp
+++ b/compiler/ir/mir/mir_test.cpp
@@ -373,6 +373,40 @@ suite<"mir_edge"> mir_edge = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Generator / yield
+// ---------------------------------------------------------------------------
+
+suite<"mir_generator"> mir_generator = [] {
+  "yield lowers to MirYield"_test = [] {
+    MirTestPipeline pipe(
+        "fn range(n: i32): Generator<i32>\n"
+        "    let i = 0\n"
+        "    while i < n:\n"
+        "        yield i\n"
+        "        i = i + 1\n");
+    auto dump = pipe.dump();
+    expect(contains(dump, "yield %")) << dump;
+  };
+
+  "for-in over generator extracts element type"_test = [] {
+    MirTestPipeline pipe(
+        "fn range(n: i32): Generator<i32>\n"
+        "    yield n\n"
+        "fn main(): i32\n"
+        "    let total = 0\n"
+        "    for x in range(10):\n"
+        "        total = total + x\n"
+        "    return total\n");
+    auto dump = pipe.dump();
+    expect(contains(dump, "iter_init")) << dump;
+    expect(contains(dump, "iter_has_next")) << dump;
+    // iter_next should produce i32, not Generator<i32>
+    expect(contains(dump, "iter_next")) << dump;
+    expect(contains(dump, ": i32")) << dump;
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/ir/mir/mir_test.cpp
+++ b/compiler/ir/mir/mir_test.cpp
@@ -361,8 +361,10 @@ suite<"mir_edge"> mir_edge = [] {
 
   "for loop lowers to iter instructions"_test = [] {
     MirTestPipeline pipe(
-        "fn test(xs: i32): i32\n"
-        "    for item in xs:\n"
+        "fn gen(n: i32): Generator<i32>\n"
+        "    yield n\n"
+        "fn test(): i32\n"
+        "    for item in gen(10):\n"
         "        let y: i32 = item\n"
         "    return 0\n");
     auto dump = pipe.dump();

--- a/examples/iteration.dao
+++ b/examples/iteration.dao
@@ -1,26 +1,31 @@
-concept Iterator:
-    fn has_next(self): bool
-    fn next(self): i32
+fn range(n: i32): Generator<i32>
+    let i = 0
+    while i < n:
+        yield i
+        i = i + 1
 
-concept Iterable:
-    fn iter(self): RangeIter
+fn squares(n: i32): Generator<i32>
+    let i = 0
+    while i < n:
+        yield i * i
+        i = i + 1
 
-class RangeIter:
-    pos: i32
-    end: i32
-
-    as Iterator:
-        fn has_next(self): bool -> self.pos < self.end
-        fn next(self): i32 -> self.pos
-
-class Range:
-    n: i32
-
-    as Iterable:
-        fn iter(self): RangeIter -> RangeIter(0, self.n)
-
-fn sum(r: Range): i32
+fn sum_squares(n: i32): i32
     let total = 0
-    for x in r:
+    for x in squares(n):
         total = total + x
+    return total
+
+fn count_positive(gen: Generator<i32>): i32
+    let count = 0
+    for x in gen:
+        if x > 0:
+            count = count + 1
+    return count
+
+fn nested_iteration(): i32
+    let total = 0
+    for i in range(3):
+        for j in range(3):
+            total = total + i + j
     return total

--- a/examples/iteration.dao
+++ b/examples/iteration.dao
@@ -1,0 +1,26 @@
+concept Iterator:
+    fn has_next(self): bool
+    fn next(self): i32
+
+concept Iterable:
+    fn iter(self): RangeIter
+
+class RangeIter:
+    pos: i32
+    end: i32
+
+    as Iterator:
+        fn has_next(self): bool -> self.pos < self.end
+        fn next(self): i32 -> self.pos
+
+class Range:
+    n: i32
+
+    as Iterable:
+        fn iter(self): RangeIter -> RangeIter(0, self.n)
+
+fn sum(r: Range): i32
+    let total = 0
+    for x in r:
+        total = total + x
+    return total

--- a/testdata/ast/examples_iteration.ast
+++ b/testdata/ast/examples_iteration.ast
@@ -1,0 +1,62 @@
+File
+  ConceptDecl Iterator
+    FunctionDecl has_next
+      Param self
+      ReturnType: bool
+    FunctionDecl next
+      Param self
+      ReturnType: i32
+  ConceptDecl Iterable
+    FunctionDecl iter
+      Param self
+      ReturnType: RangeIter
+  ClassDecl RangeIter
+    Field pos: i32
+    Field end: i32
+    Conformance Iterator
+      FunctionDecl has_next
+        Param self
+        ReturnType: bool
+        ExprBody
+          BinaryExpr <
+            FieldExpr .pos
+              Identifier self
+            FieldExpr .end
+              Identifier self
+      FunctionDecl next
+        Param self
+        ReturnType: i32
+        ExprBody
+          FieldExpr .pos
+            Identifier self
+  ClassDecl Range
+    Field n: i32
+    Conformance Iterable
+      FunctionDecl iter
+        Param self
+        ReturnType: RangeIter
+        ExprBody
+          CallExpr
+            Callee
+              Identifier RangeIter
+            Args
+              IntLiteral 0
+              FieldExpr .n
+                Identifier self
+  FunctionDecl sum
+    Param r: Range
+    ReturnType: i32
+    LetStatement total
+      IntLiteral 0
+    ForStatement x
+      Iterable
+        Identifier r
+      Assignment
+        Target
+          Identifier total
+        Value
+          BinaryExpr +
+            Identifier total
+            Identifier x
+    ReturnStatement
+      Identifier total

--- a/testdata/ast/examples_iteration.ast
+++ b/testdata/ast/examples_iteration.ast
@@ -1,56 +1,56 @@
 File
-  ConceptDecl Iterator
-    FunctionDecl has_next
-      Param self
-      ReturnType: bool
-    FunctionDecl next
-      Param self
-      ReturnType: i32
-  ConceptDecl Iterable
-    FunctionDecl iter
-      Param self
-      ReturnType: RangeIter
-  ClassDecl RangeIter
-    Field pos: i32
-    Field end: i32
-    Conformance Iterator
-      FunctionDecl has_next
-        Param self
-        ReturnType: bool
-        ExprBody
-          BinaryExpr <
-            FieldExpr .pos
-              Identifier self
-            FieldExpr .end
-              Identifier self
-      FunctionDecl next
-        Param self
-        ReturnType: i32
-        ExprBody
-          FieldExpr .pos
-            Identifier self
-  ClassDecl Range
-    Field n: i32
-    Conformance Iterable
-      FunctionDecl iter
-        Param self
-        ReturnType: RangeIter
-        ExprBody
-          CallExpr
-            Callee
-              Identifier RangeIter
-            Args
-              IntLiteral 0
-              FieldExpr .n
-                Identifier self
-  FunctionDecl sum
-    Param r: Range
+  FunctionDecl range
+    Param n: i32
+    ReturnType: Generator<i32>
+    LetStatement i
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier n
+      YieldStatement
+        Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+  FunctionDecl squares
+    Param n: i32
+    ReturnType: Generator<i32>
+    LetStatement i
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier n
+      YieldStatement
+        BinaryExpr *
+          Identifier i
+          Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+  FunctionDecl sum_squares
+    Param n: i32
     ReturnType: i32
     LetStatement total
       IntLiteral 0
     ForStatement x
       Iterable
-        Identifier r
+        CallExpr
+          Callee
+            Identifier squares
+          Args
+            Identifier n
       Assignment
         Target
           Identifier total
@@ -58,5 +58,57 @@ File
           BinaryExpr +
             Identifier total
             Identifier x
+    ReturnStatement
+      Identifier total
+  FunctionDecl count_positive
+    Param gen: Generator<i32>
+    ReturnType: i32
+    LetStatement count
+      IntLiteral 0
+    ForStatement x
+      Iterable
+        Identifier gen
+      IfStatement
+        Condition
+          BinaryExpr >
+            Identifier x
+            IntLiteral 0
+        Then
+          Assignment
+            Target
+              Identifier count
+            Value
+              BinaryExpr +
+                Identifier count
+                IntLiteral 1
+    ReturnStatement
+      Identifier count
+  FunctionDecl nested_iteration
+    ReturnType: i32
+    LetStatement total
+      IntLiteral 0
+    ForStatement i
+      Iterable
+        CallExpr
+          Callee
+            Identifier range
+          Args
+            IntLiteral 3
+      ForStatement j
+        Iterable
+          CallExpr
+            Callee
+              Identifier range
+            Args
+              IntLiteral 3
+        Assignment
+          Target
+            Identifier total
+          Value
+            BinaryExpr +
+              BinaryExpr +
+                Identifier total
+                Identifier i
+              Identifier j
     ReturnStatement
       Identifier total


### PR DESCRIPTION
## Summary

Implements TASK_13 §11.2 step 7: yield and for-in generator desugaring at the HIR and MIR layers. The old concept-based `.iter()/.next()` protocol from the original PR is replaced by Generator<T>-based iteration, consistent with the generator primitive merged in PR #108.

## Highlights

- **HirYield**: new HIR statement node; AST `YieldStatement` lowers to typed `HirYield` with value expression
- **MirYieldInst**: new MIR instruction representing a coroutine suspension point
- **For-loop element type fix**: MIR builder now extracts `T` from `Generator<T>` for the loop variable (was incorrectly using `Generator<T>` as the variable type)
- **LLVM backend stub**: `MirYieldInst` handled with "not yet implemented" diagnostic
- **Examples**: `iteration.dao` rewritten to use generator-based patterns (nested loops, generator parameter passing)
- **Tests**: HIR and MIR test suites for yield lowering and for-in over generators

## Test plan

- [x] `ctest --test-dir build --output-on-failure` — 10/10 tests pass
- [x] `daoc check examples/generators.dao` — ok
- [x] `daoc check examples/iteration.dao` — ok
- [x] `daoc hir examples/generators.dao` — Yield nodes present
- [x] `daoc mir examples/generators.dao` — yield and iter_next with correct element types

🤖 Generated with [Claude Code](https://claude.com/claude-code)