### PR TITLE
feat(typecheck): ✨ resolve concept name as conforming type in method signatures

### DIFF
--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -84,6 +84,14 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
         uint32_t index = find_generic_param_index(sym);
         return types_.generic_param(sym->decl, sym->name, index);
       }
+      // Concept name in type position: substitute the conforming type
+      // when inside a context that has set concept_self_map_ (§3.2).
+      if (sym->kind == SymbolKind::Concept) {
+        auto csm = concept_self_map_.find(sym->name);
+        if (csm != concept_self_map_.end()) {
+          return csm->second;
+        }
+      }
       return resolve_symbol_type(sym);
     }
 
@@ -1313,17 +1321,24 @@ auto TypeChecker::lookup_method(const Type* obj_type,
   }
 
   // 3. Search derived conformances — concept method signatures.
+  //    Set concept_self_map_ so that the concept name in type position
+  //    resolves to the receiver type (§3.2).
   auto derived_it = derived_conformances_.find(obj_type);
   if (derived_it != derived_conformances_.end()) {
+    auto saved_csm = concept_self_map_;
     for (const auto* concept_decl : derived_it->second) {
       const auto& cpt = concept_decl->as<ConceptDecl>();
+      concept_self_map_[cpt.name] = obj_type;
       for (const auto* method_decl : cpt.methods) {
         const auto& method = method_decl->as<FunctionDecl>();
         if (method.name == name) {
-          return method_fn_type(method);
+          auto result = method_fn_type(method);
+          concept_self_map_ = saved_csm;
+          return result;
         }
       }
     }
+    concept_self_map_ = saved_csm;
   }
 
   return nullptr;

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -73,6 +73,12 @@ private:
   // Derived conformances: type -> list of derived concept Decls it auto-conforms to.
   std::unordered_map<const Type*, std::vector<const Decl*>> derived_conformances_;
 
+  // Concept self-type substitution: concept name -> conforming type.
+  // When set, resolve_type_node substitutes the concept name with the
+  // conforming type (§3.2: concept name in type position means the
+  // conforming type).
+  std::unordered_map<std::string_view, const Type*> concept_self_map_;
+
   // --- TypeNode -> Type* bridge ---
 
   auto resolve_type_node(const TypeNode* node) -> const Type*;

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -970,6 +970,76 @@ suite<"typecheck_scalar_conformance"> typecheck_scalar_conformance = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Concept self-type resolution (§3.2 / §11.5 item 19)
+// ---------------------------------------------------------------------------
+
+suite<"typecheck_concept_self_type"> concept_self_type_tests = [] {
+  "concept name resolves to conforming type in derived method dispatch"_test =
+      [] {
+        auto result = check_source(
+            "derived concept Equatable:\n"
+            "    fn eq(self, other: Equatable): bool\n"
+            "extend i32 as Equatable:\n"
+            "    fn eq(self, other: i32): bool -> true\n"
+            "class Point:\n"
+            "    x: i32\n"
+            "    y: i32\n"
+            "fn same(a: Point, b: Point): bool -> a.eq(b)\n");
+        expect(is_ok(result))
+            << "concept name should resolve to conforming type (Point) "
+               "in derived method signature";
+      };
+
+  "concept name in return position resolves to conforming type"_test = [] {
+    auto result = check_source(
+        "derived concept Copyable:\n"
+        "    fn copy(self): Copyable\n"
+        "extend i32 as Copyable:\n"
+        "    fn copy(self): i32 -> self\n"
+        "class Pair:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "fn dup(p: Pair): Pair -> p.copy()\n");
+    expect(is_ok(result))
+        << "concept name in return type should resolve to conforming type";
+  };
+
+  "concept self-type does not leak across concepts"_test = [] {
+    auto result = check_source(
+        "derived concept Equatable:\n"
+        "    fn eq(self, other: Equatable): bool\n"
+        "derived concept Printable:\n"
+        "    fn to_string(self): string\n"
+        "extend i32 as Equatable:\n"
+        "    fn eq(self, other: i32): bool -> true\n"
+        "extend i32 as Printable:\n"
+        "    fn to_string(self): string -> \"num\"\n"
+        "class Val:\n"
+        "    n: i32\n"
+        "fn same(a: Val, b: Val): bool -> a.eq(b)\n"
+        "fn show(v: Val): string -> v.to_string()\n");
+    expect(is_ok(result))
+        << "concept self-type should be scoped per concept";
+  };
+
+  "wrong argument type errors with concept self-type"_test = [] {
+    auto result = check_source(
+        "derived concept Equatable:\n"
+        "    fn eq(self, other: Equatable): bool\n"
+        "extend i32 as Equatable:\n"
+        "    fn eq(self, other: i32): bool -> true\n"
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "class Other:\n"
+        "    z: i32\n"
+        "fn bad(a: Point, b: Other): bool -> a.eq(b)\n");
+    expect(!is_ok(result))
+        << "passing wrong type to concept method should error";
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)


### PR DESCRIPTION
## Summary

Implement TASK_12 §11.5 item 19: when a concept method signature uses the concept name in type position (e.g., `fn eq(self, other: Equatable): bool`), resolve it to the actual conforming type at dispatch sites. This completes §11.5 (receivers and methods).

## Highlights

- Add `concept_self_map_` to `TypeChecker` for concept-name → conforming-type substitution during type resolution
- Wire substitution into `resolve_type_node` when encountering `SymbolKind::Concept` — if the concept name is in the map, return the conforming type
- Set `concept_self_map_` in `lookup_method` step 3 (derived conformance dispatch) so `method_fn_type` correctly resolves concept-named parameters and return types
- Save/restore `concept_self_map_` around the lookup to avoid leaking substitutions across concepts

## Test plan

- [x] `concept name resolves to conforming type in derived method dispatch` — `a.eq(b)` works where `eq` takes `other: Equatable` and both args are `Point`
- [x] `concept name in return position resolves to conforming type` — `p.copy()` returns `Pair` where concept declares `fn copy(self): Copyable`
- [x] `concept self-type does not leak across concepts` — `Equatable` and `Printable` substitutions are scoped correctly
- [x] `wrong argument type errors with concept self-type` — passing `Other` where `Point` is expected produces a type error
- [x] All 10/10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)