### PR TITLE
feat(frontend): ✨ implement prelude auto-import for stdlib core concepts

### DIFF
--- a/compiler/driver/CMakeLists.txt
+++ b/compiler/driver/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable(daoc main.cpp)
 target_link_libraries(daoc PRIVATE dao_analysis dao_backend_llvm dao_ir dao_frontend)
 
 # Bake the path to the runtime static library so `daoc build` can link it.
+# Bake the source root so the driver can find stdlib prelude files.
 target_compile_definitions(daoc PRIVATE
   DAO_RUNTIME_LIB="$<TARGET_FILE:dao_runtime>"
+  DAO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -49,10 +49,12 @@ auto read_file(const std::filesystem::path& path) -> std::string {
 // Print all diagnostics as errors. Returns true if any were printed.
 auto print_error_diagnostics(std::string_view filename,
                              const dao::SourceBuffer& source,
-                             std::span<const dao::Diagnostic> diags) -> bool {
+                             std::span<const dao::Diagnostic> diags,
+                             uint32_t line_offset = 0) -> bool {
   for (const auto& diag : diags) {
     auto loc = source.line_col(diag.span.offset);
-    std::cerr << filename << ":" << loc.line << ":" << loc.col
+    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
+    std::cerr << filename << ":" << line << ":" << loc.col
               << ": error: " << diag.message << "\n";
   }
   return !diags.empty();
@@ -61,12 +63,14 @@ auto print_error_diagnostics(std::string_view filename,
 // Print diagnostics with severity labels. Returns true if any errors.
 auto print_diagnostics(std::string_view filename,
                        const dao::SourceBuffer& source,
-                       std::span<const dao::Diagnostic> diags) -> bool {
+                       std::span<const dao::Diagnostic> diags,
+                       uint32_t line_offset = 0) -> bool {
   bool has_errors = false;
   for (const auto& diag : diags) {
     auto loc = source.line_col(diag.span.offset);
+    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
     const auto* severity = diag.severity == dao::Severity::Error ? "error" : "warning";
-    std::cerr << filename << ":" << loc.line << ":" << loc.col
+    std::cerr << filename << ":" << line << ":" << loc.col
               << ": " << severity << ": " << diag.message << "\n";
     if (diag.severity == dao::Severity::Error) {
       has_errors = true;
@@ -141,68 +145,87 @@ auto load_prelude_source() -> std::string {
   return prelude;
 }
 
-struct FrontendResult {
+struct PreludeParsedFile {
   ParsedFile parsed;
-  dao::ResolveResult resolve;
-  dao::TypeContext types;
-  dao::TypeCheckResult typecheck;
-  uint32_t prelude_lines = 0; // line offset for diagnostic adjustment
+  uint32_t prelude_lines = 0;
+  uint32_t prelude_bytes = 0;
 };
 
-// Run lex → parse → resolve → typecheck. Exits on error.
-auto run_frontend(const std::filesystem::path& path) -> FrontendResult {
-  // Load and prepend stdlib prelude source.
+auto lex_and_parse_with_prelude(const std::filesystem::path& path)
+    -> PreludeParsedFile {
   auto prelude_source = load_prelude_source();
   auto user_source = read_file(path);
 
-  // Count prelude lines for diagnostic offset adjustment.
   uint32_t prelude_lines = 0;
   for (char chr : prelude_source) {
     if (chr == '\n') {
       ++prelude_lines;
     }
   }
+  auto prelude_bytes = static_cast<uint32_t>(prelude_source.size());
 
-  auto combined_source = prelude_source + user_source;
-  dao::SourceBuffer source(path.filename().string(),
-                           std::move(combined_source));
+  auto combined = prelude_source + user_source;
+  dao::SourceBuffer source(path.filename().string(), std::move(combined));
   auto lex_result = dao::lex(source);
 
   if (print_error_diagnostics(path.filename().string(), source,
-                              lex_result.diagnostics)) {
+                              lex_result.diagnostics, prelude_lines)) {
     std::exit(EXIT_FAILURE);
   }
 
   auto parse_result = dao::parse(lex_result.tokens);
-  if (parse_result.file == nullptr ||
-      print_error_diagnostics(path.filename().string(), source,
-                              parse_result.diagnostics)) {
+  if (print_error_diagnostics(path.filename().string(), source,
+                              parse_result.diagnostics, prelude_lines)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.parsed = {.source = std::move(source),
+                     .lex_result = std::move(lex_result),
+                     .parse_result = std::move(parse_result)},
+          .prelude_lines = prelude_lines,
+          .prelude_bytes = prelude_bytes};
+}
+
+struct FrontendResult {
+  ParsedFile parsed;
+  dao::ResolveResult resolve;
+  dao::TypeContext types;
+  dao::TypeCheckResult typecheck;
+  uint32_t prelude_lines = 0;
+  uint32_t prelude_bytes = 0;
+};
+
+// Run lex → parse → resolve → typecheck. Exits on error.
+auto run_frontend(const std::filesystem::path& path) -> FrontendResult {
+  auto preparsed = lex_and_parse_with_prelude(path);
+
+  if (preparsed.parsed.parse_result.file == nullptr) {
     std::exit(EXIT_FAILURE);
   }
 
   auto filename = path.filename().string();
-  auto resolve_result = dao::resolve(*parse_result.file);
-  bool has_errors = print_error_diagnostics(filename, source,
-                                            resolve_result.diagnostics);
+  auto resolve_result = dao::resolve(*preparsed.parsed.parse_result.file);
+  bool has_errors = print_error_diagnostics(
+      filename, preparsed.parsed.source, resolve_result.diagnostics,
+      preparsed.prelude_lines);
 
   dao::TypeContext types;
-  auto check_result =
-      dao::typecheck(*parse_result.file, resolve_result, types);
-  has_errors |= print_diagnostics(filename, source, check_result.diagnostics);
+  auto check_result = dao::typecheck(*preparsed.parsed.parse_result.file,
+                                     resolve_result, types);
+  has_errors |= print_diagnostics(filename, preparsed.parsed.source,
+                                  check_result.diagnostics,
+                                  preparsed.prelude_lines);
 
   if (has_errors) {
     std::exit(EXIT_FAILURE);
   }
 
-  ParsedFile parsed_file{.source = std::move(source),
-                         .lex_result = std::move(lex_result),
-                         .parse_result = std::move(parse_result)};
-
-  return {.parsed = std::move(parsed_file),
+  return {.parsed = std::move(preparsed.parsed),
           .resolve = std::move(resolve_result),
           .types = std::move(types),
           .typecheck = std::move(check_result),
-          .prelude_lines = prelude_lines};
+          .prelude_lines = preparsed.prelude_lines,
+          .prelude_bytes = preparsed.prelude_bytes};
 }
 
 struct HirResult {
@@ -219,7 +242,8 @@ auto run_through_hir(const std::filesystem::path& path) -> HirResult {
 
   auto filename = path.filename().string();
   bool has_errors = print_error_diagnostics(filename, frontend.parsed.source,
-                                            hir.diagnostics);
+                                            hir.diagnostics,
+                                            frontend.prelude_lines);
 
   if (hir.module == nullptr || has_errors) {
     std::exit(EXIT_FAILURE);
@@ -244,7 +268,8 @@ auto run_through_mir(const std::filesystem::path& path) -> MirResult {
 
   auto filename = path.filename().string();
   bool has_errors = print_error_diagnostics(
-      filename, hir_result.frontend.parsed.source, mir.diagnostics);
+      filename, hir_result.frontend.parsed.source, mir.diagnostics,
+      hir_result.frontend.prelude_lines);
 
   if (mir.module == nullptr || has_errors) {
     std::exit(EXIT_FAILURE);
@@ -305,67 +330,92 @@ void cmd_ast(const std::filesystem::path& path) {
 
 // Emit semantic token classification. Output is deterministic.
 void cmd_tokens(const std::filesystem::path& path) {
-  auto result = lex_and_parse(path);
+  auto result = lex_and_parse_with_prelude(path);
 
   // Run name resolution for resolve-driven classifications.
   dao::ResolveResult resolve_result;
-  if (result.parse_result.file != nullptr) {
-    resolve_result = dao::resolve(*result.parse_result.file);
+  if (result.parsed.parse_result.file != nullptr) {
+    resolve_result = dao::resolve(*result.parsed.parse_result.file);
   }
 
-  auto sem_tokens =
-      dao::classify_tokens(result.lex_result.tokens, result.parse_result.file, &resolve_result);
+  auto sem_tokens = dao::classify_tokens(result.parsed.lex_result.tokens,
+                                         result.parsed.parse_result.file,
+                                         &resolve_result);
 
   for (const auto& tok : sem_tokens) {
-    auto loc = result.source.line_col(tok.span.offset);
-    auto text = result.source.text(tok.span);
-    std::cout << loc.line << ":" << loc.col << " " << tok.kind << " " << text << "\n";
+    if (tok.span.offset < result.prelude_bytes) {
+      continue;
+    }
+    auto loc = result.parsed.source.line_col(tok.span.offset);
+    auto line = loc.line > result.prelude_lines ? loc.line - result.prelude_lines : loc.line;
+    auto text = result.parsed.source.text(tok.span);
+    std::cout << line << ":" << loc.col << " " << tok.kind << " " << text << "\n";
   }
 }
 
 // Run name resolution and print results.
 void cmd_resolve(const std::filesystem::path& path) {
-  auto result = lex_and_parse(path);
-  if (result.parse_result.file == nullptr) {
+  auto result = lex_and_parse_with_prelude(path);
+  if (result.parsed.parse_result.file == nullptr) {
     return;
   }
 
-  auto resolve_result = dao::resolve(*result.parse_result.file);
+  auto resolve_result = dao::resolve(*result.parsed.parse_result.file);
 
-  // Print declared symbols.
+  // Print declared symbols (user region only).
   std::cout << "Symbols:\n";
   for (const auto& sym : resolve_result.context.symbols()) {
+    if (sym->decl_span.offset < result.prelude_bytes) {
+      continue;
+    }
     std::cout << "  " << dao::symbol_kind_name(sym->kind) << " " << sym->name;
     if (sym->decl_span.length > 0) {
-      auto decl_loc = result.source.line_col(sym->decl_span.offset);
-      std::cout << " [" << decl_loc.line << ":" << decl_loc.col << "]";
+      auto decl_loc = result.parsed.source.line_col(sym->decl_span.offset);
+      auto line = decl_loc.line > result.prelude_lines
+                      ? decl_loc.line - result.prelude_lines
+                      : decl_loc.line;
+      std::cout << " [" << line << ":" << decl_loc.col << "]";
     }
     std::cout << "\n";
   }
 
-  // Print uses (resolved references).
+  // Print uses in user region (resolved references).
   std::cout << "\nUses:\n";
   for (const auto& [offset, sym] : resolve_result.uses) {
-    auto loc = result.source.line_col(offset);
-    std::cout << "  " << loc.line << ":" << loc.col << " "
-              << result.source.text(dao::Span{.offset = offset,
-                                              .length = static_cast<uint32_t>(sym->name.size())})
+    if (offset < result.prelude_bytes) {
+      continue;
+    }
+    auto loc = result.parsed.source.line_col(offset);
+    auto line = loc.line > result.prelude_lines ? loc.line - result.prelude_lines : loc.line;
+    std::cout << "  " << line << ":" << loc.col << " "
+              << result.parsed.source.text(
+                     dao::Span{.offset = offset,
+                               .length = static_cast<uint32_t>(sym->name.size())})
               << " -> " << dao::symbol_kind_name(sym->kind) << " " << sym->name;
     if (sym->decl_span.length > 0) {
-      auto decl_loc = result.source.line_col(sym->decl_span.offset);
-      std::cout << " [" << decl_loc.line << ":" << decl_loc.col << "]";
+      auto decl_loc = result.parsed.source.line_col(sym->decl_span.offset);
+      auto decl_line = decl_loc.line > result.prelude_lines
+                           ? decl_loc.line - result.prelude_lines
+                           : decl_loc.line;
+      std::cout << " [" << decl_line << ":" << decl_loc.col << "]";
     }
     std::cout << "\n";
   }
 
-  // Print diagnostics (to stdout — this is a debug dump command).
-  if (!resolve_result.diagnostics.empty()) {
-    std::cout << "\nDiagnostics:\n";
-    for (const auto& diag : resolve_result.diagnostics) {
-      auto loc = result.source.line_col(diag.span.offset);
-      std::cout << "  " << path.filename().string() << ":" << loc.line << ":" << loc.col
-                << ": error: " << diag.message << "\n";
+  // Print diagnostics in user region (to stdout — this is a debug dump command).
+  bool has_user_diags = false;
+  for (const auto& diag : resolve_result.diagnostics) {
+    if (diag.span.offset < result.prelude_bytes) {
+      continue;
     }
+    if (!has_user_diags) {
+      std::cout << "\nDiagnostics:\n";
+      has_user_diags = true;
+    }
+    auto loc = result.parsed.source.line_col(diag.span.offset);
+    auto line = loc.line > result.prelude_lines ? loc.line - result.prelude_lines : loc.line;
+    std::cout << "  " << path.filename().string() << ":" << line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
   }
 }
 
@@ -401,7 +451,8 @@ void cmd_llvm_ir(const std::filesystem::path& path) {
 
   auto filename = path.filename().string();
   print_error_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                          llvm_result.diagnostics);
+                          llvm_result.diagnostics,
+                          mir.hir_result.frontend.prelude_lines);
 
   if (llvm_result.module == nullptr || !llvm_result.diagnostics.empty()) {
     std::exit(EXIT_FAILURE);
@@ -420,7 +471,8 @@ void cmd_build(const std::filesystem::path& path) {
 
   auto filename = path.filename().string();
   print_error_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                          llvm_result.diagnostics);
+                          llvm_result.diagnostics,
+                          mir.hir_result.frontend.prelude_lines);
 
   if (llvm_result.module == nullptr || !llvm_result.diagnostics.empty()) {
     std::exit(EXIT_FAILURE);

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -117,39 +117,92 @@ auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
           .parse_result = std::move(parse_result)};
 }
 
+// ---------------------------------------------------------------------------
+// Prelude loading — stdlib/core/*.dao source is prepended to user source
+// so prelude symbols are available without explicit import.
+// ---------------------------------------------------------------------------
+
+auto load_prelude_source() -> std::string {
+  std::filesystem::path root(DAO_SOURCE_DIR);
+  auto stdlib_core = root / "stdlib" / "core";
+  std::string prelude;
+
+  if (!std::filesystem::exists(stdlib_core)) {
+    return prelude;
+  }
+
+  for (const auto& entry : std::filesystem::directory_iterator(stdlib_core)) {
+    if (entry.path().extension() != ".dao") {
+      continue;
+    }
+    prelude += read_file(entry.path());
+    prelude += '\n';
+  }
+  return prelude;
+}
+
 struct FrontendResult {
   ParsedFile parsed;
   dao::ResolveResult resolve;
   dao::TypeContext types;
   dao::TypeCheckResult typecheck;
+  uint32_t prelude_lines = 0; // line offset for diagnostic adjustment
 };
 
 // Run lex → parse → resolve → typecheck. Exits on error.
 auto run_frontend(const std::filesystem::path& path) -> FrontendResult {
-  auto parsed = lex_and_parse(path);
-  if (parsed.parse_result.file == nullptr) {
+  // Load and prepend stdlib prelude source.
+  auto prelude_source = load_prelude_source();
+  auto user_source = read_file(path);
+
+  // Count prelude lines for diagnostic offset adjustment.
+  uint32_t prelude_lines = 0;
+  for (char chr : prelude_source) {
+    if (chr == '\n') {
+      ++prelude_lines;
+    }
+  }
+
+  auto combined_source = prelude_source + user_source;
+  dao::SourceBuffer source(path.filename().string(),
+                           std::move(combined_source));
+  auto lex_result = dao::lex(source);
+
+  if (print_error_diagnostics(path.filename().string(), source,
+                              lex_result.diagnostics)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  auto parse_result = dao::parse(lex_result.tokens);
+  if (parse_result.file == nullptr ||
+      print_error_diagnostics(path.filename().string(), source,
+                              parse_result.diagnostics)) {
     std::exit(EXIT_FAILURE);
   }
 
   auto filename = path.filename().string();
-  auto resolve_result = dao::resolve(*parsed.parse_result.file);
-  bool has_errors = print_error_diagnostics(filename, parsed.source,
+  auto resolve_result = dao::resolve(*parse_result.file);
+  bool has_errors = print_error_diagnostics(filename, source,
                                             resolve_result.diagnostics);
 
   dao::TypeContext types;
   auto check_result =
-      dao::typecheck(*parsed.parse_result.file, resolve_result, types);
-  has_errors |= print_diagnostics(filename, parsed.source,
-                                  check_result.diagnostics);
+      dao::typecheck(*parse_result.file, resolve_result, types);
+  has_errors |= print_diagnostics(filename, source, check_result.diagnostics);
 
   if (has_errors) {
     std::exit(EXIT_FAILURE);
   }
 
-  return {.parsed = std::move(parsed),
+  ParsedFile parsed_file{.source = std::move(source),
+                         .lex_result = std::move(lex_result),
+                         .parse_result = std::move(parse_result)};
+
+  return {.parsed = std::move(parsed_file),
           .resolve = std::move(resolve_result),
           .types = std::move(types),
-          .typecheck = std::move(check_result)};
+          .typecheck = std::move(check_result),
+          .prelude_lines = prelude_lines};
 }
 
 struct HirResult {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -381,14 +381,14 @@ auto TypeChecker::type_conforms_to(const Type* type,
 
   // Check extend declarations.
   if (file_ != nullptr) {
-    const auto& concept_name = concept_decl->as<ConceptDecl>().name;
+    const auto& cpt_name = concept_decl->as<ConceptDecl>().name;
     for (const auto* decl : file_->declarations) {
       if (decl->kind() != NodeKind::ExtendDecl) {
         continue;
       }
       const auto& ext = decl->as<ExtendDecl>();
       const auto* target = resolve_type_node(ext.target_type);
-      if (target == type && ext.concept_name == concept_name) {
+      if (target == type && ext.concept_name == cpt_name) {
         return true;
       }
     }

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -27,6 +27,20 @@ auto check_source(const std::string& source) -> TypeCheckResult {
   return typecheck(*parse_result.file, resolve_result, types);
 }
 
+/// Check user source with prelude source strings prepended.
+/// Uses source concatenation (same approach as the driver).
+auto check_with_prelude(const std::string& user_source,
+                        std::span<const std::string> prelude_sources)
+    -> TypeCheckResult {
+  std::string combined;
+  for (const auto& pre : prelude_sources) {
+    combined += pre;
+    combined += '\n';
+  }
+  combined += user_source;
+  return check_source(combined);
+}
+
 /// Returns true if any diagnostic message contains the substring.
 auto has_error_containing(const TypeCheckResult& result, std::string_view sub)
     -> bool {
@@ -1037,6 +1051,83 @@ suite<"typecheck_concept_self_type"> concept_self_type_tests = [] {
         "fn bad(a: Point, b: Other): bool -> a.eq(b)\n");
     expect(!is_ok(result))
         << "passing wrong type to concept method should error";
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Prelude auto-import
+// ---------------------------------------------------------------------------
+
+suite<"typecheck_prelude"> prelude_tests = [] {
+  // Common prelude source fragments.
+  const std::string printable_prelude =
+      "extern fn __i32_to_string(x: i32): string\n"
+      "derived concept Printable:\n"
+      "    fn to_string(self): string\n"
+      "extend i32 as Printable:\n"
+      "    fn to_string(self): string -> __i32_to_string(self)\n";
+  const std::string equatable_prelude =
+      "extern fn __i32_eq(a: i32, b: i32): bool\n"
+      "derived concept Equatable:\n"
+      "    fn eq(self, other: Equatable): bool\n"
+      "extend i32 as Equatable:\n"
+      "    fn eq(self, other: i32): bool -> __i32_eq(self, other)\n";
+  const std::string print_prelude =
+      "extern fn __write_stdout(msg: string): void\n"
+      "fn print(msg: string): void -> __write_stdout(msg)\n";
+
+  "prelude concept visible in user code"_test = [&] {
+    std::array preludes{printable_prelude};
+    auto result = check_with_prelude(
+        "class Point:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "fn show(p: Point): string -> p.to_string()\n",
+        preludes);
+    expect(is_ok(result))
+        << "prelude concept should enable derived method dispatch";
+  };
+
+  "prelude extern fn callable from user code"_test = [&] {
+    std::array preludes{print_prelude};
+    auto result = check_with_prelude(
+        "fn hello(): void -> print(\"hi\")\n",
+        preludes);
+    expect(is_ok(result))
+        << "prelude function should be callable without import";
+  };
+
+  "prelude extend enables scalar method calls"_test = [&] {
+    std::array preludes{equatable_prelude};
+    auto result = check_with_prelude(
+        "fn same(a: i32, b: i32): bool -> a.eq(b)\n",
+        preludes);
+    expect(is_ok(result))
+        << "prelude extend should enable scalar method calls";
+  };
+
+  "user code can define types deriving from prelude concepts"_test = [&] {
+    std::array preludes{equatable_prelude};
+    auto result = check_with_prelude(
+        "class Pair:\n"
+        "    x: i32\n"
+        "    y: i32\n"
+        "fn same(a: Pair, b: Pair): bool -> a.eq(b)\n",
+        preludes);
+    expect(is_ok(result))
+        << "user class should auto-derive from prelude concept";
+  };
+
+  "multiple prelude files compose"_test = [&] {
+    std::array preludes{printable_prelude, equatable_prelude};
+    auto result = check_with_prelude(
+        "class Val:\n"
+        "    n: i32\n"
+        "fn show(v: Val): string -> v.to_string()\n"
+        "fn same(a: Val, b: Val): bool -> a.eq(b)\n",
+        preludes);
+    expect(is_ok(result))
+        << "multiple prelude files should compose correctly";
   };
 };
 


### PR DESCRIPTION
## Summary

Implement prelude auto-import so stdlib/core concepts (`Printable`, `Equatable`), scalar conformances, and utility functions (`print`) are available in user code without explicit import. Uses source concatenation as a bootstrap simplification.

## Highlights

- Add `load_prelude_source()` to driver — reads all `stdlib/core/*.dao` files and concatenates their source text
- Prepend prelude source to user source in `run_frontend()` before the lex → parse → resolve → typecheck pipeline
- Track `prelude_lines` offset for future diagnostic line adjustment
- Add `DAO_SOURCE_DIR` compile definition to driver for stdlib file discovery
- Add `typecheck_prelude` test suite (5 tests): prelude concept dispatch, extern fn calls, scalar method calls, derived conformance through prelude, multi-prelude composition
- Source concatenation is a deliberate bootstrap trade-off — proper multi-file prelude deferred to module system

## Test plan

- [x] `prelude concept visible in user code` — derived method dispatch via prepended concept
- [x] `prelude extern fn callable from user code` — `print("hi")` works without import
- [x] `prelude extend enables scalar method calls` — `a.eq(b)` on i32 via prelude extend
- [x] `user code can define types deriving from prelude concepts` — auto-derivation from prelude Equatable
- [x] `multiple prelude files compose` — Printable + Equatable both active
- [x] Driver end-to-end: `daoc check` succeeds for user code referencing `print`, `to_string`, `eq` without import
- [x] All 10/10 tests pass

## Known Limitations

- Diagnostic line numbers for user code are offset by the prelude line count (prelude source is prepended)
- If user code redefines a prelude symbol, it will get a "duplicate declaration" error from the resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)