### PR TITLE
feat(stdlib): ✨ add range generator function to prelude

### DIFF
--- a/stdlib/core/range.dao
+++ b/stdlib/core/range.dao
@@ -1,0 +1,5 @@
+fn range(n: i32): Generator<i32>
+    let i = 0
+    while i < n:
+        yield i
+        i = i + 1

--- a/testdata/ast/stdlib_core_range.ast
+++ b/testdata/ast/stdlib_core_range.ast
@@ -1,0 +1,20 @@
+File
+  FunctionDecl range
+    Param n: i32
+    ReturnType: Generator<i32>
+    LetStatement i
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier n
+      YieldStatement
+        Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1


### PR DESCRIPTION
## Summary

Implements TASK_13 §11.3 — adds `range(n: i32): Generator<i32>` as a stdlib core prelude function. The function is automatically available to all Dao programs via the existing prelude auto-import mechanism (`stdlib/core/*.dao` prepended to user source).

## Highlights

- Add `stdlib/core/range.dao` with a generator function using `yield`/`while`
- Add golden AST fixture `testdata/ast/stdlib_core_range.ast`
- Verified: `daoc check` resolves `range()` from prelude without explicit import
- Verified: HIR/MIR pipeline correctly lowers `for i in range(n):` with element type extraction
- All 10 test suites pass

## Test plan

- [x] `daoc check /tmp/test_range.dao` — user code calls `range(5)` without local definition
- [x] `daoc hir` / `daoc mir` — range function and for-loop desugaring produce correct output
- [x] All existing tests pass (10/10)
- [x] Golden AST file generated and validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)