### PR TITLE
feat(backend): ✨ enable end-to-end compilation and execution

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -82,14 +82,37 @@ auto LlvmBackend::lower(const MirModule& mir_module) -> LlvmBackendResult {
   }
 
   // Second pass: lower function bodies.
+  size_t diag_count_before = diagnostics_.size();
   for (const auto* fn : mir_module.functions) {
+    size_t diag_before = diagnostics_.size();
     if (!lower_function(*fn)) {
-      // Diagnostics already emitted.
+      // Function body failed — remove body, leaving it as a declaration.
+      // This allows the rest of the module to compile; calling this
+      // function will produce a link error, which is honest.
+      if (fn->symbol != nullptr) {
+        auto* llvm_fn = module_->getFunction(std::string(fn->symbol->name));
+        if (llvm_fn != nullptr && !llvm_fn->empty()) {
+          llvm_fn->deleteBody();
+        }
+      }
+      // Downgrade body-lowering errors to warnings so they don't kill
+      // the module.
+      for (size_t i = diag_before; i < diagnostics_.size(); ++i) {
+        diagnostics_[i].severity = Severity::Warning;
+      }
     }
   }
 
-  // Do not return a partial module when lowering produced errors.
-  if (!diagnostics_.empty()) {
+  // Only kill the module if new hard errors were emitted (not warnings
+  // from failed function bodies).
+  bool has_errors = false;
+  for (size_t i = diag_count_before; i < diagnostics_.size(); ++i) {
+    if (diagnostics_[i].severity == Severity::Error) {
+      has_errors = true;
+      break;
+    }
+  }
+  if (has_errors) {
     module_.reset();
   }
 
@@ -407,7 +430,12 @@ auto LlvmBackend::lower_const_bool(const MirConstBool& p, const MirInst& inst,
 auto LlvmBackend::lower_const_string(const MirConstString& p, const MirInst& inst,
                                        FunctionState& state) -> bool {
   // Create a global constant for the string data.
-  auto str = std::string(p.value);
+  // Strip surrounding quotes — the lexer preserves them in the token text.
+  auto raw = p.value;
+  if (raw.size() >= 2 && raw.front() == '"' && raw.back() == '"') {
+    raw = raw.substr(1, raw.size() - 2);
+  }
+  auto str = std::string(raw);
   auto* str_constant = llvm::ConstantDataArray::getString(ctx_, str, /*AddNull=*/true);
   auto* global = new llvm::GlobalVariable(
       *module_, str_constant->getType(), /*isConstant=*/true,
@@ -885,6 +913,13 @@ auto LlvmBackend::lower_construct(const MirConstruct& p, const MirInst& inst,
 
 auto LlvmBackend::lower_return(const MirReturn& p, const MirInst& inst,
                                  FunctionState& state) -> bool {
+  // Void functions always emit ret void, even if MIR has a value
+  // (e.g. returning a void call result).
+  if (state.llvm_fn->getReturnType()->isVoidTy()) {
+    state.builder->CreateRetVoid();
+    return true;
+  }
+
   if (p.has_value) {
     auto* val = get_value(p.value, state);
     if (val == nullptr) {

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -1,7 +1,13 @@
+// NOLINTBEGIN(readability-identifier-length)
+// Short names `fn`, `p`, `it`, `id` are idiomatic in this file:
+//   - `fn`  = MIR function being lowered
+//   - `p`   = typed payload from std::visit
+//   - `it`  = iterator / map lookup
+//   - `id`  = MIR value identifier
+
 #include "backend/llvm/llvm_backend.h"
 
 #include "ir/mir/mir.h"
-#include "ir/mir/mir_kind.h"
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -30,84 +36,18 @@ namespace dao {
 
 LlvmBackend::LlvmBackend(llvm::LLVMContext& ctx) : ctx_(ctx), types_(ctx) {}
 
-auto LlvmBackend::lower(const MirModule& mir_module) -> LlvmBackendResult {
+auto LlvmBackend::lower(const MirModule& mir_module, uint32_t prelude_bytes)
+    -> LlvmBackendResult {
   module_ = std::make_unique<llvm::Module>("dao_module", ctx_);
   diagnostics_.clear();
 
-  // First pass: declare all functions (forward declarations).
-  for (const auto* fn : mir_module.functions) {
-    if (fn->symbol == nullptr) {
-      continue;
-    }
+  declare_functions(mir_module);
+  lower_bodies(mir_module, prelude_bytes);
 
-    // Build LLVM function type.
-    auto* ret_type = types_.lower(fn->return_type);
-    if (ret_type == nullptr) {
-      emit_diagnostic(fn->span, "cannot lower return type: " + types_.error());
-      continue;
-    }
-
-    std::vector<llvm::Type*> param_types;
-    for (const auto& local : fn->locals) {
-      if (!local.is_param) {
-        break; // params come first
-      }
-      auto* pt = types_.lower(local.type);
-      if (pt == nullptr) {
-        emit_diagnostic(local.span, "cannot lower param type: " + types_.error());
-        break;
-      }
-      // String params are passed by pointer for C ABI compatibility.
-      if (LlvmTypeLowering::is_string_type(local.type)) {
-        pt = llvm::PointerType::getUnqual(pt);
-      }
-      param_types.push_back(pt);
-    }
-
-    auto* fn_type = llvm::FunctionType::get(ret_type, param_types, /*isVarArg=*/false);
-    auto* llvm_fn = llvm::Function::Create(
-        fn_type, llvm::Function::ExternalLinkage,
-        std::string(fn->symbol->name), module_.get());
-
-    // Name parameters.
-    size_t idx = 0;
-    for (auto& arg : llvm_fn->args()) {
-      if (idx < fn->locals.size() && fn->locals[idx].is_param) {
-        if (fn->locals[idx].symbol != nullptr) {
-          arg.setName(std::string(fn->locals[idx].symbol->name));
-        }
-      }
-      ++idx;
-    }
-  }
-
-  // Second pass: lower function bodies.
-  size_t diag_count_before = diagnostics_.size();
-  for (const auto* fn : mir_module.functions) {
-    size_t diag_before = diagnostics_.size();
-    if (!lower_function(*fn)) {
-      // Function body failed — remove body, leaving it as a declaration.
-      // This allows the rest of the module to compile; calling this
-      // function will produce a link error, which is honest.
-      if (fn->symbol != nullptr) {
-        auto* llvm_fn = module_->getFunction(std::string(fn->symbol->name));
-        if (llvm_fn != nullptr && !llvm_fn->empty()) {
-          llvm_fn->deleteBody();
-        }
-      }
-      // Downgrade body-lowering errors to warnings so they don't kill
-      // the module.
-      for (size_t i = diag_before; i < diagnostics_.size(); ++i) {
-        diagnostics_[i].severity = Severity::Warning;
-      }
-    }
-  }
-
-  // Only kill the module if new hard errors were emitted (not warnings
-  // from failed function bodies).
+  // Kill the module if any hard errors remain.
   bool has_errors = false;
-  for (size_t i = diag_count_before; i < diagnostics_.size(); ++i) {
-    if (diagnostics_[i].severity == Severity::Error) {
+  for (const auto& diag : diagnostics_) {
+    if (diag.severity == Severity::Error) {
       has_errors = true;
       break;
     }
@@ -117,6 +57,94 @@ auto LlvmBackend::lower(const MirModule& mir_module) -> LlvmBackendResult {
   }
 
   return {.module = std::move(module_), .diagnostics = std::move(diagnostics_)};
+}
+
+// ---------------------------------------------------------------------------
+// Declaration pass — forward-declare all functions.
+// ---------------------------------------------------------------------------
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void LlvmBackend::declare_functions(const MirModule& mir_module) {
+  for (const auto* mir_fn : mir_module.functions) {
+    if (mir_fn->symbol == nullptr) {
+      continue;
+    }
+
+    // Build LLVM function type.
+    auto* ret_type = types_.lower(mir_fn->return_type);
+    if (ret_type == nullptr) {
+      emit_diagnostic(mir_fn->span,
+                      "cannot lower return type: " + types_.error());
+      continue;
+    }
+
+    std::vector<llvm::Type*> param_types;
+    for (const auto& local : mir_fn->locals) {
+      if (!local.is_param) {
+        break; // params come first
+      }
+      auto* lowered_param = types_.lower(local.type);
+      if (lowered_param == nullptr) {
+        emit_diagnostic(local.span,
+                        "cannot lower param type: " + types_.error());
+        break;
+      }
+      // String params are passed by pointer for C ABI compatibility.
+      if (LlvmTypeLowering::is_string_type(local.type)) {
+        lowered_param = llvm::PointerType::getUnqual(lowered_param);
+      }
+      param_types.push_back(lowered_param);
+    }
+
+    auto* fn_type =
+        llvm::FunctionType::get(ret_type, param_types, /*isVarArg=*/false);
+    auto* llvm_fn = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage,
+        std::string(mir_fn->symbol->name), module_.get());
+
+    // Name parameters.
+    size_t idx = 0;
+    for (auto& arg : llvm_fn->args()) {
+      if (idx < mir_fn->locals.size() && mir_fn->locals[idx].is_param) {
+        if (mir_fn->locals[idx].symbol != nullptr) {
+          arg.setName(std::string(mir_fn->locals[idx].symbol->name));
+        }
+      }
+      ++idx;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body pass — lower function bodies; prelude failures are non-fatal.
+// ---------------------------------------------------------------------------
+
+void LlvmBackend::lower_bodies(const MirModule& mir_module,
+                                uint32_t prelude_bytes) {
+  for (const auto* mir_fn : mir_module.functions) {
+    size_t diag_before = diagnostics_.size();
+    if (!lower_function(*mir_fn)) {
+      bool is_prelude = mir_fn->span.offset < prelude_bytes;
+      if (is_prelude) {
+        // Prelude function body failed — remove body so it becomes a
+        // declaration. The rest of the module can still compile; if
+        // user code actually calls this function, linking will fail
+        // with a clear undefined-reference error.
+        if (mir_fn->symbol != nullptr) {
+          auto* llvm_fn =
+              module_->getFunction(std::string(mir_fn->symbol->name));
+          if (llvm_fn != nullptr && !llvm_fn->empty()) {
+            llvm_fn->deleteBody();
+          }
+        }
+        // Downgrade prelude errors to warnings.
+        for (size_t i = diag_before; i < diagnostics_.size(); ++i) {
+          diagnostics_[i].severity = Severity::Warning;
+        }
+      }
+      // User functions: diagnostics stay as errors (no downgrade).
+    }
+  }
 }
 
 void LlvmBackend::print_ir(std::ostream& out, const llvm::Module& module) {
@@ -156,10 +184,10 @@ auto LlvmBackend::emit_object(llvm::Module& module,
 
   module.setDataLayout(target_machine->createDataLayout());
 
-  std::error_code ec;
-  llvm::raw_fd_ostream dest(output_path, ec, llvm::sys::fs::OF_None);
-  if (ec) {
-    error_out = "failed to open output file: " + ec.message();
+  std::error_code err_code;
+  llvm::raw_fd_ostream dest(output_path, err_code, llvm::sys::fs::OF_None);
+  if (err_code) {
+    error_out = "failed to open output file: " + err_code.message();
     return false;
   }
 
@@ -205,17 +233,17 @@ auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
 
   // Create all basic blocks first (for forward branches).
   for (const auto* block : fn.blocks) {
-    auto* bb = llvm::BasicBlock::Create(
+    auto* llvm_block = llvm::BasicBlock::Create(
         ctx_, "bb" + std::to_string(block->id.id), llvm_fn);
-    state.blocks[block->id.id] = bb;
+    state.blocks[block->id.id] = llvm_block;
   }
 
   // Create entry block allocas for all locals.
   llvm::IRBuilder<> builder(ctx_);
   state.builder = &builder;
 
-  auto* entry_bb = state.blocks[fn.blocks[0]->id.id];
-  builder.SetInsertPoint(entry_bb);
+  auto* entry_block = state.blocks[fn.blocks[0]->id.id];
+  builder.SetInsertPoint(entry_block);
 
   // Allocate locals. Params get their alloca here too (store from arg below).
   for (const auto& local : fn.locals) {
@@ -229,6 +257,7 @@ auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
         local_type, nullptr,
         local.symbol != nullptr ? std::string(local.symbol->name) : "");
     state.locals[local.id.id] = alloca;
+    state.local_types[local.id.id] = local.type;
   }
 
   // Store function parameters into their allocas.
@@ -249,7 +278,7 @@ auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
 
   // Lower each block.
   for (const auto* block : fn.blocks) {
-    if (!lower_block(*block, fn, state)) {
+    if (!lower_block(*block, state)) {
       return false;
     }
   }
@@ -261,13 +290,13 @@ auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
 // Block lowering
 // ---------------------------------------------------------------------------
 
-auto LlvmBackend::lower_block(const MirBlock& block, const MirFunction& fn,
+auto LlvmBackend::lower_block(const MirBlock& block,
                                 FunctionState& state) -> bool {
-  auto* bb = state.blocks[block.id.id];
-  state.builder->SetInsertPoint(bb);
+  auto* target_block = state.blocks[block.id.id];
+  state.builder->SetInsertPoint(target_block);
 
   for (const auto* inst : block.insts) {
-    if (!lower_inst(*inst, fn, state)) {
+    if (!lower_inst(*inst, state)) {
       return false;
     }
   }
@@ -280,7 +309,7 @@ auto LlvmBackend::lower_block(const MirBlock& block, const MirFunction& fn,
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
+auto LlvmBackend::lower_inst(const MirInst& inst,
                                FunctionState& state) -> bool {
   return std::visit(overloaded{
       [&](const MirConstInt& p)    { return lower_const_int(p, inst, state); },
@@ -289,8 +318,8 @@ auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
       [&](const MirConstString& p) { return lower_const_string(p, inst, state); },
       [&](const MirUnary& p)       { return lower_unary(p, inst, state); },
       [&](const MirBinary& p)      { return lower_binary(p, inst, state); },
-      [&](const MirStore& p)       { return lower_store(p, inst, fn, state); },
-      [&](const MirLoad& p)        { return lower_load(p, inst, fn, state); },
+      [&](const MirStore& p)       { return lower_store(p, inst, state); },
+      [&](const MirLoad& p)        { return lower_load(p, inst, state); },
       [&](const MirFnRef& p)       { return lower_fn_ref(p, inst, state); },
       [&](const MirCall& p)        { return lower_call(p, inst, state); },
       [&](const MirConstruct& p)   { return lower_construct(p, inst, state); },
@@ -311,7 +340,7 @@ auto LlvmBackend::lower_inst(const MirInst& inst, const MirFunction& fn,
           return false;
         }
         if (!p.place->projections.empty()) {
-          auto* ptr = resolve_place(*p.place, fn, state);
+          auto* ptr = resolve_place(*p.place, state);
           if (ptr == nullptr) {
             emit_diagnostic(inst.span, "cannot resolve AddrOf projected place");
             return false;
@@ -610,8 +639,8 @@ auto LlvmBackend::lower_binary(const MirBinary& p, const MirInst& inst,
 // Place resolution — walk projection chains to an LLVM pointer.
 // ---------------------------------------------------------------------------
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto LlvmBackend::resolve_place(const MirPlace& place,
-                                 const MirFunction& fn,
                                  FunctionState& state) -> llvm::Value* {
   auto it = state.locals.find(place.local.id);
   if (it == state.locals.end()) {
@@ -624,11 +653,9 @@ auto LlvmBackend::resolve_place(const MirPlace& place,
   // produces a raw loaded pointer we still know the LLVM type for the
   // subsequent Field GEP.
   const Type* current_type = nullptr;
-  for (const auto& local : fn.locals) {
-    if (local.id.id == place.local.id) {
-      current_type = local.type;
-      break;
-    }
+  auto type_it = state.local_types.find(place.local.id);
+  if (type_it != state.local_types.end()) {
+    current_type = type_it->second;
   }
 
   for (const auto& proj : place.projections) {
@@ -688,7 +715,6 @@ auto LlvmBackend::resolve_place(const MirPlace& place,
 // ---------------------------------------------------------------------------
 
 auto LlvmBackend::lower_store(const MirStore& p, const MirInst& inst,
-                                const MirFunction& fn,
                                 FunctionState& state) -> bool {
   if (p.place == nullptr) {
     emit_diagnostic(inst.span, "store with null place");
@@ -708,7 +734,7 @@ auto LlvmBackend::lower_store(const MirStore& p, const MirInst& inst,
   }
 
   if (!p.place->projections.empty()) {
-    auto* ptr = resolve_place(*p.place, fn, state);
+    auto* ptr = resolve_place(*p.place, state);
     if (ptr == nullptr) {
       emit_diagnostic(inst.span, "cannot resolve projected store target");
       return false;
@@ -722,7 +748,6 @@ auto LlvmBackend::lower_store(const MirStore& p, const MirInst& inst,
 }
 
 auto LlvmBackend::lower_load(const MirLoad& p, const MirInst& inst,
-                               const MirFunction& fn,
                                FunctionState& state) -> bool {
   if (p.place == nullptr) {
     emit_diagnostic(inst.span, "load with null place");
@@ -736,7 +761,7 @@ auto LlvmBackend::lower_load(const MirLoad& p, const MirInst& inst,
   }
 
   if (!p.place->projections.empty()) {
-    auto* ptr = resolve_place(*p.place, fn, state);
+    auto* ptr = resolve_place(*p.place, state);
     if (ptr == nullptr) {
       emit_diagnostic(inst.span, "cannot resolve projected load source");
       return false;
@@ -964,3 +989,5 @@ auto LlvmBackend::lower_cond_br(const MirCondBr& p, const MirInst& inst,
 }
 
 } // namespace dao
+
+// NOLINTEND(readability-identifier-length)

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -1,3 +1,4 @@
+// NOLINTBEGIN(readability-identifier-length)
 #ifndef DAO_BACKEND_LLVM_LLVM_BACKEND_H
 #define DAO_BACKEND_LLVM_LLVM_BACKEND_H
 
@@ -37,7 +38,13 @@ class LlvmBackend {
 public:
   explicit LlvmBackend(llvm::LLVMContext& ctx);
 
-  auto lower(const MirModule& mir_module) -> LlvmBackendResult;
+  // Lower a MirModule to LLVM IR. prelude_bytes indicates the byte
+  // offset boundary: functions whose source span starts before this
+  // offset are prelude functions and may have their bodies dropped
+  // (with a warning) if they use unsupported constructs. Functions
+  // beyond this offset are user code and produce hard errors.
+  auto lower(const MirModule& mir_module, uint32_t prelude_bytes = 0)
+      -> LlvmBackendResult;
 
   // Emit textual LLVM IR to a stream.
   static void print_ir(std::ostream& out, const llvm::Module& module);
@@ -70,6 +77,9 @@ private:
     // MIR LocalId → LLVM alloca (for named locals / params)
     std::unordered_map<uint32_t, llvm::AllocaInst*> locals;
 
+    // MIR LocalId → semantic Type* (for place resolution)
+    std::unordered_map<uint32_t, const Type*> local_types;
+
     // MIR MirValueId → LLVM Value* (for SSA temporaries)
     std::unordered_map<uint32_t, llvm::Value*> values;
 
@@ -80,9 +90,13 @@ private:
     std::unordered_map<uint32_t, llvm::BasicBlock*> blocks;
   };
 
-  auto lower_block(const MirBlock& block, const MirFunction& fn,
+  // Top-level lowering phases (called by lower()).
+  void declare_functions(const MirModule& mir_module);
+  void lower_bodies(const MirModule& mir_module, uint32_t prelude_bytes);
+
+  auto lower_block(const MirBlock& block,
                     FunctionState& state) -> bool;
-  auto lower_inst(const MirInst& inst, const MirFunction& fn,
+  auto lower_inst(const MirInst& inst,
                    FunctionState& state) -> bool;
 
   // Typed instruction lowering helpers
@@ -99,9 +113,9 @@ private:
   auto lower_binary(const MirBinary& p, const MirInst& inst,
                     FunctionState& state) -> bool;
   auto lower_store(const MirStore& p, const MirInst& inst,
-                   const MirFunction& fn, FunctionState& state) -> bool;
+                   FunctionState& state) -> bool;
   auto lower_load(const MirLoad& p, const MirInst& inst,
-                  const MirFunction& fn, FunctionState& state) -> bool;
+                  FunctionState& state) -> bool;
   auto lower_field_access(const MirFieldAccess& p, const MirInst& inst,
                           FunctionState& state) -> bool;
   auto lower_fn_ref(const MirFnRef& p, const MirInst& inst,
@@ -118,7 +132,7 @@ private:
                      FunctionState& state) -> bool;
 
   // Place resolution — walk projection chains to an LLVM pointer.
-  auto resolve_place(const MirPlace& place, const MirFunction& fn,
+  auto resolve_place(const MirPlace& place,
                       FunctionState& state) -> llvm::Value*;
 
   // Value lookup
@@ -128,3 +142,4 @@ private:
 } // namespace dao
 
 #endif // DAO_BACKEND_LLVM_LLVM_BACKEND_H
+// NOLINTEND(readability-identifier-length)

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -15,6 +15,7 @@
 #include <llvm/IR/Module.h>
 
 #include <boost/ut.hpp>
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -70,7 +71,11 @@ struct LlvmTestPipeline {
   }
 
   [[nodiscard]] auto has_errors() const -> bool {
-    return !llvm_result.diagnostics.empty();
+    return std::any_of(llvm_result.diagnostics.begin(),
+                       llvm_result.diagnostics.end(),
+                       [](const Diagnostic& diag) {
+                         return diag.severity == Severity::Error;
+                       });
   }
 };
 

--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -73,6 +73,10 @@ auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
     error_ = "enum lowering not yet implemented: " + std::string(e->name());
     return nullptr;
   }
+
+  case TypeKind::Generator:
+    error_ = "generator/coroutine type lowering not yet implemented";
+    return nullptr;
   }
 
   error_ = "unknown type kind";

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -450,11 +450,11 @@ void cmd_llvm_ir(const std::filesystem::path& path) {
   auto llvm_result = backend.lower(*mir.mir.module);
 
   auto filename = path.filename().string();
-  print_error_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                          llvm_result.diagnostics,
-                          mir.hir_result.frontend.prelude_lines);
+  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
+                                      llvm_result.diagnostics,
+                                      mir.hir_result.frontend.prelude_lines);
 
-  if (llvm_result.module == nullptr || !llvm_result.diagnostics.empty()) {
+  if (llvm_result.module == nullptr || has_errors) {
     std::exit(EXIT_FAILURE);
   }
 
@@ -470,11 +470,11 @@ void cmd_build(const std::filesystem::path& path) {
   auto llvm_result = backend.lower(*mir.mir.module);
 
   auto filename = path.filename().string();
-  print_error_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                          llvm_result.diagnostics,
-                          mir.hir_result.frontend.prelude_lines);
+  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
+                                      llvm_result.diagnostics,
+                                      mir.hir_result.frontend.prelude_lines);
 
-  if (llvm_result.module == nullptr || !llvm_result.diagnostics.empty()) {
+  if (llvm_result.module == nullptr || has_errors) {
     std::exit(EXIT_FAILURE);
   }
 

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -280,6 +280,25 @@ auto run_through_mir(const std::filesystem::path& path) -> MirResult {
           .mir = std::move(mir)};
 }
 
+// Lower MIR to LLVM IR, check diagnostics, and exit on error.
+auto lower_to_llvm(const MirResult& mir, llvm::LLVMContext& llvm_ctx,
+                   const std::filesystem::path& path) -> dao::LlvmBackendResult {
+  dao::LlvmBackend backend(llvm_ctx);
+  auto result = backend.lower(*mir.mir.module,
+                               mir.hir_result.frontend.prelude_bytes);
+
+  auto filename = path.filename().string();
+  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
+                                      result.diagnostics,
+                                      mir.hir_result.frontend.prelude_lines);
+
+  if (result.module == nullptr || has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Command handlers
 // ---------------------------------------------------------------------------
@@ -444,41 +463,16 @@ void cmd_mir(const std::filesystem::path& path) {
 // Build and emit LLVM IR. Output is deterministic.
 void cmd_llvm_ir(const std::filesystem::path& path) {
   auto mir = run_through_mir(path);
-
   llvm::LLVMContext llvm_ctx;
-  dao::LlvmBackend backend(llvm_ctx);
-  auto llvm_result = backend.lower(*mir.mir.module,
-                                   mir.hir_result.frontend.prelude_bytes);
-
-  auto filename = path.filename().string();
-  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                                      llvm_result.diagnostics,
-                                      mir.hir_result.frontend.prelude_lines);
-
-  if (llvm_result.module == nullptr || has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
-
+  auto llvm_result = lower_to_llvm(mir, llvm_ctx, path);
   dao::LlvmBackend::print_ir(std::cout, *llvm_result.module);
 }
 
 // Compile a .dao file to a native executable.
 void cmd_build(const std::filesystem::path& path) {
   auto mir = run_through_mir(path);
-
   llvm::LLVMContext llvm_ctx;
-  dao::LlvmBackend backend(llvm_ctx);
-  auto llvm_result = backend.lower(*mir.mir.module,
-                                   mir.hir_result.frontend.prelude_bytes);
-
-  auto filename = path.filename().string();
-  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                                      llvm_result.diagnostics,
-                                      mir.hir_result.frontend.prelude_lines);
-
-  if (llvm_result.module == nullptr || has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
+  auto llvm_result = lower_to_llvm(mir, llvm_ctx, path);
 
   // Initialize LLVM targets and emit object file.
   dao::LlvmBackend::initialize_targets();

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -447,7 +447,8 @@ void cmd_llvm_ir(const std::filesystem::path& path) {
 
   llvm::LLVMContext llvm_ctx;
   dao::LlvmBackend backend(llvm_ctx);
-  auto llvm_result = backend.lower(*mir.mir.module);
+  auto llvm_result = backend.lower(*mir.mir.module,
+                                   mir.hir_result.frontend.prelude_bytes);
 
   auto filename = path.filename().string();
   bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
@@ -467,7 +468,8 @@ void cmd_build(const std::filesystem::path& path) {
 
   llvm::LLVMContext llvm_ctx;
   dao::LlvmBackend backend(llvm_ctx);
-  auto llvm_result = backend.lower(*mir.mir.module);
+  auto llvm_result = backend.lower(*mir.mir.module,
+                                   mir.hir_result.frontend.prelude_bytes);
 
   auto filename = path.filename().string();
   bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,

--- a/runtime/core/dao_runtime.c
+++ b/runtime/core/dao_runtime.c
@@ -1,38 +1,94 @@
 // Minimal Dao runtime — linked into every executable produced by daoc.
 // This file provides C implementations for Dao builtins that the
 // compiler emits as extern symbols.
+//
+// The calling convention for dao.string is: pointer to { i8*, i64 }
+// (passed by pointer per the LLVM backend's string ABI).
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 // Matches the LLVM IR struct %dao.string = type { ptr, i64 }.
-// String parameters are passed by pointer in the Dao calling convention.
 struct dao_string {
   const char *ptr;
   int64_t len;
 };
 
-// fn print(msg: string): void
-//
-// The compiler stores string literals with their surrounding quotes
-// (e.g. "hello" has ptr pointing to '"hello"' with len 7). Strip the
-// outer quotes before printing.
-void print(const struct dao_string *msg) {
-  if (msg == NULL || msg->ptr == NULL || msg->len == 0) {
+// ---------------------------------------------------------------------------
+// IO
+// ---------------------------------------------------------------------------
+
+// extern fn __write_stdout(msg: string): void
+void __write_stdout(const struct dao_string *msg) {
+  if (msg == NULL || msg->ptr == NULL || msg->len <= 0) {
     return;
   }
 
   const char *start = msg->ptr;
   int64_t len = msg->len;
 
-  // Strip surrounding double quotes if present.
-  if (len >= 2 && start[0] == '"' && start[len - 1] == '"') {
-    start++;
-    len -= 2;
-  }
-
+  // String literals are stored without quotes by the compiler.
   if (len > 0) {
     fwrite(start, 1, (size_t)len, stdout);
   }
   fputc('\n', stdout);
+}
+
+// ---------------------------------------------------------------------------
+// Equatable
+// ---------------------------------------------------------------------------
+
+// extern fn __i32_eq(a: i32, b: i32): bool
+bool __i32_eq(int32_t a, int32_t b) { return a == b; }
+
+// extern fn __f64_eq(a: f64, b: f64): bool
+bool __f64_eq(double a, double b) { return a == b; }
+
+// extern fn __bool_eq(a: bool, b: bool): bool
+bool __bool_eq(bool a, bool b) { return a == b; }
+
+// extern fn __string_eq(a: string, b: string): bool
+bool __string_eq(const struct dao_string *a, const struct dao_string *b) {
+  if (a == NULL || b == NULL) {
+    return a == b;
+  }
+  if (a->len != b->len) {
+    return false;
+  }
+  if (a->ptr == b->ptr) {
+    return true;
+  }
+  return memcmp(a->ptr, b->ptr, (size_t)a->len) == 0;
+}
+
+// ---------------------------------------------------------------------------
+// Printable (to_string)
+// ---------------------------------------------------------------------------
+
+// extern fn __i32_to_string(x: i32): string
+//
+// Returns a stack-allocated dao_string. Since Dao returns structs by
+// value, the caller receives a copy.
+struct dao_string __i32_to_string(int32_t x) {
+  // Use a thread-local buffer for the conversion.
+  static _Thread_local char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%d", x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+// extern fn __f64_to_string(x: f64): string
+struct dao_string __f64_to_string(double x) {
+  static _Thread_local char buf[64];
+  int len = snprintf(buf, sizeof(buf), "%g", x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+// extern fn __bool_to_string(x: bool): string
+struct dao_string __bool_to_string(bool x) {
+  if (x) {
+    return (struct dao_string){.ptr = "true", .len = 4};
+  }
+  return (struct dao_string){.ptr = "false", .len = 5};
 }


### PR DESCRIPTION
## Summary

Fixes multiple LLVM backend and runtime blockers so that `daoc build` produces working native executables. Dao "hello world" now compiles and runs end-to-end.

## Highlights

- **Void return fix**: emit `ret void` for void functions even when MIR passes a void call result value (fixes prelude `print` function)
- **String literal fix**: strip surrounding quotes from string constants in LLVM lowering — strings are now emitted without lexer quote chars
- **Generator type handling**: `TypeKind::Generator` in type lowering produces a clear error instead of a compiler warning
- **Non-fatal function failures**: function bodies that fail to lower are removed (left as declarations) with warnings instead of errors, so prelude functions using unsupported features (yield/coroutines) don't kill the entire module
- **Complete runtime**: all prelude extern symbols implemented in C — `__write_stdout`, `__i32_eq`, `__f64_eq`, `__bool_eq`, `__string_eq`, `__i32_to_string`, `__f64_to_string`, `__bool_to_string`
- **Severity-aware diagnostics**: `cmd_llvm_ir` and `cmd_build` use `print_diagnostics` (shows warnings) instead of `print_error_diagnostics`

## Test plan

- [x] `daoc build hello.dao && ./hello` → prints `hello from Dao!`, exits 0
- [x] `daoc build calc.dao && ./calc` → exits 42 (20 + 22)
- [x] `daoc build control.dao && ./control` → exits 8 (abs(-5) + abs(3))
- [x] `daoc build loop.dao && ./loop` → exits 55 (sum 1..10)
- [x] `daoc build struct.dao && ./struct` → exits 42 (Point(10, 32) manhattan distance)
- [x] All 10 test suites pass (ctest 10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)