### PR TITLE
feat(backend): ✨ implement stackless generator coroutine lowering

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -130,6 +130,17 @@ void LlvmBackend::declare_functions(const MirModule& mir_module,
       }
       ++idx;
     }
+
+    // For generator functions, also declare the resume function.
+    if (is_generator_function(*mir_fn)) {
+      auto* ptr_type = llvm::PointerType::getUnqual(ctx_);
+      auto* void_type = llvm::Type::getVoidTy(ctx_);
+      auto* resume_fn_type =
+          llvm::FunctionType::get(void_type, {ptr_type}, /*isVarArg=*/false);
+      llvm::Function::Create(
+          resume_fn_type, llvm::Function::ExternalLinkage,
+          std::string(mir_fn->symbol->name) + ".resume", module_.get());
+    }
   }
 }
 
@@ -141,7 +152,10 @@ void LlvmBackend::lower_bodies(const MirModule& mir_module,
                                 uint32_t prelude_bytes) {
   for (const auto* mir_fn : mir_module.functions) {
     size_t diag_before = diagnostics_.size();
-    if (!lower_function(*mir_fn)) {
+    bool fn_ok = is_generator_function(*mir_fn)
+        ? lower_generator_init(*mir_fn) && lower_generator_resume(*mir_fn)
+        : lower_function(*mir_fn);
+    if (!fn_ok) {
       bool is_prelude = mir_fn->span.offset < prelude_bytes;
       if (is_prelude) {
         // Prelude function body failed — remove body so it becomes a
@@ -399,20 +413,14 @@ auto LlvmBackend::lower_inst(const MirInst& inst,
         emit_diagnostic(inst.span, "index access lowering not yet implemented");
         return false;
       },
-      [&](const MirIterInit&) -> bool {
-        emit_diagnostic(inst.span, "iteration lowering not yet implemented");
-        return false;
-      },
-      [&](const MirIterHasNext&) -> bool {
-        emit_diagnostic(inst.span, "iteration lowering not yet implemented");
-        return false;
-      },
-      [&](const MirIterNext&) -> bool {
-        emit_diagnostic(inst.span, "iteration lowering not yet implemented");
-        return false;
-      },
+      [&](const MirIterInit& p)    { return lower_iter_init(p, inst, state); },
+      [&](const MirIterHasNext& p) { return lower_iter_has_next(p, inst, state); },
+      [&](const MirIterNext& p)    { return lower_iter_next(p, inst, state); },
+      [&](const MirIterDestroy& p) { return lower_iter_destroy(p, inst, state); },
       [&](const MirYieldInst&) -> bool {
-        emit_diagnostic(inst.span, "yield/coroutine lowering not yet implemented");
+        // Yield is handled inline by lower_generator_resume; reaching
+        // this visitor means yield appeared outside a generator context.
+        emit_diagnostic(inst.span, "yield outside generator function");
         return false;
       },
       [&](const MirLambdaInst&) -> bool {
@@ -899,6 +907,17 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
   if (!callee_fn->getReturnType()->isVoidTy() && inst.result.valid()) {
     state.values[inst.result.id] = call;
     state.value_types[inst.result.id] = inst.type;
+
+    // Track generator resume function for downstream iter_init.
+    if (inst.type != nullptr && inst.type->kind() == TypeKind::Generator) {
+      auto resume_name = std::string(callee_fn->getName()) + ".resume";
+      auto* resume_fn = module_->getFunction(resume_name);
+      if (resume_fn != nullptr) {
+        state.iter_resume_fns[inst.result.id] = resume_fn;
+        const auto* gen = static_cast<const TypeGenerator*>(inst.type);
+        state.iter_yield_types[inst.result.id] = gen->yield_type();
+      }
+    }
   }
   return true;
 }
@@ -956,6 +975,15 @@ auto LlvmBackend::lower_construct(const MirConstruct& p, const MirInst& inst,
 
 auto LlvmBackend::lower_return(const MirReturn& p, const MirInst& inst,
                                  FunctionState& state) -> bool {
+  // Generator resume: mark done and return void.
+  if (state.gen_frame_ptr != nullptr) {
+    auto* done_ptr = state.builder->CreateStructGEP(
+        state.gen_frame_type, state.gen_frame_ptr, 1, "done.ptr");
+    state.builder->CreateStore(state.builder->getTrue(), done_ptr);
+    state.builder->CreateRetVoid();
+    return true;
+  }
+
   // Void functions always emit ret void, even if MIR has a value
   // (e.g. returning a void call result).
   if (state.llvm_fn->getReturnType()->isVoidTy()) {
@@ -1003,6 +1031,412 @@ auto LlvmBackend::lower_cond_br(const MirCondBr& p, const MirInst& inst,
   }
 
   state.builder->CreateCondBr(cond, then_it->second, else_it->second);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Generator detection
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::is_generator_function(const MirFunction& fn) -> bool {
+  return fn.return_type != nullptr &&
+         fn.return_type->kind() == TypeKind::Generator;
+}
+
+// ---------------------------------------------------------------------------
+// Generator frame type construction
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::create_generator_frame_type(const MirFunction& fn)
+    -> llvm::StructType* {
+  auto frame_name = "dao.gen." + std::string(fn.symbol->name);
+
+  // Return cached type if already created.
+  auto* existing = llvm::StructType::getTypeByName(ctx_, frame_name);
+  if (existing != nullptr) {
+    return existing;
+  }
+
+  const auto* gen_type = static_cast<const TypeGenerator*>(fn.return_type);
+  auto* yield_llvm = types_.lower(gen_type->yield_type());
+  if (yield_llvm == nullptr) {
+    return nullptr;
+  }
+
+  // Frame layout: { i32 state, i1 done, T yield_slot, locals... }
+  std::vector<llvm::Type*> fields;
+  fields.push_back(llvm::Type::getInt32Ty(ctx_));  // 0: state
+  fields.push_back(llvm::Type::getInt1Ty(ctx_));   // 1: done
+  fields.push_back(yield_llvm);                     // 2: yield_slot
+
+  for (const auto& local : fn.locals) {
+    auto* lt = types_.lower(local.type);
+    if (lt == nullptr) {
+      return nullptr;
+    }
+    fields.push_back(lt);
+  }
+
+  return llvm::StructType::create(ctx_, fields, frame_name);
+}
+
+// ---------------------------------------------------------------------------
+// Generator init function lowering
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_generator_init(const MirFunction& fn) -> bool {
+  if (fn.symbol == nullptr || fn.is_extern) {
+    return true;
+  }
+
+  auto* init_fn = module_->getFunction(std::string(fn.symbol->name));
+  if (init_fn == nullptr) {
+    emit_diagnostic(fn.span, "generator init function not declared");
+    return false;
+  }
+
+  auto* frame_type = create_generator_frame_type(fn);
+  if (frame_type == nullptr) {
+    emit_diagnostic(fn.span, "cannot create generator frame type");
+    return false;
+  }
+
+  auto* entry = llvm::BasicBlock::Create(ctx_, "entry", init_fn);
+  llvm::IRBuilder<> builder(ctx_);
+  builder.SetInsertPoint(entry);
+
+  // Compute frame size via GEP-from-null trick (target-independent).
+  auto* i64_ty = llvm::Type::getInt64Ty(ctx_);
+  auto* null_ptr =
+      llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(ctx_));
+  auto* size_gep = builder.CreateGEP(
+      frame_type, null_ptr,
+      {llvm::ConstantInt::get(i64_ty, 1)}, "sizeof.gep");
+  auto* frame_size =
+      builder.CreatePtrToInt(size_gep, i64_ty, "frame.size");
+  auto* frame_align = llvm::ConstantInt::get(i64_ty, 8);
+
+  // Call __dao_gen_alloc(size, align).
+  auto* alloc_fn =
+      module_->getFunction(std::string(runtime_hooks::kGenAlloc));
+  auto* frame_ptr = builder.CreateCall(
+      alloc_fn->getFunctionType(), alloc_fn,
+      {frame_size, frame_align}, "frame");
+
+  // Store state = 0.
+  auto* state_ptr =
+      builder.CreateStructGEP(frame_type, frame_ptr, 0, "state.ptr");
+  builder.CreateStore(
+      llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx_), 0), state_ptr);
+
+  // Store done = false.
+  auto* done_ptr =
+      builder.CreateStructGEP(frame_type, frame_ptr, 1, "done.ptr");
+  builder.CreateStore(builder.getFalse(), done_ptr);
+
+  // Store parameters into frame (fields 3+).
+  uint32_t frame_field = 3;
+  for (auto& arg : init_fn->args()) {
+    auto* field_ptr = builder.CreateStructGEP(
+        frame_type, frame_ptr, frame_field, "param.ptr");
+    builder.CreateStore(&arg, field_ptr);
+    ++frame_field;
+  }
+
+  // Return the frame pointer.
+  builder.CreateRet(frame_ptr);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Generator resume function lowering
+// ---------------------------------------------------------------------------
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+auto LlvmBackend::lower_generator_resume(const MirFunction& fn) -> bool {
+  if (fn.symbol == nullptr || fn.is_extern) {
+    return true;
+  }
+
+  auto resume_name = std::string(fn.symbol->name) + ".resume";
+  auto* resume_fn = module_->getFunction(resume_name);
+  if (resume_fn == nullptr) {
+    emit_diagnostic(fn.span,
+                    "resume function not declared: " + resume_name);
+    return false;
+  }
+
+  auto* frame_type = create_generator_frame_type(fn);
+  if (frame_type == nullptr) {
+    emit_diagnostic(fn.span, "cannot create generator frame type");
+    return false;
+  }
+
+  auto* frame_arg = resume_fn->getArg(0);
+  frame_arg->setName("frame");
+
+  FunctionState state;
+  state.llvm_fn = resume_fn;
+  state.gen_frame_ptr = frame_arg;
+  state.gen_frame_type = frame_type;
+
+  llvm::IRBuilder<> builder(ctx_);
+  state.builder = &builder;
+
+  // --- Pre-scan: count yield points ---
+  uint32_t yield_count = 0;
+  for (const auto* block : fn.blocks) {
+    for (const auto* inst : block->insts) {
+      if (std::holds_alternative<MirYieldInst>(inst->payload)) {
+        ++yield_count;
+      }
+    }
+  }
+
+  // --- Create entry block first (must be first for LLVM entry) ---
+  auto* entry_bb = llvm::BasicBlock::Create(ctx_, "entry", resume_fn);
+
+  // --- Create LLVM blocks for MIR blocks ---
+  for (const auto* block : fn.blocks) {
+    auto* llvm_block = llvm::BasicBlock::Create(
+        ctx_, "bb" + std::to_string(block->id.id), resume_fn);
+    state.blocks[block->id.id] = llvm_block;
+  }
+
+  // --- Create resume blocks for each yield point ---
+  std::vector<llvm::BasicBlock*> resume_blocks;
+  for (uint32_t i = 0; i < yield_count; ++i) {
+    auto* bb = llvm::BasicBlock::Create(
+        ctx_, "resume." + std::to_string(i + 1), resume_fn);
+    resume_blocks.push_back(bb);
+  }
+
+  auto* unreachable_bb =
+      llvm::BasicBlock::Create(ctx_, "unreachable", resume_fn);
+
+  // --- Entry block: compute frame GEPs for locals, then dispatch ---
+  builder.SetInsertPoint(entry_bb);
+
+  // Set up frame-based locals (GEPs at field indices 3+).
+  uint32_t frame_field = 3;
+  for (const auto& local : fn.locals) {
+    auto name = local.symbol != nullptr
+        ? std::string(local.symbol->name) + ".ptr"
+        : "local." + std::to_string(local.id.id) + ".ptr";
+    auto* gep = builder.CreateStructGEP(
+        frame_type, frame_arg, frame_field, name);
+    state.locals[local.id.id] = gep;
+    state.local_types[local.id.id] = local.type;
+    ++frame_field;
+  }
+
+  // Load state and dispatch.
+  auto* state_ptr = builder.CreateStructGEP(
+      frame_type, frame_arg, 0, "state.ptr");
+  auto* state_val = builder.CreateLoad(
+      llvm::Type::getInt32Ty(ctx_), state_ptr, "state");
+
+  auto* sw = builder.CreateSwitch(
+      state_val, unreachable_bb, yield_count + 1);
+  sw->addCase(builder.getInt32(0),
+              state.blocks[fn.blocks[0]->id.id]);
+  for (uint32_t i = 0; i < yield_count; ++i) {
+    sw->addCase(builder.getInt32(i + 1), resume_blocks[i]);
+  }
+
+  // --- Unreachable block: set done, ret void ---
+  builder.SetInsertPoint(unreachable_bb);
+  auto* done_unr = builder.CreateStructGEP(
+      frame_type, frame_arg, 1, "done.ptr");
+  builder.CreateStore(builder.getTrue(), done_unr);
+  builder.CreateRetVoid();
+
+  // --- Lower MIR blocks with yield splitting ---
+  uint32_t yield_idx = 0;
+  for (const auto* block : fn.blocks) {
+    builder.SetInsertPoint(state.blocks[block->id.id]);
+
+    for (const auto* inst : block->insts) {
+      const auto* yp = std::get_if<MirYieldInst>(&inst->payload);
+      if (yp != nullptr) {
+        // Store value to yield slot (frame field 2).
+        auto* val = get_value(yp->value, state);
+        if (val == nullptr) {
+          emit_diagnostic(inst->span, "yield value not found");
+          return false;
+        }
+        auto* yield_ptr = builder.CreateStructGEP(
+            frame_type, frame_arg, 2, "yield.ptr");
+        builder.CreateStore(val, yield_ptr);
+
+        // Store next state number.
+        auto* st_ptr = builder.CreateStructGEP(
+            frame_type, frame_arg, 0, "state.ptr");
+        builder.CreateStore(
+            builder.getInt32(yield_idx + 1), st_ptr);
+
+        // Return to caller.
+        builder.CreateRetVoid();
+
+        // Remaining instructions continue in resume block.
+        builder.SetInsertPoint(resume_blocks[yield_idx]);
+        ++yield_idx;
+      } else {
+        if (!lower_inst(*inst, state)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Iterator operations (consumer side)
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::lower_iter_init(const MirIterInit& p, const MirInst& inst,
+                                    FunctionState& state) -> bool {
+  auto* frame_ptr = get_value(p.iter_operand, state);
+  if (frame_ptr == nullptr) {
+    emit_diagnostic(inst.span, "iter_init: generator value not found");
+    return false;
+  }
+
+  // Look up the resume function tracked from the call that produced
+  // the generator frame.
+  auto resume_it = state.iter_resume_fns.find(p.iter_operand.id);
+  if (resume_it == state.iter_resume_fns.end()) {
+    emit_diagnostic(inst.span, "iter_init: cannot find resume function");
+    return false;
+  }
+  auto* resume_fn = resume_it->second;
+
+  // Call resume to advance to the first yield point (or completion).
+  state.builder->CreateCall(
+      resume_fn->getFunctionType(), resume_fn, {frame_ptr});
+
+  // Propagate tracking to iter_init result for has_next/next/destroy.
+  state.values[inst.result.id] = frame_ptr;
+  state.value_types[inst.result.id] = inst.type;
+  state.iter_resume_fns[inst.result.id] = resume_fn;
+
+  auto yield_it = state.iter_yield_types.find(p.iter_operand.id);
+  if (yield_it != state.iter_yield_types.end()) {
+    state.iter_yield_types[inst.result.id] = yield_it->second;
+  }
+
+  return true;
+}
+
+auto LlvmBackend::lower_iter_has_next(const MirIterHasNext& p,
+                                        const MirInst& inst,
+                                        FunctionState& state) -> bool {
+  auto* frame_ptr = get_value(p.iter_operand, state);
+  if (frame_ptr == nullptr) {
+    emit_diagnostic(inst.span, "iter_has_next: iterator not found");
+    return false;
+  }
+
+  auto yield_it = state.iter_yield_types.find(p.iter_operand.id);
+  if (yield_it == state.iter_yield_types.end()) {
+    emit_diagnostic(inst.span, "iter_has_next: unknown yield type");
+    return false;
+  }
+  auto* yield_llvm = types_.lower(yield_it->second);
+  if (yield_llvm == nullptr) {
+    emit_diagnostic(inst.span,
+                    "iter_has_next: cannot lower yield type: " +
+                    types_.error());
+    return false;
+  }
+
+  // Consumer view of the frame header: { i32 state, i1 done, T yield_slot }.
+  auto* view = llvm::StructType::get(ctx_, {
+      llvm::Type::getInt32Ty(ctx_),
+      llvm::Type::getInt1Ty(ctx_),
+      yield_llvm});
+
+  auto* done_ptr =
+      state.builder->CreateStructGEP(view, frame_ptr, 1, "done.ptr");
+  auto* done = state.builder->CreateLoad(
+      llvm::Type::getInt1Ty(ctx_), done_ptr, "done");
+  auto* has_next = state.builder->CreateNot(done, "has_next");
+
+  state.values[inst.result.id] = has_next;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_iter_next(const MirIterNext& p,
+                                     const MirInst& inst,
+                                     FunctionState& state) -> bool {
+  auto* frame_ptr = get_value(p.iter_operand, state);
+  if (frame_ptr == nullptr) {
+    emit_diagnostic(inst.span, "iter_next: iterator not found");
+    return false;
+  }
+
+  auto yield_it = state.iter_yield_types.find(p.iter_operand.id);
+  if (yield_it == state.iter_yield_types.end()) {
+    emit_diagnostic(inst.span, "iter_next: unknown yield type");
+    return false;
+  }
+  auto* yield_llvm = types_.lower(yield_it->second);
+  if (yield_llvm == nullptr) {
+    emit_diagnostic(inst.span,
+                    "iter_next: cannot lower yield type: " +
+                    types_.error());
+    return false;
+  }
+
+  // Consumer view of the frame header: { i32 state, i1 done, T yield_slot }.
+  auto* view = llvm::StructType::get(ctx_, {
+      llvm::Type::getInt32Ty(ctx_),
+      llvm::Type::getInt1Ty(ctx_),
+      yield_llvm});
+
+  // Read current yield value.
+  auto* yield_ptr =
+      state.builder->CreateStructGEP(view, frame_ptr, 2, "yield.ptr");
+  auto* yield_val = state.builder->CreateLoad(
+      yield_llvm, yield_ptr, "yield.val");
+
+  // Call resume to advance to next yield point.
+  auto resume_it = state.iter_resume_fns.find(p.iter_operand.id);
+  if (resume_it == state.iter_resume_fns.end()) {
+    emit_diagnostic(inst.span, "iter_next: cannot find resume function");
+    return false;
+  }
+  state.builder->CreateCall(
+      resume_it->second->getFunctionType(),
+      resume_it->second, {frame_ptr});
+
+  state.values[inst.result.id] = yield_val;
+  state.value_types[inst.result.id] = inst.type;
+  return true;
+}
+
+auto LlvmBackend::lower_iter_destroy(const MirIterDestroy& p,
+                                       const MirInst& inst,
+                                       FunctionState& state) -> bool {
+  auto* frame_ptr = get_value(p.iter_operand, state);
+  if (frame_ptr == nullptr) {
+    emit_diagnostic(inst.span, "iter_destroy: iterator not found");
+    return false;
+  }
+
+  auto* free_fn =
+      module_->getFunction(std::string(runtime_hooks::kGenFree));
+  if (free_fn == nullptr) {
+    emit_diagnostic(inst.span,
+                    "iter_destroy: __dao_gen_free not declared");
+    return false;
+  }
+
+  state.builder->CreateCall(
+      free_fn->getFunctionType(), free_fn, {frame_ptr});
   return true;
 }
 

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -1105,16 +1105,29 @@ auto LlvmBackend::lower_generator_init(const MirFunction& fn) -> bool {
   llvm::IRBuilder<> builder(ctx_);
   builder.SetInsertPoint(entry);
 
-  // Compute frame size via GEP-from-null trick (target-independent).
+  // Compute sizeof(frame) and alignof(frame) via GEP-from-null tricks
+  // (target-independent — correct regardless of data layout).
   auto* i64_ty = llvm::Type::getInt64Ty(ctx_);
   auto* null_ptr =
       llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(ctx_));
+
+  // sizeof: offset of element 1 from a null pointer.
   auto* size_gep = builder.CreateGEP(
       frame_type, null_ptr,
       {llvm::ConstantInt::get(i64_ty, 1)}, "sizeof.gep");
   auto* frame_size =
       builder.CreatePtrToInt(size_gep, i64_ty, "frame.size");
-  auto* frame_align = llvm::ConstantInt::get(i64_ty, 8);
+
+  // alignof: offsetof(struct { i8; frame_type }, field_1).
+  auto* align_wrap = llvm::StructType::get(
+      ctx_, {llvm::Type::getInt8Ty(ctx_), frame_type});
+  auto* align_gep = builder.CreateGEP(
+      align_wrap, null_ptr,
+      {llvm::ConstantInt::get(i64_ty, 0),
+       llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx_), 1)},
+      "alignof.gep");
+  auto* frame_align =
+      builder.CreatePtrToInt(align_gep, i64_ty, "frame.align");
 
   // Call __dao_gen_alloc(size, align).
   auto* alloc_fn =

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -74,8 +74,8 @@ private:
     llvm::Function* llvm_fn = nullptr;
     llvm::IRBuilder<>* builder = nullptr;
 
-    // MIR LocalId → LLVM alloca (for named locals / params)
-    std::unordered_map<uint32_t, llvm::AllocaInst*> locals;
+    // MIR LocalId → LLVM pointer (alloca for normal fns, frame GEP for generators)
+    std::unordered_map<uint32_t, llvm::Value*> locals;
 
     // MIR LocalId → semantic Type* (for place resolution)
     std::unordered_map<uint32_t, const Type*> local_types;
@@ -88,6 +88,25 @@ private:
 
     // MIR BlockId → LLVM BasicBlock*
     std::unordered_map<uint32_t, llvm::BasicBlock*> blocks;
+
+    // --- Generator iteration state (consumer side) ---
+
+    // MIR ValueId (from IterInit) → resume function for that generator
+    std::unordered_map<uint32_t, llvm::Function*> iter_resume_fns;
+
+    // MIR ValueId (from IterInit) → yield type (T in Generator<T>)
+    std::unordered_map<uint32_t, const Type*> iter_yield_types;
+
+    // --- Generator function state (producer side) ---
+
+    // Frame pointer (alloca/heap ptr) for the generator being lowered.
+    llvm::Value* gen_frame_ptr = nullptr;
+
+    // Frame struct type for the generator being lowered.
+    llvm::StructType* gen_frame_type = nullptr;
+
+    // Yield-point state index counter.
+    uint32_t gen_next_state = 1;
   };
 
   // Top-level lowering phases (called by lower()).
@@ -130,6 +149,23 @@ private:
                 FunctionState& state) -> bool;
   auto lower_cond_br(const MirCondBr& p, const MirInst& inst,
                      FunctionState& state) -> bool;
+
+  // Generator function lowering
+  static auto is_generator_function(const MirFunction& fn) -> bool;
+  auto create_generator_frame_type(const MirFunction& fn)
+      -> llvm::StructType*;
+  auto lower_generator_init(const MirFunction& fn) -> bool;
+  auto lower_generator_resume(const MirFunction& fn) -> bool;
+
+  // Iterator instruction lowering (consumer side)
+  auto lower_iter_init(const MirIterInit& p, const MirInst& inst,
+                       FunctionState& state) -> bool;
+  auto lower_iter_has_next(const MirIterHasNext& p, const MirInst& inst,
+                           FunctionState& state) -> bool;
+  auto lower_iter_next(const MirIterNext& p, const MirInst& inst,
+                       FunctionState& state) -> bool;
+  auto lower_iter_destroy(const MirIterDestroy& p, const MirInst& inst,
+                          FunctionState& state) -> bool;
 
   // Place resolution — walk projection chains to an LLVM pointer.
   auto resolve_place(const MirPlace& place,

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -771,6 +771,47 @@ suite<"generators"> generators = [] {
     expect(contains(ir, "__dao_gen_free")) << ir;
   };
 
+  "early return from for-loop frees generator frame"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn single(): Generator<i32>\n"
+        "  yield 42\n"
+        "\n"
+        "fn main(): i32\n"
+        "  for x in single():\n"
+        "    return x\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // The early-return path must call __dao_gen_free before returning.
+    // Count occurrences: one for the early-return path, one for the
+    // normal loop-exit path.
+    size_t count = 0;
+    std::string::size_type pos = 0;
+    while ((pos = ir.find("__dao_gen_free", pos)) != std::string::npos) {
+      ++count;
+      ++pos;
+    }
+    expect(count >= 2u) << "expected >=2 gen_free calls (early + normal), got "
+                        << count << "\n" << ir;
+  };
+
+  "init passes alignof to gen_alloc"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn single(): Generator<i32>\n"
+        "  yield 1\n"
+        "\n"
+        "fn main(): i32\n"
+        "  for x in single():\n"
+        "    return x\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // Alignment is computed via GEP-from-null offsetof trick, not
+    // hardcoded.  LLVM constant-folds the GEP to a ConstantExpr,
+    // so we check for the { i8, %frame } wrapper struct pattern.
+    expect(contains(ir, "{ i8, %dao.gen.single }")) << ir;
+  };
+
   "range generator with params"_test = [] {
     LlvmTestPipeline pipe(
         "fn range(start: i32, end: i32): Generator<i32>\n"

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -698,6 +698,103 @@ suite<"runtime_abi"> runtime_abi = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Generator / coroutine lowering
+// ---------------------------------------------------------------------------
+
+suite<"generators"> generators = [] {
+  "generator declares init and resume functions"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn single(): Generator<i32>\n"
+        "  yield 42\n"
+        "\n"
+        "fn main(): i32\n"
+        "  for x in single():\n"
+        "    return x\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // Init function: returns an opaque pointer.
+    expect(contains(ir, "define ptr @single()")) << ir;
+    // Resume function: takes ptr, returns void.
+    expect(contains(ir, "define void @single.resume(ptr")) << ir;
+  };
+
+  "generator init allocates frame"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn single(): Generator<i32>\n"
+        "  yield 1\n"
+        "\n"
+        "fn main(): i32\n"
+        "  for x in single():\n"
+        "    return x\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "__dao_gen_alloc")) << ir;
+    expect(contains(ir, "ret ptr")) << ir;
+  };
+
+  "generator resume has state dispatch"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn single(): Generator<i32>\n"
+        "  yield 42\n"
+        "\n"
+        "fn main(): i32\n"
+        "  for x in single():\n"
+        "    return x\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "switch i32")) << ir;
+    expect(contains(ir, "yield.ptr")) << ir;
+  };
+
+  "for-loop over generator produces iterator ops"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn nums(): Generator<i32>\n"
+        "  yield 1\n"
+        "  yield 2\n"
+        "\n"
+        "fn main(): i32\n"
+        "  let sum: i32 = 0\n"
+        "  for x in nums():\n"
+        "    sum = sum + x\n"
+        "  return sum\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // Consumer calls resume, reads done flag, reads yield slot.
+    expect(contains(ir, "call void @nums.resume")) << ir;
+    expect(contains(ir, "done.ptr")) << ir;
+    expect(contains(ir, "yield.val")) << ir;
+    // Destroy calls __dao_gen_free.
+    expect(contains(ir, "__dao_gen_free")) << ir;
+  };
+
+  "range generator with params"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn range(start: i32, end: i32): Generator<i32>\n"
+        "  let i: i32 = start\n"
+        "  while i < end:\n"
+        "    yield i\n"
+        "    i = i + 1\n"
+        "\n"
+        "fn main(): i32\n"
+        "  let sum: i32 = 0\n"
+        "  for x in range(0, 5):\n"
+        "    sum = sum + x\n"
+        "  return sum\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // Init function takes params.
+    expect(contains(ir, "define ptr @range(i32 %start, i32 %end)")) << ir;
+    // Resume function.
+    expect(contains(ir, "define void @range.resume(ptr")) << ir;
+    // Frame type exists.
+    expect(contains(ir, "dao.gen.range")) << ir;
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -21,6 +21,7 @@ void LlvmRuntimeHooks::declare_all() {
   declare_io_hooks();
   declare_equality_hooks();
   declare_conversion_hooks();
+  declare_generator_hooks();
 }
 
 auto LlvmRuntimeHooks::is_runtime_hook(std::string_view name) -> bool {
@@ -94,6 +95,25 @@ void LlvmRuntimeHooks::declare_conversion_hooks() {
   auto* i1 = llvm::Type::getInt1Ty(ctx);
   ensure_declared(runtime_hooks::kConvBoolToString,
                   llvm::FunctionType::get(str_type, {i1}, false));
+}
+
+// ---------------------------------------------------------------------------
+// Generator hooks
+// ---------------------------------------------------------------------------
+
+void LlvmRuntimeHooks::declare_generator_hooks() {
+  auto& ctx = module_.getContext();
+  auto* ptr = llvm::PointerType::getUnqual(ctx);
+  auto* i64 = llvm::Type::getInt64Ty(ctx);
+  auto* void_ty = llvm::Type::getVoidTy(ctx);
+
+  // __dao_gen_alloc(size: i64, align: i64): ptr
+  ensure_declared(runtime_hooks::kGenAlloc,
+                  llvm::FunctionType::get(ptr, {i64, i64}, false));
+
+  // __dao_gen_free(ptr): void
+  ensure_declared(runtime_hooks::kGenFree,
+                  llvm::FunctionType::get(void_ty, {ptr}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -43,11 +43,16 @@ inline constexpr std::string_view kConvI32ToString  = "__dao_conv_i32_to_string"
 inline constexpr std::string_view kConvF64ToString  = "__dao_conv_f64_to_string";
 inline constexpr std::string_view kConvBoolToString = "__dao_conv_bool_to_string";
 
+// Generator domain
+inline constexpr std::string_view kGenAlloc = "__dao_gen_alloc";
+inline constexpr std::string_view kGenFree  = "__dao_gen_free";
+
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
     kWriteStdout,
     kEqI32,    kEqF64,    kEqBool,    kEqString,
     kConvI32ToString, kConvF64ToString, kConvBoolToString,
+    kGenAlloc, kGenFree,
 };
 
 } // namespace runtime_hooks
@@ -74,6 +79,7 @@ private:
   void declare_io_hooks();
   void declare_equality_hooks();
   void declare_conversion_hooks();
+  void declare_generator_hooks();
 
   // Helper: get-or-create a function declaration.
   auto ensure_declared(std::string_view name, llvm::FunctionType* fn_type)

--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -75,8 +75,8 @@ auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
   }
 
   case TypeKind::Generator:
-    error_ = "generator/coroutine type lowering not yet implemented";
-    return nullptr;
+    // Generator<T> is an opaque pointer to a compiler-generated frame.
+    return llvm::PointerType::getUnqual(ctx_);
   }
 
   error_ = "unknown type kind";

--- a/compiler/ir/mir/mir.cpp
+++ b/compiler/ir/mir/mir.cpp
@@ -27,6 +27,7 @@ auto MirInst::kind() const -> MirInstKind {
       [](const MirIterInit&)      { return MirInstKind::IterInit; },
       [](const MirIterHasNext&)   { return MirInstKind::IterHasNext; },
       [](const MirIterNext&)      { return MirInstKind::IterNext; },
+      [](const MirIterDestroy&)   { return MirInstKind::IterDestroy; },
       [](const MirYieldInst&)     { return MirInstKind::Yield; },
       [](const MirModeEnter&)     { return MirInstKind::ModeEnter; },
       [](const MirModeExit&)      { return MirInstKind::ModeExit; },
@@ -62,6 +63,7 @@ auto mir_inst_kind_name(MirInstKind kind) -> const char* {
   case MirInstKind::IterInit:       return "iter_init";
   case MirInstKind::IterHasNext:    return "iter_has_next";
   case MirInstKind::IterNext:       return "iter_next";
+  case MirInstKind::IterDestroy:   return "iter_destroy";
   case MirInstKind::Yield:          return "yield";
   case MirInstKind::ModeEnter:      return "mode_enter";
   case MirInstKind::ModeExit:       return "mode_exit";

--- a/compiler/ir/mir/mir.h
+++ b/compiler/ir/mir/mir.h
@@ -97,6 +97,7 @@ struct MirConstruct { const TypeStruct* struct_type; std::vector<MirValueId>* fi
 struct MirIterInit    { MirValueId iter_operand; };
 struct MirIterHasNext { MirValueId iter_operand; };
 struct MirIterNext    { MirValueId iter_operand; };
+struct MirIterDestroy { MirValueId iter_operand; };
 
 struct MirYieldInst   { MirValueId value; };
 
@@ -122,7 +123,7 @@ using MirPayload = std::variant<
     MirStore, MirLoad, MirAddrOf,
     MirFieldAccess, MirIndexAccess,
     MirFnRef, MirCall, MirConstruct,
-    MirIterInit, MirIterHasNext, MirIterNext,
+    MirIterInit, MirIterHasNext, MirIterNext, MirIterDestroy,
     MirYieldInst,
     MirModeEnter, MirModeExit, MirResourceEnter, MirResourceExit,
     MirLambdaInst,

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -275,6 +275,8 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         }
 
         switch_to_block(exit_bb);
+        // Free the generator frame when the for-loop exits.
+        emit_effect(stmt.span, MirIterDestroy{iter_val});
       },
       [&](const HirYield& yield) {
         auto val = lower_expr_value(*yield.value);

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -267,6 +267,11 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         place->local = var_local;
         emit_effect(stmt.span, MirStore{place, next_val});
 
+        // Push iterator cleanup so early returns inside the body
+        // emit MirIterDestroy before the return terminator.
+        active_regions_.push_back(
+            ActiveRegion{MirIterDestroy{iter_val}, stmt.span});
+
         for (const auto* s : hir_for.body) {
           lower_stmt(*s);
         }
@@ -274,8 +279,10 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
           emit_terminator(stmt.span, MirBr{cond_bb->id});
         }
 
+        active_regions_.pop_back();
+
         switch_to_block(exit_bb);
-        // Free the generator frame when the for-loop exits.
+        // Free the generator frame on the normal loop-exit path.
         emit_effect(stmt.span, MirIterDestroy{iter_val});
       },
       [&](const HirYield& yield) {

--- a/compiler/ir/mir/mir_kind.h
+++ b/compiler/ir/mir/mir_kind.h
@@ -38,6 +38,7 @@ enum class MirInstKind : std::uint8_t {
   IterInit,
   IterHasNext,
   IterNext,
+  IterDestroy,
 
   // Coroutine
   Yield,

--- a/compiler/ir/mir/mir_printer.cpp
+++ b/compiler/ir/mir/mir_printer.cpp
@@ -163,6 +163,9 @@ private:
         [&](const MirIterNext& p) {
           out_ << "iter_next %" << p.iter_operand.id;
         },
+        [&](const MirIterDestroy& p) {
+          out_ << "iter_destroy %" << p.iter_operand.id;
+        },
         [&](const MirYieldInst& p) {
           out_ << "yield %" << p.value.id;
         },

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -55,6 +55,7 @@ Domains:
 | `io`       | Output, input (currently stdout only)      |
 | `eq`       | Equality comparison                        |
 | `conv`     | Value-to-value conversion (e.g. to_string) |
+| `gen`      | Generator frame allocation and lifetime    |
 
 Examples:
 
@@ -68,6 +69,8 @@ Examples:
 | `__dao_conv_i32_to_string`| `(x: i32): string`                   |
 | `__dao_conv_f64_to_string`| `(x: f64): string`                   |
 | `__dao_conv_bool_to_string`| `(x: bool): string`                 |
+| `__dao_gen_alloc`         | `(size: i64, align: i64): *void`     |
+| `__dao_gen_free`          | `(ptr: *void): void`                 |
 
 These are the **only** runtime hooks in the current supported slice.
 New hooks require updating this contract before implementation.
@@ -116,6 +119,14 @@ Properties:
 - **Return values**: string-returning hooks return the struct **by
   value** (`struct dao_string`). The caller receives a copy.
 
+### Generator type representation
+
+`Generator<T>` is represented at the ABI boundary as an opaque pointer
+to a compiler-generated frame struct. The frame layout is private to the
+backend and may vary per generator function. Consumer code accesses the
+generator exclusively through the `__dao_gen_*` hooks and
+compiler-generated resume functions.
+
 ## Ownership and lifetime rules
 
 For the current supported hook slice:
@@ -135,9 +146,10 @@ For the current supported hook slice:
    same thread. Callers must consume or copy the result before the
    next conversion call.
 
-4. **No caller-managed deallocation.** No hook in the current slice
-   requires the caller to free memory. If future hooks introduce
-   allocation, this contract must be updated first.
+4. **Generator frames are caller-managed.** Generator frames are
+   allocated by `__dao_gen_alloc` and must be freed by
+   `__dao_gen_free` when the iterator is no longer needed. The
+   compiler inserts the free call at for-loop exit.
 
 ## Stability
 

--- a/runtime/core/CMakeLists.txt
+++ b/runtime/core/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(dao_runtime STATIC
   io.c
   equality.c
   convert.c
+  generator.c
 )
 
 # This is C code, not C++.

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -64,6 +64,18 @@ struct dao_string __dao_conv_i32_to_string(int32_t x);
 struct dao_string __dao_conv_f64_to_string(double x);
 struct dao_string __dao_conv_bool_to_string(bool x);
 
+// ---------------------------------------------------------------------------
+// Runtime hook declarations — Generator domain
+// ---------------------------------------------------------------------------
+
+// Allocate a generator frame of the given size and alignment.
+// Returns a zeroed block. The caller (compiler-generated init function)
+// populates the frame after allocation.
+void *__dao_gen_alloc(int64_t size, int64_t align);
+
+// Free a generator frame previously allocated by __dao_gen_alloc.
+void __dao_gen_free(void *ptr);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/runtime/core/generator.c
+++ b/runtime/core/generator.c
@@ -9,10 +9,13 @@
 #include <string.h>
 
 void *__dao_gen_alloc(int64_t size, int64_t align) {
-  (void)align; // For first cut, rely on malloc's natural alignment.
-  void *ptr = malloc((size_t)size);
+  size_t a = (size_t)align;
+  size_t s = (size_t)size;
+  // aligned_alloc requires size to be a multiple of alignment.
+  size_t padded = (s + a - 1) & ~(a - 1);
+  void *ptr = aligned_alloc(a, padded);
   if (ptr != NULL) {
-    memset(ptr, 0, (size_t)size);
+    memset(ptr, 0, s);
   }
   return ptr;
 }

--- a/runtime/core/generator.c
+++ b/runtime/core/generator.c
@@ -1,0 +1,20 @@
+// generator.c — Generator frame allocation for the Dao runtime.
+//
+// Generator frames are heap-allocated by the compiler-generated init
+// function and freed when the for-loop iterator is destroyed.
+
+#include "dao_abi.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void *__dao_gen_alloc(int64_t size, int64_t align) {
+  (void)align; // For first cut, rely on malloc's natural alignment.
+  void *ptr = malloc((size_t)size);
+  if (ptr != NULL) {
+    memset(ptr, 0, (size_t)size);
+  }
+  return ptr;
+}
+
+void __dao_gen_free(void *ptr) { free(ptr); }

--- a/runtime/core/generator.c
+++ b/runtime/core/generator.c
@@ -9,7 +9,14 @@
 #include <string.h>
 
 void *__dao_gen_alloc(int64_t size, int64_t align) {
+  // Clamp alignment to at least sizeof(void*) — aligned_alloc requires
+  // a power-of-two alignment that the implementation supports, and
+  // values below pointer size are not guaranteed to be accepted.
+  size_t min_align = sizeof(void *);
   size_t a = (size_t)align;
+  if (a < min_align) {
+    a = min_align;
+  }
   size_t s = (size_t)size;
   // aligned_alloc requires size to be a multiple of alignment.
   size_t padded = (s + a - 1) & ~(a - 1);


### PR DESCRIPTION
## Summary

Implements TASK_13: stackless generator coroutines via manual state machine transform in the LLVM backend. Each generator function `foo(...) → Generator<T>` is split into an init function (heap-allocates a frame, stores params) and a resume function (state-dispatch switch with yield-point splitting). Consumer-side for-loops are lowered through `iter_init`/`iter_has_next`/`iter_next`/`iter_destroy` operations that drive the resume function and manage frame lifetime via runtime hooks.

## Highlights

- **State machine transform**: Generator functions are split into `@name(params…) → ptr` (init) and `@name.resume(ptr) → void` (resume) with a switch-based state dispatch
- **Frame layout**: `{ i32 state, i1 done, T yield_slot, spilled_locals… }` — all locals spilled to heap frame (conservative first-cut)
- **Runtime hooks**: `__dao_gen_alloc(size, align)` and `__dao_gen_free(ptr)` for frame lifecycle, declared in `CONTRACT_RUNTIME_ABI.md`
- **MIR `iter_destroy`**: New MIR instruction emitted after for-loop exit to free generator frames
- **`Generator<T>` → `ptr`**: Type lowering produces opaque pointer for generator types
- **Consumer-side lowering**: `iter_init` calls resume to prime first value, `iter_has_next` checks `!done`, `iter_next` reads yield slot then advances, `iter_destroy` frees frame

## Test plan

- [x] All 10 existing test suites pass (45 total tests including 5 new generator tests)
- [x] `generators` suite: init/resume declaration, frame allocation, state dispatch, iterator ops, parameterized range generator
- [x] Existing function/arithmetic/control-flow/string/struct/runtime-ABI tests unaffected
- [ ] E2E compile-and-run validation (requires linker integration with runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)