### PR TITLE
feat(compiler): ✨ implement monomorphization pass for generic functions

### DIFF
--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -11,6 +11,7 @@
 #include "backend/llvm/llvm_backend.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
+#include "ir/mir/mir_monomorphize.h"
 #include "ir/mir/mir_printer.h"
 
 #include <llvm/IR/LLVMContext.h>
@@ -274,6 +275,15 @@ auto run_through_mir(const std::filesystem::path& path) -> MirResult {
 
   if (mir.module == nullptr || has_errors) {
     std::exit(EXIT_FAILURE);
+  }
+
+  // Monomorphize generic functions before LLVM lowering.
+  auto mono_result =
+      dao::monomorphize(*mir.module, mir_ctx, hir_result.frontend.types);
+  if (!mono_result.diagnostics.empty()) {
+    print_error_diagnostics(filename, hir_result.frontend.parsed.source,
+                            mono_result.diagnostics,
+                            hir_result.frontend.prelude_lines);
   }
 
   return {.hir_result = std::move(hir_result),

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1135,6 +1135,106 @@ auto TypeChecker::check_unary(const Expr* expr) -> const Type* {
 }
 
 // ---------------------------------------------------------------------------
+// Generic type inference and substitution helpers
+// ---------------------------------------------------------------------------
+
+void TypeChecker::infer_type_bindings(
+    const Type* pattern, const Type* concrete,
+    std::unordered_map<uint32_t, const Type*>& bindings, Span error_span) {
+  if (pattern == nullptr || concrete == nullptr) {
+    return;
+  }
+
+  if (pattern->kind() == TypeKind::GenericParam) {
+    const auto* gp = static_cast<const TypeGenericParam*>(pattern);
+    auto it = bindings.find(gp->index());
+    if (it != bindings.end()) {
+      // Already bound — check consistency.
+      if (it->second != concrete) {
+        error(error_span,
+              "conflicting types for generic parameter '" +
+                  std::string(gp->name()) + "': '" +
+                  print_type(it->second) + "' vs '" +
+                  print_type(concrete) + "'");
+      }
+    } else {
+      bindings[gp->index()] = concrete;
+    }
+    return;
+  }
+
+  // Structural recursion for composite types.
+  if (pattern->kind() == TypeKind::Pointer &&
+      concrete->kind() == TypeKind::Pointer) {
+    infer_type_bindings(
+        static_cast<const TypePointer*>(pattern)->pointee(),
+        static_cast<const TypePointer*>(concrete)->pointee(),
+        bindings, error_span);
+  } else if (pattern->kind() == TypeKind::Generator &&
+             concrete->kind() == TypeKind::Generator) {
+    infer_type_bindings(
+        static_cast<const TypeGenerator*>(pattern)->yield_type(),
+        static_cast<const TypeGenerator*>(concrete)->yield_type(),
+        bindings, error_span);
+  } else if (pattern->kind() == TypeKind::Function &&
+             concrete->kind() == TypeKind::Function) {
+    const auto* fp = static_cast<const TypeFunction*>(pattern);
+    const auto* fc = static_cast<const TypeFunction*>(concrete);
+    if (fp->param_types().size() == fc->param_types().size()) {
+      for (size_t j = 0; j < fp->param_types().size(); ++j) {
+        infer_type_bindings(fp->param_types()[j], fc->param_types()[j],
+                            bindings, error_span);
+      }
+      infer_type_bindings(fp->return_type(), fc->return_type(),
+                          bindings, error_span);
+    }
+  }
+}
+
+auto TypeChecker::substitute_generics(
+    const Type* type,
+    const std::unordered_map<uint32_t, const Type*>& bindings)
+    -> const Type* {
+  if (type == nullptr || bindings.empty()) {
+    return type;
+  }
+
+  switch (type->kind()) {
+  case TypeKind::GenericParam: {
+    const auto* gp = static_cast<const TypeGenericParam*>(type);
+    auto it = bindings.find(gp->index());
+    return it != bindings.end() ? it->second : type;
+  }
+  case TypeKind::Pointer: {
+    const auto* ptr = static_cast<const TypePointer*>(type);
+    const auto* sub = substitute_generics(ptr->pointee(), bindings);
+    return sub == ptr->pointee() ? type : types_.pointer_to(sub);
+  }
+  case TypeKind::Generator: {
+    const auto* gen = static_cast<const TypeGenerator*>(type);
+    const auto* sub = substitute_generics(gen->yield_type(), bindings);
+    return sub == gen->yield_type() ? type : types_.generator_type(sub);
+  }
+  case TypeKind::Function: {
+    const auto* fn = static_cast<const TypeFunction*>(type);
+    bool changed = false;
+    std::vector<const Type*> params;
+    params.reserve(fn->param_types().size());
+    for (const auto* param : fn->param_types()) {
+      const auto* sub = substitute_generics(param, bindings);
+      if (sub != param) changed = true;
+      params.push_back(sub);
+    }
+    const auto* ret = substitute_generics(fn->return_type(), bindings);
+    if (ret != fn->return_type()) changed = true;
+    return changed ? types_.function_type(std::move(params), ret) : type;
+  }
+  default:
+    return type;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Call expressions
 // ---------------------------------------------------------------------------
 
@@ -1189,24 +1289,13 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
                 "' is not assignable to parameter type '" +
                 print_type(params[i]) + "'");
     }
-    // Record binding: generic param → concrete argument type.
-    if (params[i]->kind() == TypeKind::GenericParam) {
-      const auto* gp = static_cast<const TypeGenericParam*>(params[i]);
-      type_bindings[gp->index()] = arg_type;
-    }
+    // Infer generic bindings by structural matching.
+    infer_type_bindings(params[i], arg_type, type_bindings,
+                        call.args[i]->span);
   }
 
-  // Substitute generic return type if it's a type parameter.
-  const auto* ret = fn_type->return_type();
-  if (ret != nullptr && ret->kind() == TypeKind::GenericParam) {
-    const auto* gp = static_cast<const TypeGenericParam*>(ret);
-    auto it = type_bindings.find(gp->index());
-    if (it != type_bindings.end()) {
-      return it->second;
-    }
-  }
-
-  return ret;
+  // Substitute generic params in the return type.
+  return substitute_generics(fn_type->return_type(), type_bindings);
 }
 
 // ---------------------------------------------------------------------------
@@ -1307,8 +1396,12 @@ auto TypeChecker::check_field(const Expr* expr) -> const Type* {
   }
 
   // Try method lookup on any type (struct conformances + extend decls).
-  const auto* method_type = lookup_method(obj_type, field.field);
+  const Decl* method_decl = nullptr;
+  const auto* method_type = lookup_method(obj_type, field.field, &method_decl);
   if (method_type != nullptr) {
+    if (method_decl != nullptr) {
+      typed_.set_method_resolution(expr, method_decl);
+    }
     return method_type;
   }
 
@@ -1329,7 +1422,8 @@ auto TypeChecker::check_field(const Expr* expr) -> const Type* {
 // ---------------------------------------------------------------------------
 
 auto TypeChecker::lookup_method(const Type* obj_type,
-                                std::string_view name) -> const Type* {
+                                std::string_view name,
+                                const Decl** resolved_decl) -> const Type* {
   // Helper: given a FunctionDecl method, build a function type with
   // the self parameter removed (receiver is already bound).
   auto method_fn_type = [&](const FunctionDecl& method) -> const Type* {
@@ -1368,6 +1462,9 @@ auto TypeChecker::lookup_method(const Type* obj_type,
           for (const auto* method_decl : conf.methods) {
             const auto& method = method_decl->as<FunctionDecl>();
             if (method.name == name) {
+              if (resolved_decl != nullptr) {
+                *resolved_decl = method_decl;
+              }
               return method_fn_type(method);
             }
           }
@@ -1390,6 +1487,9 @@ auto TypeChecker::lookup_method(const Type* obj_type,
       for (const auto* method_decl : ext.methods) {
         const auto& method = method_decl->as<FunctionDecl>();
         if (method.name == name) {
+          if (resolved_decl != nullptr) {
+            *resolved_decl = method_decl;
+          }
           return method_fn_type(method);
         }
       }
@@ -1442,17 +1542,33 @@ auto TypeChecker::lookup_method(const Type* obj_type,
   }
 
   // 4. Search derived conformances — concept method signatures.
-  //    Set concept_self_map_ so that the concept name in type position
-  //    resolves to the receiver type (§3.2).
+  //    When a match is found, try to resolve the concrete extend
+  //    implementation for method dispatch lowering.
   auto derived_it = derived_conformances_.find(obj_type);
   if (derived_it != derived_conformances_.end()) {
     auto saved_csm = concept_self_map_;
     for (const auto* concept_decl : derived_it->second) {
       const auto& cpt = concept_decl->as<ConceptDecl>();
       concept_self_map_[cpt.name] = obj_type;
-      for (const auto* method_decl : cpt.methods) {
-        const auto& method = method_decl->as<FunctionDecl>();
+      for (const auto* cpt_method_decl : cpt.methods) {
+        const auto& method = cpt_method_decl->as<FunctionDecl>();
         if (method.name == name) {
+          // Find the extend implementation for this type + method.
+          if (resolved_decl != nullptr && file_ != nullptr) {
+            for (const auto* decl : file_->declarations) {
+              if (decl->kind() != NodeKind::ExtendDecl) continue;
+              const auto& ext = decl->as<ExtendDecl>();
+              const auto* target = resolve_type_node(ext.target_type);
+              if (target != obj_type) continue;
+              for (const auto* ext_method : ext.methods) {
+                if (ext_method->as<FunctionDecl>().name == name) {
+                  *resolved_decl = ext_method;
+                  break;
+                }
+              }
+              if (*resolved_decl != nullptr) break;
+            }
+          }
           auto result = method_fn_type(method);
           concept_self_map_ = saved_csm;
           return result;

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1402,7 +1402,7 @@ auto TypeChecker::check_pipe(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
-  // LHS becomes first argument.
+  // LHS becomes first argument — check assignability and infer generics.
   if (!is_assignable(lhs_type, params[0])) {
     error(pipe.left->span,
           "pipe source type '" + print_type(lhs_type) +
@@ -1411,7 +1411,52 @@ auto TypeChecker::check_pipe(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
-  return fn_type->return_type();
+  // Infer generic type bindings from the pipe's first argument.
+  std::unordered_map<uint32_t, const Type*> type_bindings;
+  infer_type_bindings(params[0], lhs_type, type_bindings, pipe.left->span);
+
+  // Verify concept constraints on inferred bindings.
+  if (!type_bindings.empty() && pipe.right->is<IdentifierExpr>()) {
+    auto sym_it = resolve_.uses.find(pipe.right->span.offset);
+    if (sym_it != resolve_.uses.end() &&
+        sym_it->second->kind == SymbolKind::Function &&
+        sym_it->second->decl != nullptr) {
+      const auto* fn_decl =
+          static_cast<const Decl*>(sym_it->second->decl);
+      if (fn_decl->is<FunctionDecl>()) {
+        const auto& callee_fn = fn_decl->as<FunctionDecl>();
+        for (const auto& gp_decl : callee_fn.type_params) {
+          auto idx = static_cast<uint32_t>(
+              &gp_decl - callee_fn.type_params.data());
+          auto binding_it = type_bindings.find(idx);
+          if (binding_it == type_bindings.end()) {
+            continue;
+          }
+          for (const auto* constraint : gp_decl.constraints) {
+            auto csym_it = resolve_.uses.find(constraint->span.offset);
+            if (csym_it == resolve_.uses.end() ||
+                csym_it->second->kind != SymbolKind::Concept ||
+                csym_it->second->decl == nullptr) {
+              continue;
+            }
+            const auto* concept_decl =
+                static_cast<const Decl*>(csym_it->second->decl);
+            if (!type_conforms_to(binding_it->second, concept_decl)) {
+              error(expr->span,
+                    "type '" + print_type(binding_it->second) +
+                        "' does not satisfy concept '" +
+                        std::string(csym_it->second->name) +
+                        "' required by generic parameter '" +
+                        std::string(gp_decl.name) + "'");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Substitute generic params in the return type.
+  return substitute_generics(fn_type->return_type(), type_bindings);
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1294,6 +1294,46 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
                         call.args[i]->span);
   }
 
+  // Verify concept constraints on inferred generic bindings.
+  if (!type_bindings.empty() && call.callee->is<IdentifierExpr>()) {
+    auto sym_it = resolve_.uses.find(call.callee->span.offset);
+    if (sym_it != resolve_.uses.end() &&
+        sym_it->second->kind == SymbolKind::Function &&
+        sym_it->second->decl != nullptr) {
+      const auto* fn_decl =
+          static_cast<const Decl*>(sym_it->second->decl);
+      if (fn_decl->is<FunctionDecl>()) {
+        const auto& fn = fn_decl->as<FunctionDecl>();
+        for (const auto& gp_decl : fn.type_params) {
+          // Find the index for this generic param.
+          auto idx = static_cast<uint32_t>(&gp_decl - fn.type_params.data());
+          auto binding_it = type_bindings.find(idx);
+          if (binding_it == type_bindings.end()) {
+            continue;
+          }
+          for (const auto* constraint : gp_decl.constraints) {
+            auto csym_it = resolve_.uses.find(constraint->span.offset);
+            if (csym_it == resolve_.uses.end() ||
+                csym_it->second->kind != SymbolKind::Concept ||
+                csym_it->second->decl == nullptr) {
+              continue;
+            }
+            const auto* concept_decl =
+                static_cast<const Decl*>(csym_it->second->decl);
+            if (!type_conforms_to(binding_it->second, concept_decl)) {
+              error(expr->span,
+                    "type '" + print_type(binding_it->second) +
+                        "' does not satisfy concept '" +
+                        std::string(csym_it->second->name) +
+                        "' required by generic parameter '" +
+                        std::string(gp_decl.name) + "'");
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Substitute generic params in the return type.
   return substitute_generics(fn_type->return_type(), type_bindings);
 }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1174,18 +1174,39 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
+  // Check arguments and infer generic type bindings from call site.
+  // type_bindings maps generic param index → concrete type.
+  std::unordered_map<uint32_t, const Type*> type_bindings;
+
   for (size_t i = 0; i < params.size(); ++i) {
     const auto* arg_type = check_expr(call.args[i]);
-    if (arg_type != nullptr && params[i] != nullptr &&
-        !is_assignable(arg_type, params[i])) {
+    if (arg_type == nullptr || params[i] == nullptr) {
+      continue;
+    }
+    if (!is_assignable(arg_type, params[i])) {
       error(call.args[i]->span,
             "argument type '" + print_type(arg_type) +
                 "' is not assignable to parameter type '" +
                 print_type(params[i]) + "'");
     }
+    // Record binding: generic param → concrete argument type.
+    if (params[i]->kind() == TypeKind::GenericParam) {
+      const auto* gp = static_cast<const TypeGenericParam*>(params[i]);
+      type_bindings[gp->index()] = arg_type;
+    }
   }
 
-  return fn_type->return_type();
+  // Substitute generic return type if it's a type parameter.
+  const auto* ret = fn_type->return_type();
+  if (ret != nullptr && ret->kind() == TypeKind::GenericParam) {
+    const auto* gp = static_cast<const TypeGenericParam*>(ret);
+    auto it = type_bindings.find(gp->index());
+    if (it != type_bindings.end()) {
+      return it->second;
+    }
+  }
+
+  return ret;
 }
 
 // ---------------------------------------------------------------------------
@@ -1375,7 +1396,52 @@ auto TypeChecker::lookup_method(const Type* obj_type,
     }
   }
 
-  // 3. Search derived conformances — concept method signatures.
+  // 3. If the receiver is a generic type parameter, search its concept
+  //    constraints for the method. This allows `x.to_string()` inside
+  //    `fn show<T: Printable>(x: T)` to resolve against Printable's methods.
+  if (obj_type->kind() == TypeKind::GenericParam) {
+    const auto* gp = static_cast<const TypeGenericParam*>(obj_type);
+    if (gp->binder() != nullptr) {
+      const auto* decl_node = static_cast<const Decl*>(gp->binder());
+      const std::vector<GenericParam>* type_params = nullptr;
+      if (decl_node->is<FunctionDecl>()) {
+        type_params = &decl_node->as<FunctionDecl>().type_params;
+      } else if (decl_node->is<ClassDecl>()) {
+        type_params = &decl_node->as<ClassDecl>().type_params;
+      }
+      if (type_params != nullptr && gp->index() < type_params->size()) {
+        const auto& gp_decl = (*type_params)[gp->index()];
+        for (const auto* constraint : gp_decl.constraints) {
+          // Resolve constraint to a concept symbol.
+          auto sym_it =
+              resolve_.uses.find(constraint->span.offset);
+          if (sym_it == resolve_.uses.end() ||
+              sym_it->second->kind != SymbolKind::Concept) {
+            continue;
+          }
+          const auto* cpt_decl =
+              static_cast<const Decl*>(sym_it->second->decl);
+          if (cpt_decl == nullptr || !cpt_decl->is<ConceptDecl>()) {
+            continue;
+          }
+          const auto& cpt = cpt_decl->as<ConceptDecl>();
+          for (const auto* method_decl : cpt.methods) {
+            const auto& method = method_decl->as<FunctionDecl>();
+            if (method.name == name) {
+              // Build return type with self mapped to the generic param.
+              auto saved_csm = concept_self_map_;
+              concept_self_map_[cpt.name] = obj_type;
+              auto result = method_fn_type(method);
+              concept_self_map_ = saved_csm;
+              return result;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 4. Search derived conformances — concept method signatures.
   //    Set concept_self_map_ so that the concept name in type position
   //    resolves to the receiver type (§3.2).
   auto derived_it = derived_conformances_.find(obj_type);

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -126,11 +126,18 @@ private:
   auto check_binary(const Expr* expr) -> const Type*;
   auto check_unary(const Expr* expr) -> const Type*;
   auto check_call(const Expr* expr) -> const Type*;
+  void infer_type_bindings(const Type* pattern, const Type* concrete,
+                           std::unordered_map<uint32_t, const Type*>& bindings,
+                           Span error_span);
+  auto substitute_generics(const Type* type,
+                           const std::unordered_map<uint32_t, const Type*>& bindings)
+      -> const Type*;
   auto check_construct(const Expr* expr, const TypeStruct* struct_type)
       -> const Type*;
   auto check_pipe(const Expr* expr) -> const Type*;
   auto check_field(const Expr* expr) -> const Type*;
-  auto lookup_method(const Type* obj_type, std::string_view name)
+  auto lookup_method(const Type* obj_type, std::string_view name,
+                     const Decl** resolved_decl = nullptr)
       -> const Type*;
   void validate_receiver(const Decl* method, Span context_span);
   auto check_index(const Expr* expr) -> const Type*;

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -5,7 +5,18 @@ namespace dao {
 auto is_assignable(const Type* source, const Type* target) -> bool {
   // Exact semantic type equality via pointer identity.
   // Canonical types are interned, so pointer equality is correct.
-  return source == target;
+  if (source == target) {
+    return true;
+  }
+
+  // A generic type parameter accepts any concrete type.
+  // Concept constraint checking is handled separately during
+  // conformance resolution — is_assignable only checks shape.
+  if (target->kind() == TypeKind::GenericParam) {
+    return true;
+  }
+
+  return false;
 }
 
 auto is_numeric(const Type* type) -> bool {

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -3,17 +3,43 @@
 namespace dao {
 
 auto is_assignable(const Type* source, const Type* target) -> bool {
-  // Exact semantic type equality via pointer identity.
-  // Canonical types are interned, so pointer equality is correct.
   if (source == target) {
     return true;
   }
 
   // A generic type parameter accepts any concrete type.
-  // Concept constraint checking is handled separately during
-  // conformance resolution — is_assignable only checks shape.
+  // Concept constraint checking is handled separately in check_call.
   if (target->kind() == TypeKind::GenericParam) {
     return true;
+  }
+
+  // Structural recursion for composite types containing generic params.
+  if (source->kind() == target->kind()) {
+    switch (target->kind()) {
+    case TypeKind::Pointer:
+      return is_assignable(
+          static_cast<const TypePointer*>(source)->pointee(),
+          static_cast<const TypePointer*>(target)->pointee());
+    case TypeKind::Generator:
+      return is_assignable(
+          static_cast<const TypeGenerator*>(source)->yield_type(),
+          static_cast<const TypeGenerator*>(target)->yield_type());
+    case TypeKind::Function: {
+      const auto* sf = static_cast<const TypeFunction*>(source);
+      const auto* tf = static_cast<const TypeFunction*>(target);
+      if (sf->param_types().size() != tf->param_types().size()) {
+        return false;
+      }
+      for (size_t i = 0; i < sf->param_types().size(); ++i) {
+        if (!is_assignable(sf->param_types()[i], tf->param_types()[i])) {
+          return false;
+        }
+      }
+      return is_assignable(sf->return_type(), tf->return_type());
+    }
+    default:
+      break;
+    }
   }
 
   return false;

--- a/compiler/frontend/typecheck/typed_results.h
+++ b/compiler/frontend/typecheck/typed_results.h
@@ -2,6 +2,7 @@
 #define DAO_FRONTEND_TYPECHECK_TYPED_RESULTS_H
 
 #include "frontend/ast/ast.h"
+#include "frontend/resolve/symbol.h"
 #include "frontend/types/type.h"
 
 #include <unordered_map>
@@ -55,10 +56,25 @@ public:
     return it != decl_types_.end() ? it->second : nullptr;
   }
 
+  // --- Method resolution (field access → method function symbol) ---
+
+  // --- Method resolution (field expr → resolved method FunctionDecl) ---
+
+  void set_method_resolution(const Expr* field_expr, const Decl* method_decl) {
+    method_resolutions_[field_expr] = method_decl;
+  }
+
+  [[nodiscard]] auto method_resolution(const Expr* field_expr) const
+      -> const Decl* {
+    auto it = method_resolutions_.find(field_expr);
+    return it != method_resolutions_.end() ? it->second : nullptr;
+  }
+
 private:
   std::unordered_map<const Expr*, const Type*> expr_types_;
   std::unordered_map<const Stmt*, const Type*> local_types_;
   std::unordered_map<const Decl*, const Type*> decl_types_;
+  std::unordered_map<const Expr*, const Decl*> method_resolutions_;
 };
 
 } // namespace dao

--- a/compiler/ir/CMakeLists.txt
+++ b/compiler/ir/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(dao_ir STATIC
   hir/hir_printer.cpp
   mir/mir.cpp
   mir/mir_builder.cpp
+  mir/mir_monomorphize.cpp
   mir/mir_printer.cpp
 )
 

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -306,6 +306,35 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
       }
     }
 
+    // Method call desugaring: x.method(args) → method(x, args)
+    // when the type checker resolved the FieldExpr as a method.
+    if (call.callee->is<FieldExpr>()) {
+      const auto* method_decl = typed_.typed.method_resolution(call.callee);
+      if (method_decl != nullptr) {
+        const auto& field = call.callee->as<FieldExpr>();
+        // Look up the method function's symbol by matching the Decl*.
+        const Symbol* method_sym = nullptr;
+        for (const auto& sym_ptr : resolve_.context.symbols()) {
+          if (sym_ptr->kind == SymbolKind::Function && sym_ptr->decl == method_decl) {
+            method_sym = sym_ptr.get();
+            break;
+          }
+        }
+        if (method_sym != nullptr) {
+          auto* callee_ref = ctx_.alloc<HirExpr>(
+              call.callee->span, expr_type(call.callee),
+              HirSymbolRef{method_sym});
+          std::vector<HirExpr*> args;
+          args.push_back(lower_expr(field.object)); // self
+          for (const auto* arg : call.args) {
+            args.push_back(lower_expr(arg));
+          }
+          return ctx_.alloc<HirExpr>(span, type,
+                                      HirCall{callee_ref, std::move(args)});
+        }
+      }
+    }
+
     // Normal function call.
     auto* callee = lower_expr(call.callee);
     std::vector<HirExpr*> args;

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -1,0 +1,429 @@
+// NOLINTBEGIN(readability-magic-numbers,readability-identifier-length)
+#include "ir/mir/mir_monomorphize.h"
+
+#include "frontend/types/type.h"
+#include "frontend/types/type_printer.h"
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dao {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Type substitution: replace TypeGenericParam with concrete types.
+// ---------------------------------------------------------------------------
+
+using TypeSubst = std::unordered_map<uint32_t, const Type*>;
+
+auto substitute_type(const Type* type, const TypeSubst& subst,
+                     TypeContext& types) -> const Type* {
+  if (type == nullptr) {
+    return nullptr;
+  }
+
+  switch (type->kind()) {
+  case TypeKind::GenericParam: {
+    const auto* gp = static_cast<const TypeGenericParam*>(type);
+    auto it = subst.find(gp->index());
+    if (it != subst.end()) {
+      return it->second;
+    }
+    return type; // unbound — leave as-is (shouldn't happen in practice)
+  }
+
+  case TypeKind::Function: {
+    const auto* fn = static_cast<const TypeFunction*>(type);
+    std::vector<const Type*> params;
+    params.reserve(fn->param_types().size());
+    bool changed = false;
+    for (const auto* param : fn->param_types()) {
+      auto* sub = substitute_type(param, subst, types);
+      if (sub != param) {
+        changed = true;
+      }
+      params.push_back(sub);
+    }
+    auto* ret = substitute_type(fn->return_type(), subst, types);
+    if (ret != fn->return_type()) {
+      changed = true;
+    }
+    if (!changed) {
+      return type;
+    }
+    return types.function_type(std::move(params), ret);
+  }
+
+  case TypeKind::Pointer: {
+    const auto* ptr = static_cast<const TypePointer*>(type);
+    auto* sub = substitute_type(ptr->pointee(), subst, types);
+    if (sub == ptr->pointee()) {
+      return type;
+    }
+    return types.pointer_to(sub);
+  }
+
+  case TypeKind::Generator: {
+    const auto* gen = static_cast<const TypeGenerator*>(type);
+    auto* sub = substitute_type(gen->yield_type(), subst, types);
+    if (sub == gen->yield_type()) {
+      return type;
+    }
+    return types.generator_type(sub);
+  }
+
+  default:
+    return type;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detect generic functions: any function whose locals, return type,
+// or instruction types contain TypeGenericParam.
+// ---------------------------------------------------------------------------
+
+auto type_has_generic(const Type* type) -> bool {
+  if (type == nullptr) {
+    return false;
+  }
+  switch (type->kind()) {
+  case TypeKind::GenericParam:
+    return true;
+  case TypeKind::Function: {
+    const auto* fn = static_cast<const TypeFunction*>(type);
+    for (const auto* param : fn->param_types()) {
+      if (type_has_generic(param)) {
+        return true;
+      }
+    }
+    return type_has_generic(fn->return_type());
+  }
+  case TypeKind::Pointer:
+    return type_has_generic(
+        static_cast<const TypePointer*>(type)->pointee());
+  case TypeKind::Generator:
+    return type_has_generic(
+        static_cast<const TypeGenerator*>(type)->yield_type());
+  default:
+    return false;
+  }
+}
+
+auto is_generic_function(const MirFunction* fn) -> bool {
+  if (type_has_generic(fn->return_type)) {
+    return true;
+  }
+  for (const auto& local : fn->locals) {
+    if (type_has_generic(local.type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Mangled name for specializations: "name$i32" or "name$i32_f64".
+// ---------------------------------------------------------------------------
+
+auto mangle_name(std::string_view base,
+                 const std::vector<const Type*>& type_args) -> std::string {
+  std::string result(base);
+  result += '$';
+  for (size_t i = 0; i < type_args.size(); ++i) {
+    if (i > 0) {
+      result += '_';
+    }
+    result += print_type(type_args[i]);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Specialization key for deduplication.
+// ---------------------------------------------------------------------------
+
+struct SpecKey {
+  const MirFunction* generic_fn;
+  std::vector<const Type*> type_args;
+
+  auto operator==(const SpecKey& other) const -> bool {
+    return generic_fn == other.generic_fn && type_args == other.type_args;
+  }
+};
+
+struct SpecKeyHash {
+  auto operator()(const SpecKey& key) const -> size_t {
+    size_t h = std::hash<const void*>{}(key.generic_fn);
+    for (const auto* type : key.type_args) {
+      h ^= std::hash<const void*>{}(type) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
+    return h;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Clone a MirFunction with type substitution.
+// ---------------------------------------------------------------------------
+
+auto clone_function(const MirFunction* src, const TypeSubst& subst,
+                    const Symbol* new_symbol, MirContext& ctx,
+                    TypeContext& types) -> MirFunction* {
+  auto* dst = ctx.alloc<MirFunction>();
+  dst->symbol = new_symbol;
+  dst->return_type = substitute_type(src->return_type, subst, types);
+  dst->span = src->span;
+  dst->is_extern = src->is_extern;
+
+  // Clone locals with substituted types.
+  dst->locals.reserve(src->locals.size());
+  for (const auto& local : src->locals) {
+    MirLocal cloned = local;
+    cloned.type = substitute_type(local.type, subst, types);
+    dst->locals.push_back(cloned);
+  }
+
+  // Clone blocks and instructions.
+  dst->blocks.reserve(src->blocks.size());
+  for (const auto* src_block : src->blocks) {
+    auto* dst_block = ctx.alloc<MirBlock>();
+    dst_block->id = src_block->id;
+
+    dst_block->insts.reserve(src_block->insts.size());
+    for (const auto* src_inst : src_block->insts) {
+      auto* dst_inst = ctx.alloc<MirInst>();
+      dst_inst->result = src_inst->result;
+      dst_inst->type = substitute_type(src_inst->type, subst, types);
+      dst_inst->span = src_inst->span;
+
+      // Deep-copy payload, handling heap-allocated members.
+      dst_inst->payload = src_inst->payload;
+
+      // For Call and Construct, the args/field_values vectors need
+      // to be cloned since they're heap-allocated.
+      if (auto* call = std::get_if<MirCall>(&dst_inst->payload)) {
+        if (call->args != nullptr) {
+          auto* new_args = ctx.alloc<std::vector<MirValueId>>(*call->args);
+          call->args = new_args;
+        }
+      } else if (auto* ctor = std::get_if<MirConstruct>(&dst_inst->payload)) {
+        if (ctor->field_values != nullptr) {
+          auto* new_fv =
+              ctx.alloc<std::vector<MirValueId>>(*ctor->field_values);
+          ctor->field_values = new_fv;
+        }
+      } else if (auto* store = std::get_if<MirStore>(&dst_inst->payload)) {
+        if (store->place != nullptr) {
+          store->place = ctx.alloc<MirPlace>(*store->place);
+        }
+      } else if (auto* load = std::get_if<MirLoad>(&dst_inst->payload)) {
+        if (load->place != nullptr) {
+          load->place = ctx.alloc<MirPlace>(*load->place);
+        }
+      } else if (auto* addr = std::get_if<MirAddrOf>(&dst_inst->payload)) {
+        if (addr->place != nullptr) {
+          addr->place = ctx.alloc<MirPlace>(*addr->place);
+        }
+      }
+
+      dst_block->insts.push_back(dst_inst);
+    }
+
+    dst->blocks.push_back(dst_block);
+  }
+
+  return dst;
+}
+
+// ---------------------------------------------------------------------------
+// Infer type substitution from a call site.
+// ---------------------------------------------------------------------------
+
+auto infer_substitution(const MirFunction* generic_fn,
+                        const std::vector<const Type*>& arg_types)
+    -> TypeSubst {
+  TypeSubst subst;
+  size_t param_count = 0;
+  for (const auto& local : generic_fn->locals) {
+    if (!local.is_param) {
+      break;
+    }
+    if (param_count < arg_types.size() &&
+        local.type != nullptr &&
+        local.type->kind() == TypeKind::GenericParam) {
+      const auto* gp = static_cast<const TypeGenericParam*>(local.type);
+      subst[gp->index()] = arg_types[param_count];
+    }
+    ++param_count;
+  }
+  return subst;
+}
+
+// Extract ordered type args from a substitution map.
+auto subst_to_type_args(const TypeSubst& subst) -> std::vector<const Type*> {
+  if (subst.empty()) {
+    return {};
+  }
+  uint32_t max_idx = 0;
+  for (const auto& [idx, _] : subst) {
+    if (idx > max_idx) {
+      max_idx = idx;
+    }
+  }
+  std::vector<const Type*> args(max_idx + 1, nullptr);
+  for (const auto& [idx, type] : subst) {
+    args[idx] = type;
+  }
+  return args;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Main pass
+// ---------------------------------------------------------------------------
+
+auto monomorphize(MirModule& module, MirContext& ctx,
+                  TypeContext& types) -> MonomorphizeResult {
+  MonomorphizeResult result;
+
+  // Phase 1: identify generic functions by symbol.
+  std::unordered_map<const Symbol*, MirFunction*> generic_fns;
+  for (auto* fn : module.functions) {
+    if (is_generic_function(fn)) {
+      generic_fns[fn->symbol] = fn;
+    }
+  }
+
+  if (generic_fns.empty()) {
+    return result;
+  }
+
+  // Specialization cache: (generic fn, type args) → specialized fn.
+  std::unordered_map<SpecKey, MirFunction*, SpecKeyHash> spec_cache;
+
+  // Arena-owned name strings for mangled symbols.
+  // (Stored as char arrays in MirContext arena.)
+
+  // Phase 2+3+4: iterate until no new specializations are produced.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+
+    for (auto* fn : module.functions) {
+      // Skip generic functions themselves — they'll be removed later.
+      if (generic_fns.count(fn->symbol) != 0) {
+        continue;
+      }
+
+      for (auto* block : fn->blocks) {
+        for (size_t inst_idx = 0; inst_idx < block->insts.size();
+             ++inst_idx) {
+          auto* inst = block->insts[inst_idx];
+          auto* fn_ref = std::get_if<MirFnRef>(&inst->payload);
+          if (fn_ref == nullptr) {
+            continue;
+          }
+
+          auto git = generic_fns.find(fn_ref->symbol);
+          if (git == generic_fns.end()) {
+            continue;
+          }
+
+          // Found a call to a generic function. Find the matching
+          // MirCall instruction that uses this FnRef.
+          const MirCall* call_payload = nullptr;
+          for (size_t j = inst_idx + 1; j < block->insts.size(); ++j) {
+            auto* candidate = std::get_if<MirCall>(
+                &block->insts[j]->payload);
+            if (candidate != nullptr &&
+                candidate->callee.id == inst->result.id) {
+              call_payload = candidate;
+              break;
+            }
+          }
+
+          if (call_payload == nullptr || call_payload->args == nullptr) {
+            continue;
+          }
+
+          // Collect argument types from the call.
+          std::vector<const Type*> arg_types;
+          arg_types.reserve(call_payload->args->size());
+          for (auto arg_id : *call_payload->args) {
+            // Find the instruction that produces this value to
+            // get its type.
+            const Type* arg_type = nullptr;
+            for (const auto* blk : fn->blocks) {
+              for (const auto* search_inst : blk->insts) {
+                if (search_inst->result.id == arg_id.id) {
+                  arg_type = search_inst->type;
+                  break;
+                }
+              }
+              if (arg_type != nullptr) {
+                break;
+              }
+            }
+            arg_types.push_back(arg_type);
+          }
+
+          // Infer substitution from argument types.
+          auto subst = infer_substitution(git->second, arg_types);
+          if (subst.empty()) {
+            continue;
+          }
+
+          auto type_args = subst_to_type_args(subst);
+          SpecKey key{git->second, type_args};
+
+          // Check cache.
+          auto cache_it = spec_cache.find(key);
+          if (cache_it != spec_cache.end()) {
+            // Rewrite the FnRef to point at the cached specialization.
+            fn_ref->symbol = cache_it->second->symbol;
+            inst->type = substitute_type(inst->type, subst, types);
+            continue;
+          }
+
+          // Create mangled symbol.
+          // Allocate name string on arena so it outlives this scope.
+          auto* name_str = ctx.alloc<std::string>(
+              mangle_name(git->second->symbol->name, type_args));
+
+          auto* new_sym = ctx.alloc<Symbol>();
+          new_sym->kind = SymbolKind::Function;
+          new_sym->name = std::string_view(*name_str);
+          new_sym->decl_span = git->second->symbol->decl_span;
+          new_sym->decl = git->second->symbol->decl;
+
+          // Clone the generic function with type substitution.
+          auto* specialized =
+              clone_function(git->second, subst, new_sym, ctx, types);
+
+          // Register in cache and add to module.
+          spec_cache[key] = specialized;
+          module.functions.push_back(specialized);
+
+          // Rewrite the FnRef.
+          fn_ref->symbol = new_sym;
+          inst->type = substitute_type(inst->type, subst, types);
+
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // Phase 5: remove generic originals.
+  std::erase_if(module.functions, [&](const MirFunction* fn) {
+    return generic_fns.count(fn->symbol) != 0;
+  });
+
+  return result;
+}
+
+} // namespace dao
+// NOLINTEND(readability-magic-numbers,readability-identifier-length)

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -241,6 +241,44 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
 // Infer type substitution from a call site.
 // ---------------------------------------------------------------------------
 
+// Recursively extract generic param bindings by matching a pattern type
+// (which may contain TypeGenericParam) against a concrete type.
+void infer_bindings_recursive(const Type* pattern, const Type* concrete,
+                              TypeSubst& subst) {
+  if (pattern == nullptr || concrete == nullptr) {
+    return;
+  }
+
+  if (pattern->kind() == TypeKind::GenericParam) {
+    const auto* gp = static_cast<const TypeGenericParam*>(pattern);
+    subst[gp->index()] = concrete; // last-write-wins at MIR level
+    return;
+  }
+
+  if (pattern->kind() == TypeKind::Pointer &&
+      concrete->kind() == TypeKind::Pointer) {
+    infer_bindings_recursive(
+        static_cast<const TypePointer*>(pattern)->pointee(),
+        static_cast<const TypePointer*>(concrete)->pointee(), subst);
+  } else if (pattern->kind() == TypeKind::Generator &&
+             concrete->kind() == TypeKind::Generator) {
+    infer_bindings_recursive(
+        static_cast<const TypeGenerator*>(pattern)->yield_type(),
+        static_cast<const TypeGenerator*>(concrete)->yield_type(), subst);
+  } else if (pattern->kind() == TypeKind::Function &&
+             concrete->kind() == TypeKind::Function) {
+    const auto* fp = static_cast<const TypeFunction*>(pattern);
+    const auto* fc = static_cast<const TypeFunction*>(concrete);
+    if (fp->param_types().size() == fc->param_types().size()) {
+      for (size_t i = 0; i < fp->param_types().size(); ++i) {
+        infer_bindings_recursive(fp->param_types()[i],
+                                 fc->param_types()[i], subst);
+      }
+      infer_bindings_recursive(fp->return_type(), fc->return_type(), subst);
+    }
+  }
+}
+
 auto infer_substitution(const MirFunction* generic_fn,
                         const std::vector<const Type*>& arg_types)
     -> TypeSubst {
@@ -250,11 +288,8 @@ auto infer_substitution(const MirFunction* generic_fn,
     if (!local.is_param) {
       break;
     }
-    if (param_count < arg_types.size() &&
-        local.type != nullptr &&
-        local.type->kind() == TypeKind::GenericParam) {
-      const auto* gp = static_cast<const TypeGenericParam*>(local.type);
-      subst[gp->index()] = arg_types[param_count];
+    if (param_count < arg_types.size() && local.type != nullptr) {
+      infer_bindings_recursive(local.type, arg_types[param_count], subst);
     }
     ++param_count;
   }

--- a/compiler/ir/mir/mir_monomorphize.h
+++ b/compiler/ir/mir/mir_monomorphize.h
@@ -1,0 +1,25 @@
+#ifndef DAO_IR_MIR_MIR_MONOMORPHIZE_H
+#define DAO_IR_MIR_MIR_MONOMORPHIZE_H
+
+#include "ir/mir/mir.h"
+#include "ir/mir/mir_context.h"
+#include "frontend/types/type_context.h"
+#include "frontend/diagnostics/diagnostic.h"
+
+#include <vector>
+
+namespace dao {
+
+struct MonomorphizeResult {
+  std::vector<Diagnostic> diagnostics;
+};
+
+/// Replace generic functions with concrete specializations based on
+/// observed call-site types. After this pass, no TypeGenericParam
+/// remains in the module and the LLVM backend can lower all types.
+auto monomorphize(MirModule& module, MirContext& ctx,
+                  TypeContext& types) -> MonomorphizeResult;
+
+} // namespace dao
+
+#endif // DAO_IR_MIR_MIR_MONOMORPHIZE_H

--- a/tools/playground/compiler_service/run.cpp
+++ b/tools/playground/compiler_service/run.cpp
@@ -11,6 +11,7 @@
 #include "ir/hir/hir_context.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
+#include "ir/mir/mir_monomorphize.h"
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Support/Program.h>
@@ -239,6 +240,11 @@ void handle_run(const httplib::Request& req, httplib::Response& res,
       build_mir(*hir_result.module, mir_ctx, types);
   collect_diagnostics(diagnostics, source, mir_result.diagnostics,
                       prelude_bytes, prelude_lines);
+  if (mir_result.module != nullptr) {
+    auto mono = monomorphize(*mir_result.module, mir_ctx, types);
+    collect_diagnostics(diagnostics, source, mono.diagnostics,
+                        prelude_bytes, prelude_lines);
+  }
   if (mir_result.module == nullptr) {
     if (diagnostics.empty()) {
       diagnostics.push_back({


### PR DESCRIPTION
## Summary

Implement a MIR-level monomorphization pass that replaces generic functions with concrete specializations. `fn id<T>(x: T): T` called with `id(42)` now compiles end-to-end, producing a specialized `id$i32` function in LLVM IR.

## Highlights

- **Type checker**: `is_assignable` accepts `TypeGenericParam` targets; `check_call` infers type bindings and substitutes generic return types; `lookup_method` searches concept constraints on generic params
- **Monomorphization pass** (`mir_monomorphize.cpp`): detects generic functions, infers substitutions from call sites, clones MIR with recursive type substitution, creates mangled symbols, rewrites calls, removes originals, iterates to fixpoint
- **Pipeline integration**: pass runs between `build_mir()` and LLVM lowering in both CLI driver and playground
- **ARCH_INDEX**: new file registered under `compiler/ir/mir/`

## Known Limitations

- Concept method dispatch on generic types (`x.to_string()` where `x: T: Printable`) type-checks but fails at LLVM lowering — the HIR/MIR builder treats it as field access on a non-struct type. This blocks the `fn print<T: Printable>` stdlib upgrade. Tracked as a follow-up.

## Test plan

- [x] `fn id<T>(x: T): T` with `id(42)` compiles and returns 42
- [x] Multiple specializations (`id(42)`, `id(3.14)`, `id(true)`) produce distinct `id$i32`, `id$f64`, `id$bool`
- [x] Existing examples (`hello.dao`, `arithmetic.dao`, etc.) compile unchanged
- [x] Existing test suite: no regressions (3 pre-existing failures unrelated to this change)
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)