### PR TITLE
feat(compiler): ✨ lower extend methods and enable concept method dispatch

### DIFF
--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -371,15 +371,33 @@ private:
     }
 
     // Extract target type name for method symbol mangling.
-    std::string target_name;
-    if (ext.target_type != nullptr &&
-        ext.target_type->is<NamedType>()) {
-      const auto& named = ext.target_type->as<NamedType>();
-      for (size_t seg = 0; seg < named.name.segments.size(); ++seg) {
-        if (seg > 0) { target_name += "::"; }
-        target_name += named.name.segments[seg];
+    // Must include type arguments to match print_type() output used
+    // by the monomorphization fixup (e.g. "Generator<i32>.method").
+    auto format_type_node = [](const TypeNode* node, auto& self) -> std::string {
+      if (node == nullptr) { return {}; }
+      if (node->is<NamedType>()) {
+        const auto& named = node->as<NamedType>();
+        std::string result;
+        for (size_t seg = 0; seg < named.name.segments.size(); ++seg) {
+          if (seg > 0) { result += "::"; }
+          result += named.name.segments[seg];
+        }
+        if (!named.type_args.empty()) {
+          result += "<";
+          for (size_t arg = 0; arg < named.type_args.size(); ++arg) {
+            if (arg > 0) { result += ", "; }
+            result += self(named.type_args[arg], self);
+          }
+          result += ">";
+        }
+        return result;
       }
-    }
+      if (node->is<PointerType>()) {
+        return "*" + self(node->as<PointerType>().pointee, self);
+      }
+      return {};
+    };
+    auto target_name = format_type_node(ext.target_type, format_type_node);
 
     // Resolve method signatures and create Function symbols.
     for (const auto* method : ext.methods) {

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -370,9 +370,31 @@ private:
       uses_[ext.concept_span.offset] = sym;
     }
 
-    // Resolve method signatures.
+    // Extract target type name for method symbol mangling.
+    std::string target_name;
+    if (ext.target_type != nullptr &&
+        ext.target_type->is<NamedType>()) {
+      const auto& named = ext.target_type->as<NamedType>();
+      for (size_t seg = 0; seg < named.name.segments.size(); ++seg) {
+        if (seg > 0) { target_name += "::"; }
+        target_name += named.name.segments[seg];
+      }
+    }
+
+    // Resolve method signatures and create Function symbols.
     for (const auto* method : ext.methods) {
       resolve_function(*method, parent);
+
+      // Create a Function symbol with mangled name so HIR/MIR can
+      // reference this extend method as a real function.
+      // Name format: "<type>.<method>" (e.g. "i32.to_string").
+      if (!target_name.empty()) {
+        const auto& fn_decl = method->as<FunctionDecl>();
+        auto mangled_name = ctx_.intern(
+            target_name + "." + std::string(fn_decl.name));
+        ctx_.make_symbol(SymbolKind::Function, mangled_name,
+                         fn_decl.name_span, method);
+      }
     }
   }
 

--- a/compiler/frontend/resolve/resolve_context.h
+++ b/compiler/frontend/resolve/resolve_context.h
@@ -5,6 +5,7 @@
 #include "frontend/resolve/symbol.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace dao {
@@ -39,9 +40,17 @@ public:
     return symbols_;
   }
 
+  /// Intern a string so it outlives any string_view pointing to it.
+  /// Returns a stable string_view into owned storage.
+  auto intern(std::string str) -> std::string_view {
+    strings_.push_back(std::make_unique<std::string>(std::move(str)));
+    return *strings_.back();
+  }
+
 private:
   std::vector<std::unique_ptr<Symbol>> symbols_;
   std::vector<std::unique_ptr<Scope>> scopes_;
+  std::vector<std::unique_ptr<std::string>> strings_;
 };
 
 } // namespace dao

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -340,6 +340,48 @@ void TypeChecker::register_declarations(const FileNode& file) {
       break;
     }
 
+    case NodeKind::ExtendDecl: {
+      // Register extend methods as typed functions so HIR lowering
+      // can find their type info via decl_type().
+      const auto& ext = decl->as<ExtendDecl>();
+      const auto* target_type = resolve_type_node(ext.target_type);
+      for (const auto* method : ext.methods) {
+        const auto& method_fn = method->as<FunctionDecl>();
+        std::vector<const Type*> param_types;
+        bool valid = true;
+        for (const auto& param : method_fn.params) {
+          if (param.name == "self" && param.type == nullptr) {
+            // Bare self — use the extend target type.
+            if (target_type != nullptr) {
+              param_types.push_back(target_type);
+            } else {
+              valid = false;
+              param_types.push_back(nullptr);
+            }
+          } else {
+            const auto* param_type = resolve_type_node(param.type);
+            if (param_type == nullptr) {
+              valid = false;
+            }
+            param_types.push_back(param_type);
+          }
+        }
+        const auto* ret = method_fn.return_type != nullptr
+                              ? resolve_type_node(method_fn.return_type)
+                              : types_.void_type();
+        if (valid && ret != nullptr) {
+          const auto* fn_type =
+              types_.function_type(std::move(param_types), ret);
+          auto decl_it = decl_symbols_.find(method_fn.name_span.offset);
+          if (decl_it != decl_symbols_.end()) {
+            symbol_types_[decl_it->second] = fn_type;
+          }
+          typed_.set_decl_type(method, fn_type);
+        }
+      }
+      break;
+    }
+
     default:
       break;
     }

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -35,6 +35,11 @@ auto HirBuilder::build(const FileNode& file) -> HirBuildResult {
     }
   }
 
+  // Append extend methods lowered as standalone functions.
+  for (auto* ext_decl : extend_decls_) {
+    decls.push_back(ext_decl);
+  }
+
   auto* mod = ctx_.alloc<HirModule>(file.span, std::move(decls));
   return {.module = mod, .diagnostics = std::move(diagnostics_)};
 }
@@ -49,6 +54,19 @@ auto HirBuilder::lower_decl(const Decl* decl) -> HirDecl* {
     return lower_function(decl);
   case NodeKind::ClassDecl:
     return lower_class(decl);
+  case NodeKind::ExtendDecl: {
+    // Lower each extend method as a standalone function.
+    // These are emitted as real functions so method dispatch can
+    // reference them via MirFnRef.
+    const auto& ext = decl->as<ExtendDecl>();
+    for (const auto* method : ext.methods) {
+      auto* hir_fn = lower_function(method);
+      if (hir_fn != nullptr) {
+        extend_decls_.push_back(hir_fn);
+      }
+    }
+    return nullptr; // extend itself isn't a declaration
+  }
   default:
     return nullptr;
   }

--- a/compiler/ir/hir/hir_builder.h
+++ b/compiler/ir/hir/hir_builder.h
@@ -42,6 +42,7 @@ private:
   const ResolveResult& resolve_;
   const TypeCheckResult& typed_;
   std::vector<Diagnostic> diagnostics_;
+  std::vector<HirDecl*> extend_decls_; // extend methods lowered as functions
 
   // decl_span.offset -> Symbol* for declaration-site lookups.
   std::unordered_map<uint32_t, const Symbol*> decl_symbols_;

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -248,12 +248,16 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
 // ---------------------------------------------------------------------------
 
 void fixup_method_calls(MirFunction* fn, const MirModule& module,
-                        MirContext& ctx) {
-  // Build a name → symbol lookup from the module's functions.
-  std::unordered_map<std::string, const Symbol*> fn_by_name;
+                        MirContext& ctx, TypeContext& types) {
+  // Build a name → (symbol, function) lookup from the module's functions.
+  struct FnEntry {
+    const Symbol* symbol;
+    const MirFunction* mir_fn;
+  };
+  std::unordered_map<std::string, FnEntry> fn_by_name;
   for (const auto* mod_fn : module.functions) {
     if (mod_fn->symbol != nullptr) {
-      fn_by_name[std::string(mod_fn->symbol->name)] = mod_fn->symbol;
+      fn_by_name[std::string(mod_fn->symbol->name)] = {mod_fn->symbol, mod_fn};
     }
   }
 
@@ -293,9 +297,21 @@ void fixup_method_calls(MirFunction* fn, const MirModule& module,
 
       // Save the object value before replacing the payload.
       auto object_val = field->object;
+      const auto& entry = sym_it->second;
 
       // Replace FieldAccess with FnRef to the extend method.
-      inst->payload = MirFnRef{sym_it->second};
+      // Update the instruction type to the method's function type,
+      // matching what MirBuilder would produce for a direct FnRef.
+      inst->payload = MirFnRef{entry.symbol};
+
+      // Build the function type from the extend method's MIR signature.
+      std::vector<const Type*> param_types;
+      for (const auto& local : entry.mir_fn->locals) {
+        if (!local.is_param) { break; }
+        param_types.push_back(local.type);
+      }
+      inst->type = types.function_type(
+          std::move(param_types), entry.mir_fn->return_type);
 
       // Find the MirCall that uses this instruction's result as callee
       // and prepend the object as the first argument (self).
@@ -517,7 +533,7 @@ auto monomorphize(MirModule& module, MirContext& ctx,
               clone_function(git->second, subst, new_sym, ctx, types);
 
           // Resolve method calls on newly-concrete types.
-          fixup_method_calls(specialized, module, ctx);
+          fixup_method_calls(specialized, module, ctx, types);
 
           // Register in cache and add to module.
           spec_cache[key] = specialized;

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -238,6 +238,84 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
 }
 
 // ---------------------------------------------------------------------------
+// Post-clone fixup: resolve method calls on non-struct types.
+//
+// After monomorphization substitutes T → i32, a MirFieldAccess on an
+// i32-typed value (e.g. x.to_string) should become a MirFnRef to the
+// extend method "i32.to_string". This scans for FieldAccess instructions
+// whose object type is not a struct and replaces them with FnRef to the
+// mangled extend method, looking it up in the module's function list.
+// ---------------------------------------------------------------------------
+
+void fixup_method_calls(MirFunction* fn, const MirModule& module,
+                        MirContext& ctx) {
+  // Build a name → symbol lookup from the module's functions.
+  std::unordered_map<std::string, const Symbol*> fn_by_name;
+  for (const auto* mod_fn : module.functions) {
+    if (mod_fn->symbol != nullptr) {
+      fn_by_name[std::string(mod_fn->symbol->name)] = mod_fn->symbol;
+    }
+  }
+
+  for (auto* block : fn->blocks) {
+    for (auto* inst : block->insts) {
+      auto* field = std::get_if<MirFieldAccess>(&inst->payload);
+      if (field == nullptr) {
+        continue;
+      }
+
+      // Find the type of the object being accessed.
+      const Type* obj_type = nullptr;
+      for (const auto* blk : fn->blocks) {
+        for (const auto* search : blk->insts) {
+          if (search->result.id == field->object.id) {
+            obj_type = search->type;
+            break;
+          }
+        }
+        if (obj_type != nullptr) {
+          break;
+        }
+      }
+
+      // Skip struct types — those are real field accesses.
+      if (obj_type == nullptr || obj_type->kind() == TypeKind::Struct) {
+        continue;
+      }
+
+      // Build mangled method name: "<type>.<field>".
+      auto method_name =
+          print_type(obj_type) + "." + std::string(field->field);
+      auto sym_it = fn_by_name.find(method_name);
+      if (sym_it == fn_by_name.end()) {
+        continue;
+      }
+
+      // Save the object value before replacing the payload.
+      auto object_val = field->object;
+
+      // Replace FieldAccess with FnRef to the extend method.
+      inst->payload = MirFnRef{sym_it->second};
+
+      // Find the MirCall that uses this instruction's result as callee
+      // and prepend the object as the first argument (self).
+      for (auto* call_block : fn->blocks) {
+        for (auto* call_inst : call_block->insts) {
+          auto* call = std::get_if<MirCall>(&call_inst->payload);
+          if (call == nullptr || call->callee.id != inst->result.id) {
+            continue;
+          }
+          if (call->args == nullptr) {
+            call->args = ctx.alloc<std::vector<MirValueId>>();
+          }
+          call->args->insert(call->args->begin(), object_val);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Infer type substitution from a call site.
 // ---------------------------------------------------------------------------
 
@@ -437,6 +515,9 @@ auto monomorphize(MirModule& module, MirContext& ctx,
           // Clone the generic function with type substitution.
           auto* specialized =
               clone_function(git->second, subst, new_sym, ctx, types);
+
+          // Resolve method calls on newly-concrete types.
+          fixup_method_calls(specialized, module, ctx);
 
           // Register in cache and add to module.
           spec_cache[key] = specialized;


### PR DESCRIPTION
## Summary

Enable method calls on scalar types through extend blocks (`x.to_string()`) and generic concept-constrained method dispatch (`fn show<T: Printable>(x: T) -> x.to_string()`). This is the missing piece that allows concept methods to work end-to-end from type checking through LLVM lowering.

## Highlights

- Resolve creates `Function` symbols with mangled names for extend methods (e.g. `i32.to_string`)
- Type checker registers extend method types and records resolution in `TypedResults`
- HIR builder lowers extend methods as standalone functions and desugars method calls to direct function calls
- Monomorphization pass fixes up method calls post-substitution: replaces `MirFieldAccess` on non-struct types with `MirFnRef` to the correct extend method
- `ResolveContext` gains string interning for mangled name lifetime

## Test plan

- [x] `x.to_string()` on concrete `i32` compiles and runs correctly
- [x] `fn show<T: Printable>(x: T)` calling `x.to_string()` dispatches to correct extend methods for i32, f64, bool
- [x] All existing examples compile unchanged
- [x] Existing test suite: no regressions
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)