### PR TITLE
chore(repo): 🎨 audit pass 2 — generic print, roadmap status, playground monomorphize fix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ Dao should be built in stages that preserve feedback loops:
 
 ## Phase 0 — Constitutional Baseline
 
-Status: scaffolded
+Status: **complete**
 
 Goals:
 - repository constitution, contracts, and architecture index in place
@@ -45,6 +45,8 @@ Rationale:
 
 ## Phase 1 — Frontend Skeleton
 
+Status: **complete**
+
 Goals:
 - indentation-aware lexer
 - parser for declarations, statements, expressions, lambdas, pipelines,
@@ -67,6 +69,9 @@ Exit criteria:
 
 ## Phase 1.5 — Playground and Example Hardening Loop
 
+Status: **complete** — Vite + TypeScript frontend with HMR, semantic
+tokens, IR panels, run/console, generic print
+
 Goals:
 - bring up a small web playground tied to the local `examples/` directory
 - support structural highlighting first, then compiler-backed semantic
@@ -82,6 +87,9 @@ Exit criteria:
   the browser once frontend analysis is available
 
 ## Phase 2 — Semantic Frontend + HIR
+
+Status: **complete** — resolve, typecheck, concepts, generics,
+monomorphization, extend method lowering, HIR
 
 Goals:
 - name resolution and scope analysis
@@ -103,6 +111,9 @@ Exit criteria:
 
 ## Phase 3 — MIR + Execution Semantics Lowering
 
+Status: **partial** — basic-block MIR, HIR→MIR lowering, generator
+coroutines. Resource/mode lowering deferred.
+
 Goals:
 - explicit control-flow lowering to MIR
 - ownership-free but scoped lowering model for `resource memory ... =>`
@@ -122,6 +133,9 @@ Exit criteria:
 
 ## Phase 4 — LLVM Backend + Native Driver
 
+Status: **complete** — MIR→LLVM lowering, object emission, linking,
+`daoc build`, runtime ABI
+
 Goals:
 - LLVM lowering for scalar arithmetic, control flow, calls, aggregates,
   and resource lifetime intrinsics
@@ -139,6 +153,10 @@ Exit criteria:
 - small routing / ETL / numerics examples compile through LLVM
 
 ## Phase 5 — Runtime and Initial Standard Library
+
+Status: **partial** — runtime ABI contract, IO/equality/conversion/
+generator hooks, prelude with Printable/Equatable/range. Scoped
+resource domains and mode plumbing deferred.
 
 Goals:
 - runtime memory support for scoped resource domains
@@ -202,12 +220,17 @@ Exit criteria:
 ## Tooling Track — Semantic Tooling, IntelliSense, and Web IDE
 
 ### Tooling T1 — Semantic Highlighting
+
+Status: **complete**
+
 - compiler-produced semantic token streams
 - frozen baseline token taxonomy implemented end to end
 - category distinction for declarations, calls, types, lambdas, pipes,
   modes, resources, and bindings
 
 ### Tooling T2 — Initial IntelliSense Slice
+
+Status: **not started**
 - hover
 - completion
 - go-to-definition

--- a/examples/arithmetic.dao
+++ b/examples/arithmetic.dao
@@ -21,21 +21,21 @@ fn sum_range(a: i32, b: i32): i32
 
 fn main(): i32
   print("square(7):")
-  print_i32(square(7))
+  print(square(7))
 
   print("cube(3):")
-  print_i32(cube(3))
+  print(cube(3))
 
   print("is_even(4):")
-  print_bool(is_even(4))
+  print(is_even(4))
 
   print("is_even(7):")
-  print_bool(is_even(7))
+  print(is_even(7))
 
   print("clamp(15, 0, 10):")
-  print_i32(clamp(15, 0, 10))
+  print(clamp(15, 0, 10))
 
   print("sum_range(1, 11):")
-  print_i32(sum_range(1, 11))
+  print(sum_range(1, 11))
 
   return 0

--- a/examples/astar.dao
+++ b/examples/astar.dao
@@ -14,10 +14,10 @@ fn a_star(start: NodeId, goal: NodeId): i32
 fn main(): i32
   let cost: i32 = a_star(3, 7)
   print("a_star(3, 7) cost:")
-  print_i32(cost)
+  print(cost)
 
   let same: i32 = a_star(5, 5)
   print("a_star(5, 5) cost:")
-  print_i32(same)
+  print(same)
 
   return 0

--- a/examples/control_flow.dao
+++ b/examples/control_flow.dao
@@ -29,15 +29,15 @@ fn fibonacci(n: i32): i32
 
 fn main(): i32
   print("abs(-7):")
-  print_i32(abs(0 - 7))
+  print(abs(0 - 7))
 
   print("max(3, 8):")
-  print_i32(max(3, 8))
+  print(max(3, 8))
 
   print("factorial(6):")
-  print_i32(factorial(6))
+  print(factorial(6))
 
   print("fibonacci(10):")
-  print_i32(fibonacci(10))
+  print(fibonacci(10))
 
   return 0

--- a/examples/generators.dao
+++ b/examples/generators.dao
@@ -13,16 +13,16 @@ fn evens(n: i32): Generator<i32>
 fn main(): i32
   print("countdown from 5:")
   for x in countdown(5):
-    print_i32(x)
+    print(x)
 
   print("first 4 even numbers:")
   for x in evens(4):
-    print_i32(x)
+    print(x)
 
   print("sum of range(5):")
   let total: i32 = 0
   for i in range(5):
     total = total + i
-  print_i32(total)
+  print(total)
 
   return 0

--- a/examples/iteration.dao
+++ b/examples/iteration.dao
@@ -20,12 +20,12 @@ fn nested_iteration(): i32
 fn main(): i32
   print("squares of 0..4:")
   for x in squares(5):
-    print_i32(x)
+    print(x)
 
   print("sum of squares(5):")
-  print_i32(sum_squares(5))
+  print(sum_squares(5))
 
   print("nested iteration total:")
-  print_i32(nested_iteration())
+  print(nested_iteration())
 
   return 0

--- a/examples/pipelines.dao
+++ b/examples/pipelines.dao
@@ -8,10 +8,10 @@ fn transform(x: i32): i32 -> x |> double |> increment
 
 fn main(): i32
   print("5 |> double |> increment:")
-  print_i32(transform(5))
+  print(transform(5))
 
   print("3 |> double |> negate:")
   let result: i32 = 3 |> double |> negate
-  print_i32(result)
+  print(result)
 
   return 0

--- a/examples/structs.dao
+++ b/examples/structs.dao
@@ -23,10 +23,10 @@ fn main(): i32
   print("b = (1, 2)")
 
   print("a + b = :")
-  print_i32(c.x)
-  print_i32(c.y)
+  print(c.x)
+  print(c.y)
 
   print("manhattan(a):")
-  print_i32(manhattan(a))
+  print(manhattan(a))
 
   return 0

--- a/examples/unsafe.dao
+++ b/examples/unsafe.dao
@@ -9,5 +9,5 @@ fn main(): i32
   mode unsafe =>
     let val: i32 = read_ptr(&x)
     print("read via pointer:")
-    print_i32(val)
+    print(val)
   return 0

--- a/stdlib/core/printable.dao
+++ b/stdlib/core/printable.dao
@@ -18,10 +18,4 @@ extend bool as Printable:
 extend string as Printable:
     fn to_string(self): string -> self
 
-fn print(msg: string): void -> __dao_io_write_stdout(msg)
-
-fn print_i32(x: i32): void -> print(__dao_conv_i32_to_string(x))
-
-fn print_f64(x: f64): void -> print(__dao_conv_f64_to_string(x))
-
-fn print_bool(x: bool): void -> print(__dao_conv_bool_to_string(x))
+fn print<T: Printable>(x: T): void -> __dao_io_write_stdout(x.to_string())

--- a/testdata/ast/examples_arithmetic.ast
+++ b/testdata/ast/examples_arithmetic.ast
@@ -1,0 +1,183 @@
+File
+  FunctionDecl square
+    Param x: i32
+    ReturnType: i32
+    ExprBody
+      BinaryExpr *
+        Identifier x
+        Identifier x
+  FunctionDecl cube
+    Param x: i32
+    ReturnType: i32
+    ExprBody
+      BinaryExpr *
+        BinaryExpr *
+          Identifier x
+          Identifier x
+        Identifier x
+  FunctionDecl is_even
+    Param x: i32
+    ReturnType: bool
+    ExprBody
+      BinaryExpr ==
+        Identifier x
+        BinaryExpr *
+          BinaryExpr /
+            Identifier x
+            IntLiteral 2
+          IntLiteral 2
+  FunctionDecl clamp
+    Param x: i32
+    Param lo: i32
+    Param hi: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier x
+          Identifier lo
+      Then
+        ReturnStatement
+          Identifier lo
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier x
+          Identifier hi
+      Then
+        ReturnStatement
+          Identifier hi
+    ReturnStatement
+      Identifier x
+  FunctionDecl sum_range
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    LetStatement total: i32
+      IntLiteral 0
+    LetStatement i: i32
+      Identifier a
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier b
+      Assignment
+        Target
+          Identifier total
+        Value
+          BinaryExpr +
+            Identifier total
+            Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+    ReturnStatement
+      Identifier total
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "square(7):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier square
+            Args
+              IntLiteral 7
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "cube(3):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier cube
+            Args
+              IntLiteral 3
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "is_even(4):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier is_even
+            Args
+              IntLiteral 4
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "is_even(7):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier is_even
+            Args
+              IntLiteral 7
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "clamp(15, 0, 10):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier clamp
+            Args
+              IntLiteral 15
+              IntLiteral 0
+              IntLiteral 10
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "sum_range(1, 11):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier sum_range
+            Args
+              IntLiteral 1
+              IntLiteral 11
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_astar.ast
+++ b/testdata/ast/examples_astar.ast
@@ -13,7 +13,7 @@ File
     Param start: NodeId
     Param goal: NodeId
     ReturnType: i32
-    ExprBody
+    ReturnStatement
       BinaryExpr +
         Identifier start
         Identifier goal
@@ -44,3 +44,45 @@ File
           Identifier goal
     ReturnStatement
       Identifier cost
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement cost: i32
+      CallExpr
+        Callee
+          Identifier a_star
+        Args
+          IntLiteral 3
+          IntLiteral 7
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "a_star(3, 7) cost:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier cost
+    LetStatement same: i32
+      CallExpr
+        Callee
+          Identifier a_star
+        Args
+          IntLiteral 5
+          IntLiteral 5
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "a_star(5, 5) cost:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier same
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_control_flow.ast
+++ b/testdata/ast/examples_control_flow.ast
@@ -1,0 +1,166 @@
+File
+  FunctionDecl abs
+    Param x: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier x
+          IntLiteral 0
+      Then
+        ReturnStatement
+          BinaryExpr -
+            IntLiteral 0
+            Identifier x
+    ReturnStatement
+      Identifier x
+  FunctionDecl max
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier a
+          Identifier b
+      Then
+        ReturnStatement
+          Identifier a
+    ReturnStatement
+      Identifier b
+  FunctionDecl factorial
+    Param n: i32
+    ReturnType: i32
+    LetStatement result: i32
+      IntLiteral 1
+    LetStatement i: i32
+      IntLiteral 1
+    WhileStatement
+      Condition
+        BinaryExpr <=
+          Identifier i
+          Identifier n
+      Assignment
+        Target
+          Identifier result
+        Value
+          BinaryExpr *
+            Identifier result
+            Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+    ReturnStatement
+      Identifier result
+  FunctionDecl fibonacci
+    Param n: i32
+    ReturnType: i32
+    LetStatement a: i32
+      IntLiteral 0
+    LetStatement b: i32
+      IntLiteral 1
+    LetStatement i: i32
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier n
+      LetStatement tmp: i32
+        Identifier b
+      Assignment
+        Target
+          Identifier b
+        Value
+          BinaryExpr +
+            Identifier a
+            Identifier b
+      Assignment
+        Target
+          Identifier a
+        Value
+          Identifier tmp
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+    ReturnStatement
+      Identifier a
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "abs(-7):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier abs
+            Args
+              BinaryExpr -
+                IntLiteral 0
+                IntLiteral 7
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "max(3, 8):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier max
+            Args
+              IntLiteral 3
+              IntLiteral 8
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "factorial(6):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier factorial
+            Args
+              IntLiteral 6
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "fibonacci(10):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier fibonacci
+            Args
+              IntLiteral 10
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_generators.ast
+++ b/testdata/ast/examples_generators.ast
@@ -1,27 +1,8 @@
 File
-  FunctionDecl range
-    Param n: i32
-    ReturnType: Generator<i32>
-    LetStatement i
-      IntLiteral 0
-    WhileStatement
-      Condition
-        BinaryExpr <
-          Identifier i
-          Identifier n
-      YieldStatement
-        Identifier i
-      Assignment
-        Target
-          Identifier i
-        Value
-          BinaryExpr +
-            Identifier i
-            IntLiteral 1
   FunctionDecl countdown
     Param from: i32
     ReturnType: Generator<i32>
-    LetStatement i
+    LetStatement i: i32
       Identifier from
     WhileStatement
       Condition
@@ -40,7 +21,7 @@ File
   FunctionDecl evens
     Param n: i32
     ReturnType: Generator<i32>
-    LetStatement i
+    LetStatement i: i32
       IntLiteral 0
     WhileStatement
       Condition
@@ -58,37 +39,73 @@ File
           BinaryExpr +
             Identifier i
             IntLiteral 1
-  FunctionDecl sum_range
-    Param n: i32
+  FunctionDecl main
     ReturnType: i32
-    LetStatement total
-      IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "countdown from 5:"
     ForStatement x
       Iterable
         CallExpr
           Callee
-            Identifier range
+            Identifier countdown
           Args
-            Identifier n
-      Assignment
-        Target
-          Identifier total
-        Value
-          BinaryExpr +
-            Identifier total
+            IntLiteral 5
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
             Identifier x
-    ReturnStatement
-      Identifier total
-  FunctionDecl first_even
-    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "first 4 even numbers:"
     ForStatement x
       Iterable
         CallExpr
           Callee
             Identifier evens
           Args
+            IntLiteral 4
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            Identifier x
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "sum of range(5):"
+    LetStatement total: i32
+      IntLiteral 0
+    ForStatement i
+      Iterable
+        CallExpr
+          Callee
+            Identifier range
+          Args
             IntLiteral 5
-      ReturnStatement
-        Identifier x
+      Assignment
+        Target
+          Identifier total
+        Value
+          BinaryExpr +
+            Identifier total
+            Identifier i
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier total
     ReturnStatement
       IntLiteral 0

--- a/testdata/ast/examples_hello.ast
+++ b/testdata/ast/examples_hello.ast
@@ -1,7 +1,4 @@
 File
-  ExternFunctionDecl print
-    Param msg: string
-    ReturnType: void
   FunctionDecl main
     ReturnType: i32
     ExpressionStatement
@@ -9,6 +6,12 @@ File
         Callee
           Identifier print
         Args
-          StringLiteral "hello, dao"
+          StringLiteral "hello, dao!"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "welcome to the playground"
     ReturnStatement
       IntLiteral 0

--- a/testdata/ast/examples_iteration.ast
+++ b/testdata/ast/examples_iteration.ast
@@ -1,27 +1,8 @@
 File
-  FunctionDecl range
-    Param n: i32
-    ReturnType: Generator<i32>
-    LetStatement i
-      IntLiteral 0
-    WhileStatement
-      Condition
-        BinaryExpr <
-          Identifier i
-          Identifier n
-      YieldStatement
-        Identifier i
-      Assignment
-        Target
-          Identifier i
-        Value
-          BinaryExpr +
-            Identifier i
-            IntLiteral 1
   FunctionDecl squares
     Param n: i32
     ReturnType: Generator<i32>
-    LetStatement i
+    LetStatement i: i32
       IntLiteral 0
     WhileStatement
       Condition
@@ -42,7 +23,7 @@ File
   FunctionDecl sum_squares
     Param n: i32
     ReturnType: i32
-    LetStatement total
+    LetStatement total: i32
       IntLiteral 0
     ForStatement x
       Iterable
@@ -60,32 +41,9 @@ File
             Identifier x
     ReturnStatement
       Identifier total
-  FunctionDecl count_positive
-    Param gen: Generator<i32>
-    ReturnType: i32
-    LetStatement count
-      IntLiteral 0
-    ForStatement x
-      Iterable
-        Identifier gen
-      IfStatement
-        Condition
-          BinaryExpr >
-            Identifier x
-            IntLiteral 0
-        Then
-          Assignment
-            Target
-              Identifier count
-            Value
-              BinaryExpr +
-                Identifier count
-                IntLiteral 1
-    ReturnStatement
-      Identifier count
   FunctionDecl nested_iteration
     ReturnType: i32
-    LetStatement total
+    LetStatement total: i32
       IntLiteral 0
     ForStatement i
       Iterable
@@ -112,3 +70,56 @@ File
               Identifier j
     ReturnStatement
       Identifier total
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "squares of 0..4:"
+    ForStatement x
+      Iterable
+        CallExpr
+          Callee
+            Identifier squares
+          Args
+            IntLiteral 5
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            Identifier x
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "sum of squares(5):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier sum_squares
+            Args
+              IntLiteral 5
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "nested iteration total:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier nested_iteration
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_pipelines.ast
+++ b/testdata/ast/examples_pipelines.ast
@@ -13,6 +13,13 @@ File
       BinaryExpr +
         Identifier x
         IntLiteral 1
+  FunctionDecl negate
+    Param x: i32
+    ReturnType: i32
+    ExprBody
+      BinaryExpr -
+        IntLiteral 0
+        Identifier x
   FunctionDecl transform
     Param x: i32
     ReturnType: i32
@@ -22,3 +29,41 @@ File
           Identifier x
           Identifier double
         Identifier increment
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "5 |> double |> increment:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier transform
+            Args
+              IntLiteral 5
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "3 |> double |> negate:"
+    LetStatement result: i32
+      PipeExpr
+        PipeExpr
+          IntLiteral 3
+          Identifier double
+        Identifier negate
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier result
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_structs.ast
+++ b/testdata/ast/examples_structs.ast
@@ -1,0 +1,135 @@
+File
+  ClassDecl Point
+    Field x: i32
+    Field y: i32
+  FunctionDecl manhattan
+    Param p: Point
+    ReturnType: i32
+    LetStatement ax: i32
+      FieldExpr .x
+        Identifier p
+    LetStatement ay: i32
+      FieldExpr .y
+        Identifier p
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier ax
+          IntLiteral 0
+      Then
+        Assignment
+          Target
+            Identifier ax
+          Value
+            BinaryExpr -
+              IntLiteral 0
+              Identifier ax
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier ay
+          IntLiteral 0
+      Then
+        Assignment
+          Target
+            Identifier ay
+          Value
+            BinaryExpr -
+              IntLiteral 0
+              Identifier ay
+    ReturnStatement
+      BinaryExpr +
+        Identifier ax
+        Identifier ay
+  FunctionDecl add_points
+    Param a: Point
+    Param b: Point
+    ReturnType: Point
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Point
+        Args
+          BinaryExpr +
+            FieldExpr .x
+              Identifier a
+            FieldExpr .x
+              Identifier b
+          BinaryExpr +
+            FieldExpr .y
+              Identifier a
+            FieldExpr .y
+              Identifier b
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement a: Point
+      CallExpr
+        Callee
+          Identifier Point
+        Args
+          IntLiteral 3
+          IntLiteral 4
+    LetStatement b: Point
+      CallExpr
+        Callee
+          Identifier Point
+        Args
+          IntLiteral 1
+          IntLiteral 2
+    LetStatement c: Point
+      CallExpr
+        Callee
+          Identifier add_points
+        Args
+          Identifier a
+          Identifier b
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "a = (3, 4)"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "b = (1, 2)"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "a + b = :"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          FieldExpr .x
+            Identifier c
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          FieldExpr .y
+            Identifier c
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "manhattan(a):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier manhattan
+            Args
+              Identifier a
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_unsafe.ast
+++ b/testdata/ast/examples_unsafe.ast
@@ -1,8 +1,9 @@
 File
-  FunctionDecl read
+  FunctionDecl read_ptr
     Param ptr: *i32
     ReturnType: i32
     LetStatement value: i32
+      IntLiteral 0
     ModeBlock unsafe
       Assignment
         Target
@@ -12,3 +13,29 @@ File
             Identifier ptr
     ReturnStatement
       Identifier value
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement x: i32
+      IntLiteral 42
+    ModeBlock unsafe
+      LetStatement val: i32
+        CallExpr
+          Callee
+            Identifier read_ptr
+          Args
+            UnaryExpr &
+              Identifier x
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            StringLiteral "read via pointer:"
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            Identifier val
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/stdlib_core_printable.ast
+++ b/testdata/ast/stdlib_core_printable.ast
@@ -51,12 +51,15 @@ File
       ReturnType: string
       ExprBody
         Identifier self
-  FunctionDecl print
-    Param msg: string
+  FunctionDecl print<T: Printable>
+    Param x: T
     ReturnType: void
     ExprBody
       CallExpr
         Callee
           Identifier __dao_io_write_stdout
         Args
-          Identifier msg
+          CallExpr
+            Callee
+              FieldExpr .to_string
+                Identifier x

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -15,6 +15,7 @@
 #include "backend/llvm/llvm_backend.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
+#include "ir/mir/mir_monomorphize.h"
 #include "ir/mir/mir_printer.h"
 
 #include <nlohmann/json.hpp>
@@ -236,6 +237,12 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
         MirContext mir_ctx;
         auto mir_result =
             build_mir(*hir_result.module, mir_ctx, types);
+
+        if (mir_result.module != nullptr) {
+          auto mono = monomorphize(*mir_result.module, mir_ctx, types);
+          collect_diagnostics(diagnostics, source, mono.diagnostics,
+                              prelude_bytes, prelude_lines);
+        }
 
         for (const auto& diag : mir_result.diagnostics) {
           if (diag.span.offset < prelude_bytes) {


### PR DESCRIPTION
## Summary

Second repo audit pass: modernize the stdlib and examples to use generic print, fix a missing monomorphize call in the playground, update roadmap with accurate status markers.

## Highlights

- **Generic `print<T: Printable>`**: replaces `print(string)`, `print_i32`, `print_f64`, `print_bool` with a single generic function. All 9 examples updated.
- **Playground fix**: analyze endpoint was missing the monomorphize call, causing LLVM assertion failures on any code using generic prelude functions.
- **ROADMAP.md**: all phases and tooling tracks now have explicit status markers reflecting current progress.
- **Golden files**: regenerated for stdlib and all examples; created missing golden files for arithmetic, control_flow, structs.

## Test plan

- [x] All 9 examples compile and produce correct output with generic `print`
- [x] `print(42)`, `print(3.14)`, `print(true)`, `print("hello")` all work
- [x] Playground `/api/run` and `/api/analyze` work with generic print
- [x] Test suite: same 2 pre-existing failures (resolve/semantic_tokens corpus tests lacking prelude), no regressions
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)