### PR TITLE
chore(repo): 🎨 audit pass 3 — fix all test failures, flatten analyze, update IMPL_PLAN

### DIFF
--- a/compiler/analysis/semantic_tokens_test.cpp
+++ b/compiler/analysis/semantic_tokens_test.cpp
@@ -336,9 +336,9 @@ suite<"taxonomy_coverage"> taxonomy_coverage = [] {
       categories.insert(tok.kind);
     }
 
-    // hello.dao has: extern fn, print("hello, dao"), 0, i32
-    expect(categories.contains("keyword.extern")) << "missing keyword.extern";
+    // hello.dao has: fn main(): i32, print("hello, dao!"), return 0
     expect(categories.contains("keyword.fn")) << "missing keyword.fn";
+    expect(categories.contains("keyword.return")) << "missing keyword.return";
     expect(categories.contains("decl.function")) << "missing decl.function";
     expect(categories.contains("literal.number")) << "missing literal.number";
     expect(categories.contains("literal.string")) << "missing literal.string";

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -25,7 +25,8 @@ struct ResolvedSource {
   ResolveResult resolve_result;
 };
 
-auto resolve_source(const std::string& name, std::string contents) -> ResolvedSource {
+auto resolve_source(const std::string& name, std::string contents,
+                    uint32_t prelude_bytes = 0) -> ResolvedSource {
   SourceBuffer source(name, std::move(contents));
   auto lex_result = lex(source);
   ParseResult parse_result;
@@ -34,7 +35,7 @@ auto resolve_source(const std::string& name, std::string contents) -> ResolvedSo
   if (lex_result.diagnostics.empty()) {
     parse_result = parse(lex_result.tokens);
     if (parse_result.file != nullptr) {
-      resolve_result = resolve(*parse_result.file);
+      resolve_result = resolve(*parse_result.file, prelude_bytes);
     }
   }
 
@@ -42,6 +43,23 @@ auto resolve_source(const std::string& name, std::string contents) -> ResolvedSo
           std::move(lex_result),
           std::move(parse_result),
           std::move(resolve_result)};
+}
+
+auto load_prelude() -> std::string {
+  std::filesystem::path root(DAO_SOURCE_DIR);
+  auto stdlib_core = root / "stdlib" / "core";
+  std::string prelude;
+  if (!std::filesystem::exists(stdlib_core)) {
+    return prelude;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(stdlib_core)) {
+    if (entry.path().extension() != ".dao") {
+      continue;
+    }
+    prelude += read_file(entry.path());
+    prelude += '\n';
+  }
+  return prelude;
 }
 
 auto has_diagnostic_containing(const ResolveResult& result, const std::string& text) -> bool {
@@ -304,18 +322,24 @@ suite<"resolve_corpus"> resolve_corpus = [] {
   "all examples resolve without spurious diagnostics"_test = [] {
     std::filesystem::path root(DAO_SOURCE_DIR);
     auto examples_dir = root / "examples";
+    auto prelude = load_prelude();
+    auto prelude_bytes = static_cast<uint32_t>(prelude.size());
 
     for (const auto& entry : std::filesystem::directory_iterator(examples_dir)) {
       if (entry.path().extension() != ".dao") {
         continue;
       }
 
-      auto contents = read_file(entry.path());
-      auto result = resolve_source(entry.path().filename().string(), std::move(contents));
+      auto contents = prelude + read_file(entry.path());
+      auto result = resolve_source(entry.path().filename().string(),
+                                   std::move(contents), prelude_bytes);
 
       // No value-position diagnostics should fire on example files.
+      // Skip prelude-origin diagnostics.
       for (const auto& diag : result.resolve_result.diagnostics) {
-        // Print diagnostic for debugging if it fires.
+        if (diag.span.offset < prelude_bytes) {
+          continue;
+        }
         expect(false) << entry.path().filename().string() << ": " << diag.message;
       }
     }

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -206,7 +206,9 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
       goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
-    monomorphize(*mir_result.module, mir_ctx, types);
+    auto mono_result = monomorphize(*mir_result.module, mir_ctx, types);
+    collect_diagnostics(diagnostics, source, mono_result.diagnostics,
+                        prelude_bytes, prelude_lines);
 
     std::ostringstream mir_out;
     print_mir(mir_out, *mir_result.module);

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -1,3 +1,4 @@
+// NOLINTBEGIN(readability-magic-numbers)
 #include "analyze.h"
 #include "pipeline.h"
 #include "token_category.h"
@@ -25,7 +26,59 @@
 
 namespace dao::playground {
 
-// NOLINTBEGIN(readability-magic-numbers)
+// ---------------------------------------------------------------------------
+// Token serialization (user-visible tokens only, prelude filtered)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+void build_token_array(nlohmann::json& out, const LexResult& lex_result,
+                       const SourceBuffer& source, uint32_t prelude_bytes,
+                       uint32_t prelude_lines) {
+  for (const auto& tok : lex_result.tokens) {
+    if (is_synthetic_token(tok.kind) || tok.span.offset < prelude_bytes) {
+      continue;
+    }
+    auto loc = source.line_col(tok.span.offset);
+    auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
+    out.push_back({
+        {"kind", token_kind_name(tok.kind)},
+        {"category", token_category(tok.kind)},
+        {"offset", tok.span.offset - prelude_bytes},
+        {"length", tok.span.length},
+        {"line", line},
+        {"col", loc.col},
+        {"text", std::string(tok.text)},
+    });
+  }
+}
+
+void build_semantic_tokens(nlohmann::json& out,
+                           const std::vector<SemanticToken>& sem_tokens,
+                           const SourceBuffer& source,
+                           uint32_t prelude_bytes, uint32_t prelude_lines) {
+  for (const auto& stok : sem_tokens) {
+    if (stok.span.offset < prelude_bytes) {
+      continue;
+    }
+    auto loc = source.line_col(stok.span.offset);
+    auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
+    out.push_back({
+        {"kind", stok.kind},
+        {"offset", stok.span.offset - prelude_bytes},
+        {"length", stok.span.length},
+        {"line", line},
+        {"col", loc.col},
+    });
+  }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
 void handle_analyze(const httplib::Request& req, httplib::Response& res,
                     const std::filesystem::path& repo_root) {
   nlohmann::json request;
@@ -43,274 +96,138 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
     return;
   }
 
-  // Load prelude and prepend to user source.
+  // --- Setup ---
   auto prelude_source = load_prelude(repo_root);
   auto prelude_bytes = static_cast<uint32_t>(prelude_source.size());
   auto prelude_lines = count_lines(prelude_source);
 
   auto user_source = request["source"].get<std::string>();
-  auto combined = prelude_source + user_source;
-  SourceBuffer source("<playground>", std::move(combined));
-  auto lex_result = lex(source);
+  SourceBuffer source("<playground>",  prelude_source + user_source);
 
-  // Build token array (filtering synthetic tokens, skipping prelude tokens).
+  // --- Response accumulators ---
   nlohmann::json tokens = nlohmann::json::array();
-  for (const auto& tok : lex_result.tokens) {
-    if (is_synthetic_token(tok.kind)) {
-      continue;
-    }
-    if (tok.span.offset < prelude_bytes) {
-      continue;
-    }
-    auto loc = source.line_col(tok.span.offset);
-    auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-    tokens.push_back({
-        {"kind", token_kind_name(tok.kind)},
-        {"category", token_category(tok.kind)},
-        {"offset", tok.span.offset - prelude_bytes},
-        {"length", tok.span.length},
-        {"line", line},
-        {"col", loc.col},
-        {"text", std::string(tok.text)},
-    });
-  }
-
-  // Collect diagnostics from lexer (skip prelude-origin).
   nlohmann::json diagnostics = nlohmann::json::array();
-  for (const auto& diag : lex_result.diagnostics) {
-    if (diag.span.offset < prelude_bytes) {
-      continue;
-    }
-    auto loc = source.line_col(diag.span.offset);
-    auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-    diagnostics.push_back({
-        {"severity", "error"},
-        {"offset", diag.span.offset - prelude_bytes},
-        {"length", diag.span.length},
-        {"line", line},
-        {"col", loc.col},
-        {"message", diag.message},
-    });
+  nlohmann::json semantic_tokens_json = nlohmann::json::array();
+  std::string ast_text;
+  std::string hir_text;
+  std::string mir_text;
+  std::string llvm_ir_text;
+
+  // --- Lex ---
+  auto lex_result = lex(source);
+  build_token_array(tokens, lex_result, source, prelude_bytes, prelude_lines);
+  collect_diagnostics(diagnostics, source, lex_result.diagnostics,
+                      prelude_bytes, prelude_lines);
+
+  if (has_user_error(lex_result.diagnostics, prelude_bytes)) {
+    goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
   }
 
-  // Only parse if lexing succeeded — matches CLI behavior.
-  std::string ast_text;
-  ParseResult parse_result;
-  if (!has_user_error(lex_result.diagnostics, prelude_bytes)) {
-    parse_result = parse(lex_result.tokens);
+  {
+    // --- Parse ---
+    auto parse_result = parse(lex_result.tokens);
+    collect_diagnostics(diagnostics, source, parse_result.diagnostics,
+                        prelude_bytes, prelude_lines);
 
-    for (const auto& diag : parse_result.diagnostics) {
-      if (diag.span.offset < prelude_bytes) {
-        continue;
-      }
-      auto loc = source.line_col(diag.span.offset);
-      auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-      diagnostics.push_back({
-          {"severity", "error"},
-          {"offset", diag.span.offset - prelude_bytes},
-          {"length", diag.span.length},
-          {"line", line},
-          {"col", loc.col},
-          {"message", diag.message},
-      });
+    if (has_user_error(parse_result.diagnostics, prelude_bytes) ||
+        parse_result.file == nullptr) {
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
-    // Only emit AST when there are no diagnostics at all.
-    if (diagnostics.empty() && parse_result.file != nullptr) {
+    if (diagnostics.empty()) {
       std::ostringstream ast_out;
       print_ast(ast_out, *parse_result.file);
       ast_text = ast_out.str();
     }
-  }
 
-  // Run name resolution when lex/parse succeeded without errors.
-  // Resolve diagnostics are surfaced to the user but do NOT gate
-  // semantic token classification — partial resolve results still
-  // improve highlighting for the tokens that did resolve.
-  ResolveResult resolve_result;
-  bool lex_parse_clean = !has_user_error(lex_result.diagnostics, prelude_bytes) &&
-                         !has_user_error(parse_result.diagnostics, prelude_bytes) &&
-                         parse_result.file != nullptr;
-  if (lex_parse_clean) {
-    resolve_result = resolve(*parse_result.file, prelude_bytes);
+    // --- Resolve ---
+    auto resolve_result = resolve(*parse_result.file, prelude_bytes);
+    collect_diagnostics(diagnostics, source, resolve_result.diagnostics,
+                        prelude_bytes, prelude_lines);
 
-    for (const auto& diag : resolve_result.diagnostics) {
-      if (diag.span.offset < prelude_bytes) {
-        continue;
-      }
-      auto loc = source.line_col(diag.span.offset);
-      auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-      diagnostics.push_back({
-          {"severity", "error"},
-          {"offset", diag.span.offset - prelude_bytes},
-          {"length", diag.span.length},
-          {"line", line},
-          {"col", loc.col},
-          {"message", diag.message},
-      });
-    }
-  }
-
-  // Produce semantic token classification when lex/parse succeeded.
-  // Resolve diagnostics do not suppress tokens — classify_tokens()
-  // gracefully handles partial resolve results.
-  nlohmann::json semantic_tokens_json = nlohmann::json::array();
-  if (lex_parse_clean) {
+    // Semantic tokens — always classify when lex/parse succeeded.
     auto sem_tokens =
         classify_tokens(lex_result.tokens, parse_result.file, &resolve_result);
-    for (const auto& stok : sem_tokens) {
-      if (stok.span.offset < prelude_bytes) {
-        continue;
-      }
-      auto loc = source.line_col(stok.span.offset);
-      auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-      semantic_tokens_json.push_back({
-          {"kind", stok.kind},
-          {"offset", stok.span.offset - prelude_bytes},
-          {"length", stok.span.length},
-          {"line", line},
-          {"col", loc.col},
-      });
-    }
-  }
+    build_semantic_tokens(semantic_tokens_json, sem_tokens, source,
+                          prelude_bytes, prelude_lines);
 
-  // Run type checking, HIR, MIR, and LLVM IR when lex/parse/resolve
-  // succeeded without errors. Typecheck warnings are surfaced but do
-  // not gate IR.
-  std::string hir_text;
-  std::string mir_text;
-  std::string llvm_ir_text;
-  TypeContext types;
-  bool resolve_clean =
-      lex_parse_clean && !has_user_error(resolve_result.diagnostics, prelude_bytes);
-  if (resolve_clean) {
+    if (has_user_error(resolve_result.diagnostics, prelude_bytes)) {
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
+    // --- Typecheck ---
+    TypeContext types;
     auto check_result =
         typecheck(*parse_result.file, resolve_result, types);
+    collect_diagnostics(diagnostics, source, check_result.diagnostics,
+                        prelude_bytes, prelude_lines);
 
-    bool has_errors = false;
+    bool has_tc_errors = false;
     for (const auto& diag : check_result.diagnostics) {
-      if (diag.span.offset < prelude_bytes) {
-        continue;
-      }
-      auto loc = source.line_col(diag.span.offset);
-      auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-      diagnostics.push_back({
-          {"severity",
-           diag.severity == Severity::Error ? "error" : "warning"},
-          {"offset", diag.span.offset - prelude_bytes},
-          {"length", diag.span.length},
-          {"line", line},
-          {"col", loc.col},
-          {"message", diag.message},
-      });
-      if (diag.severity == Severity::Error) {
-        has_errors = true;
+      if (diag.span.offset >= prelude_bytes &&
+          diag.severity == Severity::Error) {
+        has_tc_errors = true;
       }
     }
+    if (has_tc_errors) {
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
+    }
 
-    if (!has_errors) {
-      HirContext hir_ctx;
-      auto hir_result = build_hir(*parse_result.file, resolve_result,
-                                  check_result, hir_ctx);
+    // --- HIR ---
+    HirContext hir_ctx;
+    auto hir_result = build_hir(*parse_result.file, resolve_result,
+                                check_result, hir_ctx);
+    collect_diagnostics(diagnostics, source, hir_result.diagnostics,
+                        prelude_bytes, prelude_lines);
 
-      for (const auto& diag : hir_result.diagnostics) {
-        if (diag.span.offset < prelude_bytes) {
-          continue;
-        }
-        auto loc = source.line_col(diag.span.offset);
-        auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-        diagnostics.push_back({
-            {"severity", "error"},
-            {"offset", diag.span.offset - prelude_bytes},
-            {"length", diag.span.length},
-            {"line", line},
-            {"col", loc.col},
-            {"message", diag.message},
-        });
-      }
-
-      if (hir_result.module != nullptr) {
-        std::ostringstream hir_out;
-        print_hir(hir_out, *hir_result.module);
-        hir_text = hir_out.str();
-
-        MirContext mir_ctx;
-        auto mir_result =
-            build_mir(*hir_result.module, mir_ctx, types);
-
-        if (mir_result.module != nullptr) {
-          auto mono = monomorphize(*mir_result.module, mir_ctx, types);
-          collect_diagnostics(diagnostics, source, mono.diagnostics,
-                              prelude_bytes, prelude_lines);
-        }
-
-        for (const auto& diag : mir_result.diagnostics) {
-          if (diag.span.offset < prelude_bytes) {
-            continue;
-          }
-          auto loc = source.line_col(diag.span.offset);
-          auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-          diagnostics.push_back({
-              {"severity", "error"},
-              {"offset", diag.span.offset - prelude_bytes},
-              {"length", diag.span.length},
-              {"line", line},
-              {"col", loc.col},
-              {"message", diag.message},
-          });
-        }
-
-        if (mir_result.module == nullptr &&
-            !has_user_error(mir_result.diagnostics, prelude_bytes)) {
-          diagnostics.push_back(
-              make_internal_error("MIR lowering failed (possible prelude error)"));
-        }
-
-        if (mir_result.module != nullptr) {
-          std::ostringstream mir_out;
-          print_mir(mir_out, *mir_result.module);
-          mir_text = mir_out.str();
-
-          // LLVM IR lowering — gate on MIR success.
-          llvm::LLVMContext llvm_ctx;
-          LlvmBackend llvm_backend(llvm_ctx);
-          auto llvm_result = llvm_backend.lower(*mir_result.module, prelude_bytes);
-
-          for (const auto& diag : llvm_result.diagnostics) {
-            if (diag.severity == Severity::Warning &&
-                diag.span.offset < prelude_bytes) {
-              continue;
-            }
-            if (diag.span.offset < prelude_bytes) {
-              continue;
-            }
-            auto loc = source.line_col(diag.span.offset);
-            auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
-            diagnostics.push_back({
-                {"severity",
-                 diag.severity == Severity::Error ? "error" : "warning"},
-                {"offset", diag.span.offset - prelude_bytes},
-                {"length", diag.span.length},
-                {"line", line},
-                {"col", loc.col},
-                {"message", diag.message},
-            });
-          }
-
-          if (llvm_result.module != nullptr &&
-              !has_user_error(llvm_result.diagnostics, prelude_bytes)) {
-            std::ostringstream llvm_out;
-            LlvmBackend::print_ir(llvm_out, *llvm_result.module);
-            llvm_ir_text = llvm_out.str();
-          }
-        }
-      } else if (!has_user_error(hir_result.diagnostics, prelude_bytes)) {
+    if (hir_result.module == nullptr) {
+      if (!has_user_error(hir_result.diagnostics, prelude_bytes)) {
         diagnostics.push_back(
             make_internal_error("HIR lowering failed (possible prelude error)"));
       }
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
+    std::ostringstream hir_out;
+    print_hir(hir_out, *hir_result.module);
+    hir_text = hir_out.str();
+
+    // --- MIR ---
+    MirContext mir_ctx;
+    auto mir_result = build_mir(*hir_result.module, mir_ctx, types);
+    collect_diagnostics(diagnostics, source, mir_result.diagnostics,
+                        prelude_bytes, prelude_lines);
+
+    if (mir_result.module == nullptr) {
+      if (!has_user_error(mir_result.diagnostics, prelude_bytes)) {
+        diagnostics.push_back(
+            make_internal_error("MIR lowering failed (possible prelude error)"));
+      }
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
+    monomorphize(*mir_result.module, mir_ctx, types);
+
+    std::ostringstream mir_out;
+    print_mir(mir_out, *mir_result.module);
+    mir_text = mir_out.str();
+
+    // --- LLVM IR ---
+    llvm::LLVMContext llvm_ctx;
+    LlvmBackend llvm_backend(llvm_ctx);
+    auto llvm_result = llvm_backend.lower(*mir_result.module, prelude_bytes);
+    collect_diagnostics(diagnostics, source, llvm_result.diagnostics,
+                        prelude_bytes, prelude_lines);
+
+    if (llvm_result.module != nullptr &&
+        !has_user_error(llvm_result.diagnostics, prelude_bytes)) {
+      std::ostringstream llvm_out;
+      LlvmBackend::print_ir(llvm_out, *llvm_result.module);
+      llvm_ir_text = llvm_out.str();
     }
   }
 
+respond:
   nlohmann::json response = {
       {"tokens", tokens},
       {"semanticTokens", semantic_tokens_json},


### PR DESCRIPTION
## Summary

Third and final audit pass: fix all pre-existing test failures, flatten the worst complexity hotspot, and update documentation.

## Highlights

- **100% test pass rate**: fix the 2 pre-existing corpus test failures (was 80%). Resolve test now prepends stdlib prelude. Semantic tokens test updated for hello.dao after generic print migration.
- **`handle_analyze` CC 142 → 27**: rewritten as flat pipeline with early exits. 7 inline diagnostic loops replaced with shared `collect_diagnostics()`. Token serialization extracted into helpers. Net -83 lines.
- Both fixes verified against the full test suite and playground.

## Complexity summary after all audit passes

| Function | Before | After |
|---|---|---|
| `handle_analyze` | 142 | **27** |
| `lookup_method` | 160 | 41 |
| `monomorphize` | 88 | 27 |
| `check_call` | 49 | <25 |
| `check_pipe` | 40 | <25 |
| Tests passing | 80% | **100%** |

## Test plan

- [x] `ctest --test-dir build/debug`: 10/10 tests pass
- [x] All 9 examples compile and run
- [x] Playground `/api/analyze` returns all panels (tokens, semanticTokens, ast, hir, mir, llvm_ir)
- [x] Playground `/api/analyze` correctly reports errors and gates IR panels
- [x] Playground `/api/run` works with generic print
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)