### PR TITLE
feat(tooling): ✨ add hover and go-to-definition for playground

### DIFF
--- a/compiler/analysis/CMakeLists.txt
+++ b/compiler/analysis/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(dao_analysis STATIC
+  goto_definition.cpp
+  hover.cpp
   semantic_tokens.cpp
 )
 

--- a/compiler/analysis/goto_definition.cpp
+++ b/compiler/analysis/goto_definition.cpp
@@ -1,0 +1,26 @@
+#include "analysis/goto_definition.h"
+
+namespace dao {
+
+auto query_definition(uint32_t offset, const ResolveResult& resolve)
+    -> std::optional<DefinitionLocation> {
+  const Symbol* sym = nullptr;
+
+  auto use_it = resolve.uses.find(offset);
+  if (use_it != resolve.uses.end()) {
+    sym = use_it->second;
+  }
+
+  if (sym == nullptr) {
+    return std::nullopt;
+  }
+
+  // Must have a valid declaration span.
+  if (sym->decl_span.length == 0) {
+    return std::nullopt;
+  }
+
+  return DefinitionLocation{sym->decl_span.offset, sym->decl_span.length};
+}
+
+} // namespace dao

--- a/compiler/analysis/goto_definition.h
+++ b/compiler/analysis/goto_definition.h
@@ -1,0 +1,23 @@
+#ifndef DAO_ANALYSIS_GOTO_DEFINITION_H
+#define DAO_ANALYSIS_GOTO_DEFINITION_H
+
+#include "frontend/diagnostics/source.h"
+#include "frontend/resolve/resolve.h"
+
+#include <optional>
+
+namespace dao {
+
+struct DefinitionLocation {
+  uint32_t offset;
+  uint32_t length;
+};
+
+/// Find the declaration site for the symbol at the given use-site offset.
+/// Returns nullopt if no symbol is found or it has no declaration span.
+auto query_definition(uint32_t offset, const ResolveResult& resolve)
+    -> std::optional<DefinitionLocation>;
+
+} // namespace dao
+
+#endif // DAO_ANALYSIS_GOTO_DEFINITION_H

--- a/compiler/analysis/hover.cpp
+++ b/compiler/analysis/hover.cpp
@@ -1,0 +1,106 @@
+#include "analysis/hover.h"
+
+#include "frontend/resolve/symbol.h"
+#include "frontend/types/type_printer.h"
+
+namespace dao {
+
+auto query_hover(uint32_t offset, const ResolveResult& resolve,
+                 const TypeCheckResult& typed)
+    -> std::optional<HoverResult> {
+  const Symbol* sym = nullptr;
+
+  // Check use sites first (references like `add(1, 2)`).
+  auto use_it = resolve.uses.find(offset);
+  if (use_it != resolve.uses.end()) {
+    sym = use_it->second;
+  }
+
+  // If not a use site, check declaration sites.
+  if (sym == nullptr) {
+    for (const auto& sym_ptr : resolve.context.symbols()) {
+      if (sym_ptr->decl_span.offset == offset && sym_ptr->decl_span.length > 0) {
+        sym = sym_ptr.get();
+        break;
+      }
+    }
+  }
+
+  if (sym == nullptr) {
+    return std::nullopt;
+  }
+
+  HoverResult result;
+  result.name = std::string(sym->name);
+
+  switch (sym->kind) {
+  case SymbolKind::Function:
+    result.symbol_kind = "function";
+    break;
+  case SymbolKind::Type:
+    result.symbol_kind = "type";
+    break;
+  case SymbolKind::Param:
+    result.symbol_kind = "parameter";
+    break;
+  case SymbolKind::Local:
+    result.symbol_kind = "variable";
+    break;
+  case SymbolKind::Field:
+    result.symbol_kind = "field";
+    break;
+  case SymbolKind::Module:
+    result.symbol_kind = "module";
+    break;
+  case SymbolKind::Builtin:
+    result.symbol_kind = "type";
+    break;
+  case SymbolKind::Predeclared:
+    result.symbol_kind = "type";
+    break;
+  case SymbolKind::LambdaParam:
+    result.symbol_kind = "parameter";
+    break;
+  case SymbolKind::GenericParam:
+    result.symbol_kind = "type parameter";
+    break;
+  case SymbolKind::Concept:
+    result.symbol_kind = "concept";
+    break;
+  }
+
+  // Try to find type info from the typed results.
+  // For expressions at use sites, the expression type is in the typed
+  // results keyed by the Expr*. But we don't have the Expr* from just
+  // an offset — we have the Symbol*. Try the decl type instead.
+  if (sym->decl != nullptr &&
+      (sym->kind == SymbolKind::Function ||
+       sym->kind == SymbolKind::Type ||
+       sym->kind == SymbolKind::Param)) {
+    const auto* decl = static_cast<const Decl*>(sym->decl);
+    const auto* decl_type = typed.typed.decl_type(decl);
+    if (decl_type != nullptr) {
+      result.type = print_type(decl_type);
+    }
+  }
+
+  // For local variables, the type comes from the Stmt.
+  if (sym->kind == SymbolKind::Local && sym->decl != nullptr) {
+    const auto* stmt = static_cast<const Stmt*>(sym->decl);
+    const auto* local_type = typed.typed.local_type(stmt);
+    if (local_type != nullptr) {
+      result.type = print_type(local_type);
+    }
+  }
+
+  // For builtins and predeclared, use the name as the type.
+  if ((sym->kind == SymbolKind::Builtin ||
+       sym->kind == SymbolKind::Predeclared) &&
+      result.type.empty()) {
+    result.type = result.name;
+  }
+
+  return result;
+}
+
+} // namespace dao

--- a/compiler/analysis/hover.cpp
+++ b/compiler/analysis/hover.cpp
@@ -75,12 +75,31 @@ auto query_hover(uint32_t offset, const ResolveResult& resolve,
   // an offset — we have the Symbol*. Try the decl type instead.
   if (sym->decl != nullptr &&
       (sym->kind == SymbolKind::Function ||
-       sym->kind == SymbolKind::Type ||
-       sym->kind == SymbolKind::Param)) {
+       sym->kind == SymbolKind::Type)) {
     const auto* decl = static_cast<const Decl*>(sym->decl);
     const auto* decl_type = typed.typed.decl_type(decl);
     if (decl_type != nullptr) {
       result.type = print_type(decl_type);
+    }
+  }
+
+  // For parameters, extract the type from the enclosing function's type
+  // by matching the parameter name.
+  if (sym->kind == SymbolKind::Param && sym->decl != nullptr) {
+    const auto* fn_decl = static_cast<const Decl*>(sym->decl);
+    const auto* fn_type = typed.typed.decl_type(fn_decl);
+    if (fn_type != nullptr && fn_type->kind() == TypeKind::Function) {
+      const auto* ft = static_cast<const TypeFunction*>(fn_type);
+      if (fn_decl->is<FunctionDecl>()) {
+        const auto& fn = fn_decl->as<FunctionDecl>();
+        for (size_t idx = 0; idx < fn.params.size(); ++idx) {
+          if (fn.params[idx].name == sym->name &&
+              idx < ft->param_types().size()) {
+            result.type = print_type(ft->param_types()[idx]);
+            break;
+          }
+        }
+      }
     }
   }
 

--- a/compiler/analysis/hover.h
+++ b/compiler/analysis/hover.h
@@ -1,0 +1,27 @@
+#ifndef DAO_ANALYSIS_HOVER_H
+#define DAO_ANALYSIS_HOVER_H
+
+#include "frontend/diagnostics/source.h"
+#include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+
+#include <optional>
+#include <string>
+
+namespace dao {
+
+struct HoverResult {
+  std::string type;        // e.g. "(a: i32, b: i32): i32"
+  std::string symbol_kind; // e.g. "function", "variable", "type"
+  std::string name;        // e.g. "add"
+};
+
+/// Query hover info at a byte offset in the source.
+/// Returns nullopt if no symbol is found at that offset.
+auto query_hover(uint32_t offset, const ResolveResult& resolve,
+                 const TypeCheckResult& typed)
+    -> std::optional<HoverResult>;
+
+} // namespace dao
+
+#endif // DAO_ANALYSIS_HOVER_H

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -89,6 +89,8 @@ CLI, playground, and LSP.
 
 - `semantic_tokens.h` / `semantic_tokens.cpp` — token classification per
   the frozen taxonomy in `CONTRACT_LANGUAGE_TOOLING.md`
+- `hover.h` / `hover.cpp` — hover info: symbol kind, name, type at offset
+- `goto_definition.h` / `goto_definition.cpp` — jump-to-declaration from use site
 
 ## `runtime/`
 

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -3,6 +3,8 @@
 #include "pipeline.h"
 #include "token_category.h"
 
+#include "analysis/goto_definition.h"
+#include "analysis/hover.h"
 #include "analysis/semantic_tokens.h"
 #include "frontend/ast/ast_printer.h"
 #include "frontend/lexer/lexer.h"
@@ -240,6 +242,178 @@ respond:
       {"diagnostics", diagnostics},
   };
 
+  res.set_content(response.dump(), "application/json");
+}
+
+// ---------------------------------------------------------------------------
+// Shared lightweight pipeline for hover/goto-def (lex → parse → resolve → typecheck)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct LightPipeline {
+  SourceBuffer source;
+  LexResult lex_result;
+  ParseResult parse_result;
+  ResolveResult resolve_result;
+  TypeCheckResult check_result;
+  TypeContext types;
+  uint32_t prelude_bytes = 0;
+  bool ok = false;
+};
+
+auto run_light_pipeline(const nlohmann::json& request,
+                        const std::filesystem::path& repo_root)
+    -> LightPipeline {
+  LightPipeline pipe{SourceBuffer("", ""), {}, {}, {}, {}, {}, 0, false};
+
+  auto prelude_source = load_prelude(repo_root);
+  pipe.prelude_bytes = static_cast<uint32_t>(prelude_source.size());
+
+  auto user_source = request["source"].get<std::string>();
+  pipe.source = SourceBuffer("<playground>", prelude_source + user_source);
+  pipe.lex_result = lex(pipe.source);
+
+  if (!pipe.lex_result.diagnostics.empty()) {
+    return pipe;
+  }
+
+  pipe.parse_result = parse(pipe.lex_result.tokens);
+  if (pipe.parse_result.file == nullptr) {
+    return pipe;
+  }
+
+  pipe.resolve_result = resolve(*pipe.parse_result.file, pipe.prelude_bytes);
+
+  pipe.check_result =
+      typecheck(*pipe.parse_result.file, pipe.resolve_result, pipe.types);
+
+  pipe.ok = true;
+  return pipe;
+}
+
+/// Find the token span offset that contains the given byte offset.
+/// Returns the token's span.offset, or the offset itself if no token found.
+auto find_token_offset(uint32_t offset, const LexResult& lex_result)
+    -> uint32_t {
+  for (const auto& tok : lex_result.tokens) {
+    if (tok.span.offset <= offset &&
+        offset < tok.span.offset + tok.span.length) {
+      return tok.span.offset;
+    }
+  }
+  return offset;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Hover
+// ---------------------------------------------------------------------------
+
+void handle_hover(const httplib::Request& req, httplib::Response& res,
+                  const std::filesystem::path& repo_root) {
+  nlohmann::json request;
+  try {
+    request = nlohmann::json::parse(req.body);
+  } catch (const nlohmann::json::parse_error&) {
+    res.status = 400;
+    res.set_content(R"({"error":"invalid JSON"})", "application/json");
+    return;
+  }
+
+  if (!request.contains("source") || !request.contains("offset")) {
+    res.status = 400;
+    res.set_content(R"({"error":"missing 'source' or 'offset'"})",
+                    "application/json");
+    return;
+  }
+
+  auto user_offset = request["offset"].get<uint32_t>();
+  auto pipe = run_light_pipeline(request, repo_root);
+
+  if (!pipe.ok) {
+    res.set_content("null", "application/json");
+    return;
+  }
+
+  // Find the token at this offset and use its span start for lookup.
+  auto absolute_offset = pipe.prelude_bytes + user_offset;
+  auto token_offset = find_token_offset(absolute_offset, pipe.lex_result);
+
+  auto result = dao::query_hover(token_offset, pipe.resolve_result,
+                                 pipe.check_result);
+  if (!result) {
+    res.set_content("null", "application/json");
+    return;
+  }
+
+  nlohmann::json response = {
+      {"name", result->name},
+      {"kind", result->symbol_kind},
+      {"type", result->type},
+  };
+  res.set_content(response.dump(), "application/json");
+}
+
+// ---------------------------------------------------------------------------
+// Go to definition
+// ---------------------------------------------------------------------------
+
+void handle_goto_def(const httplib::Request& req, httplib::Response& res,
+                     const std::filesystem::path& repo_root) {
+  nlohmann::json request;
+  try {
+    request = nlohmann::json::parse(req.body);
+  } catch (const nlohmann::json::parse_error&) {
+    res.status = 400;
+    res.set_content(R"({"error":"invalid JSON"})", "application/json");
+    return;
+  }
+
+  if (!request.contains("source") || !request.contains("offset")) {
+    res.status = 400;
+    res.set_content(R"({"error":"missing 'source' or 'offset'"})",
+                    "application/json");
+    return;
+  }
+
+  auto user_offset = request["offset"].get<uint32_t>();
+  auto pipe = run_light_pipeline(request, repo_root);
+
+  if (!pipe.ok) {
+    res.set_content("null", "application/json");
+    return;
+  }
+
+  auto absolute_offset = pipe.prelude_bytes + user_offset;
+  auto token_offset = find_token_offset(absolute_offset, pipe.lex_result);
+
+  auto result = dao::query_definition(token_offset, pipe.resolve_result);
+  if (!result) {
+    res.set_content("null", "application/json");
+    return;
+  }
+
+  // Adjust definition offset back to user space.
+  // If the definition is in the prelude, report it as-is (negative would
+  // be wrong, so clamp to 0).
+  uint32_t user_def_offset = result->offset > pipe.prelude_bytes
+                                 ? result->offset - pipe.prelude_bytes
+                                 : 0;
+
+  auto loc = pipe.source.line_col(result->offset);
+  auto prelude_text = std::string(
+      pipe.source.contents().substr(0, pipe.prelude_bytes));
+  auto prelude_lines = count_lines(prelude_text);
+  auto line = loc.line > prelude_lines ? loc.line - prelude_lines : loc.line;
+
+  nlohmann::json response = {
+      {"offset", user_def_offset},
+      {"length", result->length},
+      {"line", line},
+      {"col", loc.col},
+  };
   res.set_content(response.dump(), "application/json");
 }
 

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -395,13 +395,14 @@ void handle_goto_def(const httplib::Request& req, httplib::Response& res,
     return;
   }
 
-  // Adjust definition offset back to user space.
-  // If the definition is in the prelude, report it as-is (negative would
-  // be wrong, so clamp to 0).
-  uint32_t user_def_offset = result->offset > pipe.prelude_bytes
-                                 ? result->offset - pipe.prelude_bytes
-                                 : 0;
+  // If the definition is inside the prelude, it's not navigable
+  // in the user's source — return null.
+  if (result->offset < pipe.prelude_bytes) {
+    res.set_content("null", "application/json");
+    return;
+  }
 
+  auto user_def_offset = result->offset - pipe.prelude_bytes;
   auto loc = pipe.source.line_col(result->offset);
   auto prelude_text = std::string(
       pipe.source.contents().substr(0, pipe.prelude_bytes));

--- a/tools/playground/compiler_service/analyze.h
+++ b/tools/playground/compiler_service/analyze.h
@@ -10,6 +10,12 @@ namespace dao::playground {
 void handle_analyze(const httplib::Request& req, httplib::Response& res,
                     const std::filesystem::path& repo_root);
 
+void handle_hover(const httplib::Request& req, httplib::Response& res,
+                  const std::filesystem::path& repo_root);
+
+void handle_goto_def(const httplib::Request& req, httplib::Response& res,
+                     const std::filesystem::path& repo_root);
+
 } // namespace dao::playground
 
 #endif // DAO_PLAYGROUND_ANALYZE_H

--- a/tools/playground/compiler_service/main.cpp
+++ b/tools/playground/compiler_service/main.cpp
@@ -66,6 +66,14 @@ auto main(int argc, char* argv[]) -> int {
   svr.Post("/api/run", [&root](const httplib::Request& req, httplib::Response& res) {
     dao::playground::handle_run(req, res, root);
   });
+
+  svr.Post("/api/hover", [&root](const httplib::Request& req, httplib::Response& res) {
+    dao::playground::handle_hover(req, res, root);
+  });
+
+  svr.Post("/api/goto-def", [&root](const httplib::Request& req, httplib::Response& res) {
+    dao::playground::handle_goto_def(req, res, root);
+  });
   // NOLINTEND(modernize-use-trailing-return-type)
 
   // Serve frontend static files when dist/ exists (prod mode).

--- a/tools/playground/frontend/src/goto_def.ts
+++ b/tools/playground/frontend/src/goto_def.ts
@@ -1,0 +1,44 @@
+import type { EditorView } from "@codemirror/view";
+import { getSource } from "./editor";
+
+interface GotoDefResponse {
+  offset: number;
+  length: number;
+  line: number;
+  col: number;
+}
+
+export function initGotoDef(view: EditorView): void {
+  view.dom.addEventListener("click", async (e: MouseEvent) => {
+    // Ctrl+Click (or Cmd+Click on Mac) for go-to-definition.
+    if (!e.ctrlKey && !e.metaKey) return;
+
+    e.preventDefault();
+
+    const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+    if (pos === null) return;
+
+    const source = getSource();
+
+    try {
+      const resp = await fetch("/api/goto-def", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source, offset: pos }),
+      });
+
+      if (!resp.ok) return;
+
+      const data: GotoDefResponse | null = await resp.json();
+      if (!data) return;
+
+      // Move cursor to the definition and scroll it into view.
+      view.dispatch({
+        selection: { anchor: data.offset },
+        scrollIntoView: true,
+      });
+    } catch {
+      // Silently ignore errors.
+    }
+  });
+}

--- a/tools/playground/frontend/src/hover.ts
+++ b/tools/playground/frontend/src/hover.ts
@@ -9,6 +9,12 @@ interface HoverResponse {
 
 let hoverTooltip: HTMLElement | null = null;
 
+function esc(text: string): string {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
 export function initHover(view: EditorView): void {
   const container = view.dom;
 
@@ -55,9 +61,9 @@ function showTooltip(x: number, y: number, data: HoverResponse): void {
     document.body.appendChild(hoverTooltip);
   }
 
-  let content = `<span class="hover-kind">${data.kind}</span> <strong>${data.name}</strong>`;
+  let content = `<span class="hover-kind">${esc(data.kind)}</span> <strong>${esc(data.name)}</strong>`;
   if (data.type) {
-    content += `<br><span class="hover-type">${data.type}</span>`;
+    content += `<br><span class="hover-type">${esc(data.type)}</span>`;
   }
 
   hoverTooltip.innerHTML = content;

--- a/tools/playground/frontend/src/hover.ts
+++ b/tools/playground/frontend/src/hover.ts
@@ -1,0 +1,73 @@
+import { EditorView } from "@codemirror/view";
+import { getSource } from "./editor";
+
+interface HoverResponse {
+  name: string;
+  kind: string;
+  type: string;
+}
+
+let hoverTooltip: HTMLElement | null = null;
+
+export function initHover(view: EditorView): void {
+  const container = view.dom;
+
+  container.addEventListener("mousemove", async (e: MouseEvent) => {
+    const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+    if (pos === null) {
+      hideTooltip();
+      return;
+    }
+
+    const source = getSource();
+
+    try {
+      const resp = await fetch("/api/hover", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source, offset: pos }),
+      });
+
+      if (!resp.ok) {
+        hideTooltip();
+        return;
+      }
+
+      const data: HoverResponse | null = await resp.json();
+      if (!data) {
+        hideTooltip();
+        return;
+      }
+
+      showTooltip(e.clientX, e.clientY, data);
+    } catch {
+      hideTooltip();
+    }
+  });
+
+  container.addEventListener("mouseleave", hideTooltip);
+}
+
+function showTooltip(x: number, y: number, data: HoverResponse): void {
+  if (!hoverTooltip) {
+    hoverTooltip = document.createElement("div");
+    hoverTooltip.className = "dao-hover-tooltip";
+    document.body.appendChild(hoverTooltip);
+  }
+
+  let content = `<span class="hover-kind">${data.kind}</span> <strong>${data.name}</strong>`;
+  if (data.type) {
+    content += `<br><span class="hover-type">${data.type}</span>`;
+  }
+
+  hoverTooltip.innerHTML = content;
+  hoverTooltip.style.left = `${x + 12}px`;
+  hoverTooltip.style.top = `${y + 12}px`;
+  hoverTooltip.style.display = "block";
+}
+
+function hideTooltip(): void {
+  if (hoverTooltip) {
+    hoverTooltip.style.display = "none";
+  }
+}

--- a/tools/playground/frontend/src/hover.ts
+++ b/tools/playground/frontend/src/hover.ts
@@ -8,6 +8,10 @@ interface HoverResponse {
 }
 
 let hoverTooltip: HTMLElement | null = null;
+let hoverSeq = 0;
+let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+
+const HOVER_DEBOUNCE_MS = 100;
 
 function esc(text: string): string {
   const div = document.createElement("div");
@@ -18,40 +22,51 @@ function esc(text: string): string {
 export function initHover(view: EditorView): void {
   const container = view.dom;
 
-  container.addEventListener("mousemove", async (e: MouseEvent) => {
-    const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
-    if (pos === null) {
+  container.addEventListener("mousemove", (e: MouseEvent) => {
+    if (hoverTimer) clearTimeout(hoverTimer);
+    hoverTimer = setTimeout(() => doHover(view, e), HOVER_DEBOUNCE_MS);
+  });
+
+  container.addEventListener("mouseleave", hideTooltip);
+}
+
+async function doHover(view: EditorView, e: MouseEvent): Promise<void> {
+  const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+  if (pos === null) {
+    hideTooltip();
+    return;
+  }
+
+  const seq = ++hoverSeq;
+  const source = getSource();
+
+  try {
+    const resp = await fetch("/api/hover", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source, offset: pos }),
+    });
+
+    // Discard stale response.
+    if (seq !== hoverSeq) return;
+
+    if (!resp.ok) {
       hideTooltip();
       return;
     }
 
-    const source = getSource();
+    const data: HoverResponse | null = await resp.json();
+    if (seq !== hoverSeq) return;
 
-    try {
-      const resp = await fetch("/api/hover", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ source, offset: pos }),
-      });
-
-      if (!resp.ok) {
-        hideTooltip();
-        return;
-      }
-
-      const data: HoverResponse | null = await resp.json();
-      if (!data) {
-        hideTooltip();
-        return;
-      }
-
-      showTooltip(e.clientX, e.clientY, data);
-    } catch {
+    if (!data) {
       hideTooltip();
+      return;
     }
-  });
 
-  container.addEventListener("mouseleave", hideTooltip);
+    showTooltip(e.clientX, e.clientY, data);
+  } catch {
+    if (seq === hoverSeq) hideTooltip();
+  }
 }
 
 function showTooltip(x: number, y: number, data: HoverResponse): void {

--- a/tools/playground/frontend/src/main.ts
+++ b/tools/playground/frontend/src/main.ts
@@ -3,6 +3,8 @@ import { createEditor } from "./editor";
 import { initAnalysis, scheduleAnalyze } from "./analysis";
 import { doRun } from "./run";
 import { loadExamples } from "./examples";
+import { initHover } from "./hover";
+import { initGotoDef } from "./goto_def";
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -10,6 +12,8 @@ import { loadExamples } from "./examples";
 
 const editor = createEditor(scheduleAnalyze);
 initAnalysis(editor);
+initHover(editor);
+initGotoDef(editor);
 
 // ---------------------------------------------------------------------------
 // Run button + keyboard shortcut

--- a/tools/playground/frontend/src/style.css
+++ b/tools/playground/frontend/src/style.css
@@ -305,3 +305,30 @@ main {
 .dao-literal-string { color: #a6e3a1; }
 .dao-operator { color: #89dceb; }
 .dao-punctuation { color: #6c7086; }
+
+/* Hover tooltip */
+.dao-hover-tooltip {
+  position: fixed;
+  display: none;
+  background: var(--bg-header);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg);
+  z-index: 1000;
+  pointer-events: none;
+  max-width: 400px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hover-kind {
+  color: var(--fg-dim);
+  font-style: italic;
+}
+
+.hover-type {
+  color: var(--accent);
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}


### PR DESCRIPTION
## Summary

Tooling T2 initial slice: hover info and go-to-definition, available in the playground via new API endpoints and frontend interactions.

## Highlights

- **Compiler analysis**: new `hover.h/.cpp` and `goto_definition.h/.cpp` in `compiler/analysis/` query the resolve and type-check side tables
- **API endpoints**: `POST /api/hover` and `POST /api/goto-def` accept `{source, offset}` and return symbol info or definition location
- **Frontend**: mousemove shows floating tooltip with symbol kind + type; Ctrl+Click jumps to definition
- **Token snapping**: handles click-in-middle-of-token by finding the containing token's span offset
- Both endpoints share a lightweight pipeline (lex→parse→resolve→typecheck) without IR lowering

## Test plan

- [x] Hover on function declaration shows `function add — fn(i32, i32): i32`
- [x] Hover on function call shows the same info
- [x] Go-to-def on `add` call returns offset 3 (declaration site)
- [x] Hover on whitespace/unknown returns null
- [x] `ctest --test-dir build/debug`: 10/10 tests pass
- [x] Frontend typechecks and builds
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)