### PR TITLE
fix(tooling): 🐛 use POSIX signal numbers in playground-dev trap

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,7 +69,7 @@ tasks:
     cmds:
       - cd tools/playground/frontend && npm ci --ignore-scripts
       - |
-        trap 'kill $BACKEND_PID 2>/dev/null' EXIT INT TERM
+        trap 'kill $BACKEND_PID 2>/dev/null' 0 2 15
         {{.BUILD_DIR}}/tools/playground/compiler_service/dao_playground &
         BACKEND_PID=$!
         cd tools/playground/frontend && npx vite


### PR DESCRIPTION
## Summary

The `playground-dev` task fails with `trap: INT: invalid signal specification` because Task v3 runs commands via `sh -c`, and some `/bin/sh` implementations (e.g. dash) don't accept named signals in `trap`.

## Highlights

- Replace `EXIT INT TERM` with POSIX signal numbers `0 2 15` in the `playground-dev` trap command

## Test plan

- [ ] Run `task playground-dev` and verify the backend + Vite start without trap errors
- [ ] Ctrl-C and verify the backend process is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)