### PR TITLE
fix(tooling): 🐛 replace shell trap with Task-native defer in playground-dev

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,10 +68,9 @@ tasks:
     deps: [build]
     cmds:
       - cd tools/playground/frontend && npm ci --ignore-scripts
+      - defer: kill $(lsof -ti :8090) 2>/dev/null || true
       - |
-        trap 'kill $BACKEND_PID 2>/dev/null' EXIT INT TERM
         {{.BUILD_DIR}}/tools/playground/compiler_service/dao_playground &
-        BACKEND_PID=$!
         cd tools/playground/frontend && npx vite
 
   format:


### PR DESCRIPTION
## Summary

The previous fix (#125) replaced signal names with numbers, but that still doesn't work because Task v3 uses `mvdan.cc/sh` (a Go shell interpreter), not the system shell — `trap` doesn't work at all.

This replaces the shell `trap` with Task's native `defer` command, which handles cleanup when a task exits.

## Highlights

- Remove the `trap` / `BACKEND_PID` shell pattern entirely
- Add a `defer:` cmd that kills whatever is listening on port 8090 when the task exits

## Test plan

- [ ] Run `task playground-dev` and verify the backend + Vite start without trap errors
- [ ] Ctrl-C and verify the backend process is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)