### PR TITLE
feat(runtime): ✨ add resource domain runtime hooks — full vertical

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -401,12 +401,33 @@ auto LlvmBackend::lower_inst(const MirInst& inst,
         return true;
       },
 
-      // Resource regions — no runtime hook exists yet.
+      // Resource regions — call runtime domain hooks.
       [&](const MirResourceEnter&) -> bool {
-        emit_diagnostic(inst.span, "resource region lowering not yet supported");
-        return false;
+        auto* enter_fn = module_->getFunction(
+            std::string(runtime_hooks::kMemResourceEnter));
+        if (enter_fn == nullptr) {
+          emit_diagnostic(inst.span, "resource_enter: runtime hook not found");
+          return false;
+        }
+        auto* handle = state.builder->CreateCall(enter_fn, {}, "resource.domain");
+        state.values[inst.result.id] = handle;
+        return true;
       },
-      [&](const MirResourceExit&) -> bool { return true; },
+      [&](const MirResourceExit& p) -> bool {
+        auto* handle = get_value(p.domain_handle, state);
+        if (handle == nullptr) {
+          emit_diagnostic(inst.span, "resource_exit: domain handle not found");
+          return false;
+        }
+        auto* exit_fn = module_->getFunction(
+            std::string(runtime_hooks::kMemResourceExit));
+        if (exit_fn == nullptr) {
+          emit_diagnostic(inst.span, "resource_exit: runtime hook not found");
+          return false;
+        }
+        state.builder->CreateCall(exit_fn, {handle});
+        return true;
+      },
 
       // Unsupported constructs.
       [&](const MirIndexAccess&) -> bool {

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -401,8 +401,14 @@ auto LlvmBackend::lower_inst(const MirInst& inst,
         return true;
       },
 
-      // Resource regions — call runtime domain hooks.
-      [&](const MirResourceEnter&) -> bool {
+      // Resource regions — dispatch by kind.
+      [&](const MirResourceEnter& p) -> bool {
+        if (p.region_kind != "memory") {
+          emit_diagnostic(inst.span,
+                           "resource '" + std::string(p.region_kind) +
+                           "' lowering not yet supported");
+          return false;
+        }
         auto* enter_fn = module_->getFunction(
             std::string(runtime_hooks::kMemResourceEnter));
         if (enter_fn == nullptr) {
@@ -414,6 +420,10 @@ auto LlvmBackend::lower_inst(const MirInst& inst,
         return true;
       },
       [&](const MirResourceExit& p) -> bool {
+        if (p.region_kind != "memory") {
+          // Entry already diagnosed; skip duplicate.
+          return true;
+        }
         auto* handle = get_value(p.domain_handle, state);
         if (handle == nullptr) {
           emit_diagnostic(inst.span, "resource_exit: domain handle not found");

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -451,13 +451,16 @@ suite<"unsupported_constructs"> unsupported_constructs = [] {
     expect(!pipe.has_errors()) << "mode unsafe should be no-op";
   };
 
-  "resource region is rejected"_test = [] {
+  "resource region calls domain hooks"_test = [] {
     LlvmTestPipeline pipe(
         "fn test(): i32\n"
         "  resource memory Arena =>\n"
         "    return 1\n"
         "  return 0\n");
-    expect(pipe.has_errors()) << "resource should fail";
+    expect(!pipe.has_errors()) << "resource should compile";
+    auto ir = pipe.ir();
+    expect(contains(ir, "__dao_mem_resource_enter")) << ir;
+    expect(contains(ir, "__dao_mem_resource_exit")) << ir;
   };
 
   "field assignment via store"_test = [] {

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -451,16 +451,25 @@ suite<"unsupported_constructs"> unsupported_constructs = [] {
     expect(!pipe.has_errors()) << "mode unsafe should be no-op";
   };
 
-  "resource region calls domain hooks"_test = [] {
+  "resource memory calls domain hooks"_test = [] {
     LlvmTestPipeline pipe(
         "fn test(): i32\n"
         "  resource memory Arena =>\n"
         "    return 1\n"
         "  return 0\n");
-    expect(!pipe.has_errors()) << "resource should compile";
+    expect(!pipe.has_errors()) << "resource memory should compile";
     auto ir = pipe.ir();
     expect(contains(ir, "__dao_mem_resource_enter")) << ir;
     expect(contains(ir, "__dao_mem_resource_exit")) << ir;
+  };
+
+  "resource gpu is rejected"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn test(): i32\n"
+        "  resource gpu compute =>\n"
+        "    return 1\n"
+        "  return 0\n");
+    expect(pipe.has_errors()) << "resource gpu should fail";
   };
 
   "field assignment via store"_test = [] {

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -22,6 +22,7 @@ void LlvmRuntimeHooks::declare_all() {
   declare_equality_hooks();
   declare_conversion_hooks();
   declare_generator_hooks();
+  declare_mem_resource_hooks();
 }
 
 auto LlvmRuntimeHooks::is_runtime_hook(std::string_view name) -> bool {
@@ -113,6 +114,24 @@ void LlvmRuntimeHooks::declare_generator_hooks() {
 
   // __dao_gen_free(ptr): void
   ensure_declared(runtime_hooks::kGenFree,
+                  llvm::FunctionType::get(void_ty, {ptr}, false));
+}
+
+// ---------------------------------------------------------------------------
+// Memory/resource domain hooks
+// ---------------------------------------------------------------------------
+
+void LlvmRuntimeHooks::declare_mem_resource_hooks() {
+  auto& ctx = module_.getContext();
+  auto* ptr = llvm::PointerType::getUnqual(ctx);
+  auto* void_ty = llvm::Type::getVoidTy(ctx);
+
+  // __dao_mem_resource_enter(): ptr
+  ensure_declared(runtime_hooks::kMemResourceEnter,
+                  llvm::FunctionType::get(ptr, {}, false));
+
+  // __dao_mem_resource_exit(domain: ptr): void
+  ensure_declared(runtime_hooks::kMemResourceExit,
                   llvm::FunctionType::get(void_ty, {ptr}, false));
 }
 

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -47,12 +47,17 @@ inline constexpr std::string_view kConvBoolToString = "__dao_conv_bool_to_string
 inline constexpr std::string_view kGenAlloc = "__dao_gen_alloc";
 inline constexpr std::string_view kGenFree  = "__dao_gen_free";
 
+// Memory/resource domain
+inline constexpr std::string_view kMemResourceEnter = "__dao_mem_resource_enter";
+inline constexpr std::string_view kMemResourceExit  = "__dao_mem_resource_exit";
+
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
     kWriteStdout,
     kEqI32,    kEqF64,    kEqBool,    kEqString,
     kConvI32ToString, kConvF64ToString, kConvBoolToString,
     kGenAlloc, kGenFree,
+    kMemResourceEnter, kMemResourceExit,
 };
 
 } // namespace runtime_hooks
@@ -80,6 +85,7 @@ private:
   void declare_equality_hooks();
   void declare_conversion_hooks();
   void declare_generator_hooks();
+  void declare_mem_resource_hooks();
 
   // Helper: get-or-create a function declaration.
   auto ensure_declared(std::string_view name, llvm::FunctionType* fn_type)

--- a/compiler/ir/mir/mir.h
+++ b/compiler/ir/mir/mir.h
@@ -104,7 +104,7 @@ struct MirYieldInst   { MirValueId value; };
 struct MirModeEnter     { HirModeKind mode_kind; std::string_view region_name; };
 struct MirModeExit      { HirModeKind mode_kind; };
 struct MirResourceEnter { std::string_view region_kind; std::string_view region_name; };
-struct MirResourceExit  { std::string_view region_kind; std::string_view region_name; };
+struct MirResourceExit  { std::string_view region_kind; std::string_view region_name; MirValueId domain_handle; };
 
 struct MirLambdaInst { MirFunction* fn; };
 

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -321,7 +321,7 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
       },
       [&](const HirResource& res) {
         auto domain_handle = emit_value(
-            nullptr, stmt.span,
+            types_.pointer_to(types_.void_type()), stmt.span,
             MirResourceEnter{res.resource_kind, res.resource_name});
 
         active_regions_.push_back(

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -320,12 +320,14 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         }
       },
       [&](const HirResource& res) {
-        emit_effect(stmt.span,
-                    MirResourceEnter{res.resource_kind, res.resource_name});
+        auto domain_handle = emit_value(
+            nullptr, stmt.span,
+            MirResourceEnter{res.resource_kind, res.resource_name});
 
         active_regions_.push_back(
             {.exit_payload = MirResourceExit{res.resource_kind,
-                                             res.resource_name},
+                                             res.resource_name,
+                                             domain_handle},
              .span = stmt.span});
 
         for (const auto* s : res.body) {
@@ -336,7 +338,8 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
 
         if (!block_terminated()) {
           emit_effect(stmt.span,
-                      MirResourceExit{res.resource_kind, res.resource_name});
+                      MirResourceExit{res.resource_kind, res.resource_name,
+                                      domain_handle});
         }
       },
   }, stmt.payload);

--- a/compiler/ir/mir/mir_printer.cpp
+++ b/compiler/ir/mir/mir_printer.cpp
@@ -181,7 +181,8 @@ private:
         },
         [&](const MirResourceExit& p) {
           out_ << "resource_exit " << p.region_kind
-               << " " << p.region_name;
+               << " " << p.region_name
+               << " %" << p.domain_handle.id;
         },
         [&](const MirLambdaInst& p) {
           out_ << "lambda";

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -19,7 +19,7 @@ user-written host-language glue.
 
 Out of scope:
 
-- scoped resource-domain memory semantics
+- arena/allocator-level resource-domain memory semantics
 - parallel/GPU execution runtime
 - scheduler/executor architecture
 - allocator design
@@ -56,6 +56,7 @@ Domains:
 | `eq`       | Equality comparison                        |
 | `conv`     | Value-to-value conversion (e.g. to_string) |
 | `gen`      | Generator frame allocation and lifetime    |
+| `mem`      | Resource domain scope and lifetime         |
 
 Examples:
 
@@ -71,6 +72,8 @@ Examples:
 | `__dao_conv_bool_to_string`| `(x: bool): string`                 |
 | `__dao_gen_alloc`         | `(size: i64, align: i64): *void`     |
 | `__dao_gen_free`          | `(ptr: *void): void`                 |
+| `__dao_mem_resource_enter`| `(): *void`                           |
+| `__dao_mem_resource_exit` | `(domain: *void): void`              |
 
 These are the **only** runtime hooks in the current supported slice.
 New hooks require updating this contract before implementation.
@@ -147,6 +150,41 @@ Properties:
 - Consumer code accesses the generator exclusively through the
   `__dao_gen_*` hooks and the resume function pointer.
 
+### Resource domain handle
+
+Resource domains are represented at the ABI boundary as an opaque
+pointer:
+
+```
+ptr  ; opaque domain handle
+```
+
+C-equivalent:
+
+```c
+void *domain;
+```
+
+Properties:
+
+- the handle is opaque to compiler-generated code; its internal
+  structure is private to the runtime
+- `__dao_mem_resource_enter` returns a fresh handle; the compiler
+  passes the same handle to the corresponding `__dao_mem_resource_exit`
+- handles are scope-paired: every enter has exactly one exit on every
+  control-flow path (including early return)
+- nesting is supported: each enter/exit pair is independent
+
+Current implementation status:
+
+- the first implementation provides **scope/lifetime bookkeeping
+  only** — entering a resource domain establishes a scope boundary
+  and exiting closes it
+- arena-based allocation, per-domain allocator routing, and domain-
+  scoped deallocation are deferred
+- the handle/token ABI is designed to accommodate future arena
+  semantics without signature churn
+
 ## Ownership and lifetime rules
 
 For the current supported hook slice:
@@ -171,6 +209,11 @@ For the current supported hook slice:
    `__dao_gen_free` when the iterator is no longer needed. The
    compiler inserts the free call at for-loop exit.
 
+5. **Resource domain handles are scope-paired.** Every handle
+   returned by `__dao_mem_resource_enter` must be passed to exactly
+   one `__dao_mem_resource_exit` call. The compiler inserts exit
+   calls on both normal and early-return paths.
+
 ## Stability
 
 ### Stable (frozen for current slice)
@@ -186,8 +229,8 @@ For the current supported hook slice:
 - additional scalar types (i8, i16, i64, u8, u16, u32, u64, f32)
 - additional conversion hooks
 - string concatenation / manipulation hooks
-- memory allocation hooks
-- mode/resource runtime hooks
+- memory allocation hooks (beyond resource domain scope tracking)
+- mode runtime hooks (parallel, GPU)
 
 ## Authoritative sources
 

--- a/examples/resource.dao
+++ b/examples/resource.dao
@@ -1,0 +1,34 @@
+fn compute_in_pool(): i32
+  let result: i32 = 0
+  resource memory pool =>
+    let a: i32 = 10
+    let b: i32 = 20
+    result = a + b
+  return result
+
+fn nested_domains(): i32
+  let total: i32 = 0
+  resource memory outer =>
+    let x: i32 = 100
+    resource memory inner =>
+      let y: i32 = 50
+      total = x + y
+  return total
+
+fn early_return(flag: i32): i32
+  resource memory arena =>
+    if flag > 0:
+      return flag
+    let x: i32 = 42
+  return 0
+
+fn main(): i32
+  print("compute_in_pool:")
+  print(compute_in_pool())
+  print("nested_domains:")
+  print(nested_domains())
+  print("early_return(5):")
+  print(early_return(5))
+  print("early_return(0):")
+  print(early_return(0))
+  return 0

--- a/runtime/core/CMakeLists.txt
+++ b/runtime/core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(dao_runtime STATIC
   equality.c
   convert.c
   generator.c
+  resource.c
 )
 
 # This is C code, not C++.

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -76,6 +76,18 @@ void *__dao_gen_alloc(int64_t size, int64_t align);
 // Free a generator frame previously allocated by __dao_gen_alloc.
 void __dao_gen_free(void *ptr);
 
+// ---------------------------------------------------------------------------
+// Runtime hook declarations — Memory/resource domain
+// ---------------------------------------------------------------------------
+
+// Enter a scoped resource domain. Returns an opaque domain handle.
+// Current implementation: scope/lifetime bookkeeping only.
+// Arena-based allocation semantics are deferred.
+void *__dao_mem_resource_enter(void);
+
+// Exit a scoped resource domain. Takes the handle returned by enter.
+void __dao_mem_resource_exit(void *domain);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/runtime/core/resource.c
+++ b/runtime/core/resource.c
@@ -1,0 +1,23 @@
+// resource.c — Scoped resource domain hooks.
+//
+// Current implementation: scope/lifetime bookkeeping only.
+// Enter returns a sentinel token; exit accepts and discards it.
+// The handle ABI is designed so future arena/allocator-domain
+// implementations fit without signature churn.
+
+#include "dao_abi.h"
+
+#include <stdint.h>
+
+// Monotonic domain counter. Each enter call returns a unique
+// non-null token so the compiler can verify scope pairing.
+static uint64_t next_domain_id = 1;
+
+void *__dao_mem_resource_enter(void) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  return (void *)(uintptr_t)(next_domain_id++);
+}
+
+void __dao_mem_resource_exit(void *domain) {
+  (void)domain; // Bookkeeping only; no-op in current implementation.
+}

--- a/testdata/ast/examples_resource.ast
+++ b/testdata/ast/examples_resource.ast
@@ -1,0 +1,118 @@
+File
+  FunctionDecl compute_in_pool
+    ReturnType: i32
+    LetStatement result: i32
+      IntLiteral 0
+    ResourceBlock memory pool
+      LetStatement a: i32
+        IntLiteral 10
+      LetStatement b: i32
+        IntLiteral 20
+      Assignment
+        Target
+          Identifier result
+        Value
+          BinaryExpr +
+            Identifier a
+            Identifier b
+    ReturnStatement
+      Identifier result
+  FunctionDecl nested_domains
+    ReturnType: i32
+    LetStatement total: i32
+      IntLiteral 0
+    ResourceBlock memory outer
+      LetStatement x: i32
+        IntLiteral 100
+      ResourceBlock memory inner
+        LetStatement y: i32
+          IntLiteral 50
+        Assignment
+          Target
+            Identifier total
+          Value
+            BinaryExpr +
+              Identifier x
+              Identifier y
+    ReturnStatement
+      Identifier total
+  FunctionDecl early_return
+    Param flag: i32
+    ReturnType: i32
+    ResourceBlock memory arena
+      IfStatement
+        Condition
+          BinaryExpr >
+            Identifier flag
+            IntLiteral 0
+        Then
+          ReturnStatement
+            Identifier flag
+      LetStatement x: i32
+        IntLiteral 42
+    ReturnStatement
+      IntLiteral 0
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "compute_in_pool:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier compute_in_pool
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "nested_domains:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier nested_domains
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "early_return(5):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier early_return
+            Args
+              IntLiteral 5
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "early_return(0):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier early_return
+            Args
+              IntLiteral 0
+    ReturnStatement
+      IntLiteral 0


### PR DESCRIPTION
## Summary

Implements scoped resource domain hooks from contract through runtime, compiler backend, and end-to-end example. This is the first vertical where `resource memory X =>` blocks produce actual runtime calls instead of erroring in the backend.

The first implementation provides **scope/lifetime bookkeeping only** — entering a resource domain returns an opaque handle, exiting accepts it back. The handle ABI is designed so future arena/allocator-domain support fits without signature churn.

## Highlights

- Update `CONTRACT_RUNTIME_ABI.md` with `mem` domain, hook signatures, resource handle type specification, and ownership rule
- Make `MirResourceEnter` value-producing (returns domain handle); add `domain_handle` field to `MirResourceExit` — mirrors the existing `MirIterInit`/`MirIterDestroy` pattern for clean early-return threading
- Implement C runtime hooks in `runtime/core/resource.c` with monotonic token (arena semantics deferred)
- Declare hooks in LLVM backend and wire `MirResourceEnter`/`MirResourceExit` to emit calls
- Add `examples/resource.dao` with basic, nested, and early-return resource domains — compiles and runs end-to-end
- Update backend test: resource regions now compile successfully with IR verification

## Test plan

- [x] All 10 test suites pass (MIR, LLVM backend, lexer, parser, resolve, typecheck, types, AST printer, HIR, semantic tokens)
- [x] All 10 examples compile end-to-end
- [x] `resource.dao` runs correctly: `compute_in_pool` → 30, `nested_domains` → 150, `early_return(5)` → 5, `early_return(0)` → 0
- [x] Backend test verifies `__dao_mem_resource_enter`/`_exit` appear in LLVM IR

🤖 Generated with [Claude Code](https://claude.com/claude-code)