### PR TITLE
feat(stdlib): ✨ add string length, math prelude, and Comparable concept

### DIFF
--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -695,6 +695,22 @@ suite<"runtime_abi"> runtime_abi = [] {
     expect(contains(ir, "dao.string")) << ir;
   };
 
+  "prelude length generates str_length call"_test = [] {
+    constexpr std::string_view prelude =
+        "extern fn __dao_str_length(s: string): i32\n";
+    LlvmTestPipeline pipe(
+        std::string(prelude) +
+        "fn length(s: string): i32 -> __dao_str_length(s)\n"
+        "\n"
+        "fn main(): i32\n"
+        "  return length(\"hello\")\n",
+        static_cast<uint32_t>(prelude.size()));
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "__dao_str_length")) << ir;
+    expect(contains(ir, "call i32")) << ir;
+  };
+
   "runtime hooks pre-declared by backend unconditionally"_test = [] {
     // Even without any prelude extern declarations, runtime hooks
     // should be present in the module because LlvmBackend::lower()

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -141,12 +141,18 @@ void LlvmRuntimeHooks::declare_mem_resource_hooks() {
 // ---------------------------------------------------------------------------
 
 void LlvmRuntimeHooks::declare_string_hooks() {
+  auto& ctx = module_.getContext();
   auto* str_type = types_.string_type();
   auto* str_ptr = llvm::PointerType::getUnqual(str_type);
+  auto* i32 = llvm::Type::getInt32Ty(ctx);
 
   // __dao_str_concat(a: *dao.string, b: *dao.string): dao.string
   ensure_declared(runtime_hooks::kStrConcat,
                   llvm::FunctionType::get(str_type, {str_ptr, str_ptr}, false));
+
+  // __dao_str_length(s: *dao.string): i32
+  ensure_declared(runtime_hooks::kStrLength,
+                  llvm::FunctionType::get(i32, {str_ptr}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -52,7 +52,8 @@ inline constexpr std::string_view kMemResourceEnter = "__dao_mem_resource_enter"
 inline constexpr std::string_view kMemResourceExit  = "__dao_mem_resource_exit";
 
 // String domain
-inline constexpr std::string_view kStrConcat = "__dao_str_concat";
+inline constexpr std::string_view kStrConcat  = "__dao_str_concat";
+inline constexpr std::string_view kStrLength  = "__dao_str_length";
 
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
@@ -61,7 +62,7 @@ inline constexpr std::string_view kAllHooks[] = {
     kConvI32ToString, kConvF64ToString, kConvBoolToString,
     kGenAlloc, kGenFree,
     kMemResourceEnter, kMemResourceExit,
-    kStrConcat,
+    kStrConcat, kStrLength,
 };
 
 } // namespace runtime_hooks

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -76,6 +76,7 @@ Examples:
 | `__dao_mem_resource_enter`| `(): *void`                           |
 | `__dao_mem_resource_exit` | `(domain: *void): void`              |
 | `__dao_str_concat`       | `(a: string, b: string): string`      |
+| `__dao_str_length`       | `(s: string): i32`                    |
 
 These are the **only** runtime hooks in the current supported slice.
 New hooks require updating this contract before implementation.

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -81,6 +81,12 @@ Examples:
 These are the **only** runtime hooks in the current supported slice.
 New hooks require updating this contract before implementation.
 
+**Note on `__dao_str_length`**: the internal string representation
+stores byte length as `i64`, but the hook narrows to `i32` because
+the Dao surface type system does not yet include `i64`. This will
+silently truncate for strings longer than `INT32_MAX`. When `i64`
+is added as a surface type, this hook should be widened.
+
 ## Canonical value representations
 
 ### Scalar types

--- a/examples/arithmetic.dao
+++ b/examples/arithmetic.dao
@@ -4,13 +4,6 @@ fn cube(x: i32): i32 -> x * x * x
 
 fn is_even(x: i32): bool -> x == (x / 2) * 2
 
-fn clamp(x: i32, lo: i32, hi: i32): i32
-  if x < lo:
-    return lo
-  if x > hi:
-    return hi
-  return x
-
 fn sum_range(a: i32, b: i32): i32
   let total: i32 = 0
   let i: i32 = a

--- a/examples/control_flow.dao
+++ b/examples/control_flow.dao
@@ -1,13 +1,3 @@
-fn abs(x: i32): i32
-  if x < 0:
-    return 0 - x
-  return x
-
-fn max(a: i32, b: i32): i32
-  if a > b:
-    return a
-  return b
-
 fn factorial(n: i32): i32
   let result: i32 = 1
   let i: i32 = 1

--- a/examples/math.dao
+++ b/examples/math.dao
@@ -1,0 +1,18 @@
+fn main(): i32
+  print("abs(-5):")
+  print(abs(0 - 5))
+  print("abs(3):")
+  print(abs(3))
+  print("min(10, 3):")
+  print(min(10, 3))
+  print("max(10, 3):")
+  print(max(10, 3))
+  print("clamp(15, 0, 10):")
+  print(clamp(15, 0, 10))
+  print("clamp(-5, 0, 10):")
+  print(clamp(0 - 5, 0, 10))
+  print("clamp(7, 0, 10):")
+  print(clamp(7, 0, 10))
+  print("length of hello:")
+  print(length("hello"))
+  return 0

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -86,6 +86,9 @@ void __dao_gen_free(void *ptr);
 struct dao_string __dao_str_concat(const struct dao_string *a,
                                    const struct dao_string *b);
 
+// Return the byte length of a string as i32.
+int32_t __dao_str_length(const struct dao_string *s);
+
 // ---------------------------------------------------------------------------
 // Runtime hook declarations — Memory/resource domain
 // ---------------------------------------------------------------------------

--- a/runtime/core/string.c
+++ b/runtime/core/string.c
@@ -34,3 +34,10 @@ struct dao_string __dao_str_concat(const struct dao_string *a,
 
   return (struct dao_string){.ptr = buf, .len = total};
 }
+
+int32_t __dao_str_length(const struct dao_string *s) {
+  if (s == NULL) {
+    return 0;
+  }
+  return (int32_t)s->len;
+}

--- a/stdlib/core/comparable.dao
+++ b/stdlib/core/comparable.dao
@@ -1,0 +1,3 @@
+derived concept Comparable:
+  fn lt(self, other: Comparable): bool
+  fn gt(self, other: Comparable): bool

--- a/stdlib/core/math.dao
+++ b/stdlib/core/math.dao
@@ -1,0 +1,21 @@
+fn abs(x: i32): i32
+  if x < 0:
+    return 0 - x
+  return x
+
+fn min(a: i32, b: i32): i32
+  if a < b:
+    return a
+  return b
+
+fn max(a: i32, b: i32): i32
+  if a > b:
+    return a
+  return b
+
+fn clamp(x: i32, lo: i32, hi: i32): i32
+  if x < lo:
+    return lo
+  if x > hi:
+    return hi
+  return x

--- a/stdlib/core/string.dao
+++ b/stdlib/core/string.dao
@@ -1,3 +1,5 @@
 extern fn __dao_str_concat(a: string, b: string): string
+extern fn __dao_str_length(s: string): i32
 
 fn concat(a: string, b: string): string -> __dao_str_concat(a, b)
+fn length(s: string): i32 -> __dao_str_length(s)

--- a/testdata/ast/examples_control_flow.ast
+++ b/testdata/ast/examples_control_flow.ast
@@ -1,33 +1,4 @@
 File
-  FunctionDecl abs
-    Param x: i32
-    ReturnType: i32
-    IfStatement
-      Condition
-        BinaryExpr <
-          Identifier x
-          IntLiteral 0
-      Then
-        ReturnStatement
-          BinaryExpr -
-            IntLiteral 0
-            Identifier x
-    ReturnStatement
-      Identifier x
-  FunctionDecl max
-    Param a: i32
-    Param b: i32
-    ReturnType: i32
-    IfStatement
-      Condition
-        BinaryExpr >
-          Identifier a
-          Identifier b
-      Then
-        ReturnStatement
-          Identifier a
-    ReturnStatement
-      Identifier b
   FunctionDecl factorial
     Param n: i32
     ReturnType: i32

--- a/testdata/ast/examples_math.ast
+++ b/testdata/ast/examples_math.ast
@@ -1,60 +1,4 @@
 File
-  FunctionDecl square
-    Param x: i32
-    ReturnType: i32
-    ExprBody
-      BinaryExpr *
-        Identifier x
-        Identifier x
-  FunctionDecl cube
-    Param x: i32
-    ReturnType: i32
-    ExprBody
-      BinaryExpr *
-        BinaryExpr *
-          Identifier x
-          Identifier x
-        Identifier x
-  FunctionDecl is_even
-    Param x: i32
-    ReturnType: bool
-    ExprBody
-      BinaryExpr ==
-        Identifier x
-        BinaryExpr *
-          BinaryExpr /
-            Identifier x
-            IntLiteral 2
-          IntLiteral 2
-  FunctionDecl sum_range
-    Param a: i32
-    Param b: i32
-    ReturnType: i32
-    LetStatement total: i32
-      IntLiteral 0
-    LetStatement i: i32
-      Identifier a
-    WhileStatement
-      Condition
-        BinaryExpr <
-          Identifier i
-          Identifier b
-      Assignment
-        Target
-          Identifier total
-        Value
-          BinaryExpr +
-            Identifier total
-            Identifier i
-      Assignment
-        Target
-          Identifier i
-        Value
-          BinaryExpr +
-            Identifier i
-            IntLiteral 1
-    ReturnStatement
-      Identifier total
   FunctionDecl main
     ReturnType: i32
     ExpressionStatement
@@ -62,7 +6,7 @@ File
         Callee
           Identifier print
         Args
-          StringLiteral "square(7):"
+          StringLiteral "abs(-5):"
     ExpressionStatement
       CallExpr
         Callee
@@ -70,15 +14,17 @@ File
         Args
           CallExpr
             Callee
-              Identifier square
+              Identifier abs
             Args
-              IntLiteral 7
+              BinaryExpr -
+                IntLiteral 0
+                IntLiteral 5
     ExpressionStatement
       CallExpr
         Callee
           Identifier print
         Args
-          StringLiteral "cube(3):"
+          StringLiteral "abs(3):"
     ExpressionStatement
       CallExpr
         Callee
@@ -86,7 +32,7 @@ File
         Args
           CallExpr
             Callee
-              Identifier cube
+              Identifier abs
             Args
               IntLiteral 3
     ExpressionStatement
@@ -94,7 +40,7 @@ File
         Callee
           Identifier print
         Args
-          StringLiteral "is_even(4):"
+          StringLiteral "min(10, 3):"
     ExpressionStatement
       CallExpr
         Callee
@@ -102,15 +48,16 @@ File
         Args
           CallExpr
             Callee
-              Identifier is_even
+              Identifier min
             Args
-              IntLiteral 4
+              IntLiteral 10
+              IntLiteral 3
     ExpressionStatement
       CallExpr
         Callee
           Identifier print
         Args
-          StringLiteral "is_even(7):"
+          StringLiteral "max(10, 3):"
     ExpressionStatement
       CallExpr
         Callee
@@ -118,9 +65,10 @@ File
         Args
           CallExpr
             Callee
-              Identifier is_even
+              Identifier max
             Args
-              IntLiteral 7
+              IntLiteral 10
+              IntLiteral 3
     ExpressionStatement
       CallExpr
         Callee
@@ -144,7 +92,7 @@ File
         Callee
           Identifier print
         Args
-          StringLiteral "sum_range(1, 11):"
+          StringLiteral "clamp(-5, 0, 10):"
     ExpressionStatement
       CallExpr
         Callee
@@ -152,9 +100,46 @@ File
         Args
           CallExpr
             Callee
-              Identifier sum_range
+              Identifier clamp
             Args
-              IntLiteral 1
-              IntLiteral 11
+              BinaryExpr -
+                IntLiteral 0
+                IntLiteral 5
+              IntLiteral 0
+              IntLiteral 10
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "clamp(7, 0, 10):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier clamp
+            Args
+              IntLiteral 7
+              IntLiteral 0
+              IntLiteral 10
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "length of hello:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier length
+            Args
+              StringLiteral "hello"
     ReturnStatement
       IntLiteral 0

--- a/testdata/ast/stdlib_core_comparable.ast
+++ b/testdata/ast/stdlib_core_comparable.ast
@@ -1,0 +1,10 @@
+File
+  DerivedConceptDecl Comparable
+    FunctionDecl lt
+      Param self
+      Param other: Comparable
+      ReturnType: bool
+    FunctionDecl gt
+      Param self
+      Param other: Comparable
+      ReturnType: bool

--- a/testdata/ast/stdlib_core_math.ast
+++ b/testdata/ast/stdlib_core_math.ast
@@ -1,0 +1,67 @@
+File
+  FunctionDecl abs
+    Param x: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier x
+          IntLiteral 0
+      Then
+        ReturnStatement
+          BinaryExpr -
+            IntLiteral 0
+            Identifier x
+    ReturnStatement
+      Identifier x
+  FunctionDecl min
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier a
+          Identifier b
+      Then
+        ReturnStatement
+          Identifier a
+    ReturnStatement
+      Identifier b
+  FunctionDecl max
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier a
+          Identifier b
+      Then
+        ReturnStatement
+          Identifier a
+    ReturnStatement
+      Identifier b
+  FunctionDecl clamp
+    Param x: i32
+    Param lo: i32
+    Param hi: i32
+    ReturnType: i32
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier x
+          Identifier lo
+      Then
+        ReturnStatement
+          Identifier lo
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier x
+          Identifier hi
+      Then
+        ReturnStatement
+          Identifier hi
+    ReturnStatement
+      Identifier x

--- a/testdata/ast/stdlib_core_string.ast
+++ b/testdata/ast/stdlib_core_string.ast
@@ -3,6 +3,9 @@ File
     Param a: string
     Param b: string
     ReturnType: string
+  ExternFunctionDecl __dao_str_length
+    Param s: string
+    ReturnType: i32
   FunctionDecl concat
     Param a: string
     Param b: string
@@ -14,3 +17,12 @@ File
         Args
           Identifier a
           Identifier b
+  FunctionDecl length
+    Param s: string
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_length
+        Args
+          Identifier s


### PR DESCRIPTION
## Summary

Expands the stdlib prelude with string length, integer math utilities, and the Comparable concept. Existing examples that defined their own `abs`/`max`/`clamp` now use the prelude versions, validating that the prelude auto-import works as a practical deduplication mechanism.

## Highlights

- Add `__dao_str_length` runtime hook (contract, C impl, LLVM decl) and `fn length(s: string): i32` in stdlib
- Add `stdlib/core/math.dao` with `abs`, `min`, `max`, `clamp` as pure Dao functions (no runtime hooks)
- Add `stdlib/core/comparable.dao` with derived concept `Comparable` (lt, gt) for future ordering support
- Update `examples/arithmetic.dao` and `examples/control_flow.dao` to use prelude functions instead of local definitions
- Add `examples/math.dao` exercising all math and length functions end-to-end

## Test plan

- [x] All 10 test suites pass
- [x] All 12 examples compile end-to-end
- [x] `math.dao` produces correct output for abs, min, max, clamp, and length
- [x] `arithmetic.dao` and `control_flow.dao` still produce identical output using prelude functions
- [x] Golden AST files regenerated for all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)