### PR TITLE
fix(backend): 🐛 use correct IEEE 754 predicate for float !=

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -636,7 +636,10 @@ auto LlvmBackend::lower_binary(const MirBinary& p, const MirInst& inst,
                       : state.builder->CreateICmpEQ(lhs, rhs, "eq");
     break;
   case BinaryOp::BangEq:
-    result = is_float ? state.builder->CreateFCmpONE(lhs, rhs, "fne")
+    // UNE (unordered or not equal): true if either operand is NaN or
+    // if the operands are not equal. ONE would incorrectly return false
+    // when either operand is NaN, violating IEEE 754 != semantics.
+    result = is_float ? state.builder->CreateFCmpUNE(lhs, rhs, "fne")
                       : state.builder->CreateICmpNE(lhs, rhs, "ne");
     break;
   case BinaryOp::Lt:

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -226,6 +226,44 @@ suite<"arithmetic"> arithmetic = [] {
     expect(!pipe.has_errors()) << "no backend errors";
     expect(contains(ir, "icmp slt")) << ir;
   };
+
+  "float == uses ordered equal (oeq)"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn feq(a: f64, b: f64): bool\n"
+        "  return a == b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "fcmp oeq")) << ir;
+  };
+
+  "float != uses unordered not-equal (une)"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn fne(a: f64, b: f64): bool\n"
+        "  return a != b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // UNE: true if either operand is NaN OR operands are not equal.
+    // ONE would incorrectly return false for NaN comparisons.
+    expect(contains(ir, "fcmp une")) << ir;
+  };
+
+  "float < uses ordered less-than (olt)"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn flt(a: f64, b: f64): bool\n"
+        "  return a < b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "fcmp olt")) << ir;
+  };
+
+  "float >= uses ordered greater-or-equal (oge)"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn fge(a: f64, b: f64): bool\n"
+        "  return a >= b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "fcmp oge")) << ir;
+  };
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Float `!=` was using LLVM's `ONE` (ordered not-equal) predicate, which returns false when either operand is NaN. IEEE 754 requires `!=` to be the logical negation of `==`, meaning it must return `true` when either operand is NaN. Fixed to `UNE` (unordered or not-equal).

This was identified during the review of `CONTRACT_NUMERIC_SEMANTICS.md` and completes Task 14 Tier A: IEEE correctness audit for existing f64 codegen.

## Highlights

- Change float `!=` from `CreateFCmpONE` to `CreateFCmpUNE`
- Add 4 backend tests verifying float comparison LLVM predicates: `oeq` for `==`, `une` for `!=`, `olt` for `<`, `oge` for `>=`

### IEEE 754 predicate summary

| Dao op | LLVM pred | Meaning | NaN behavior |
|--------|-----------|---------|-------------|
| `==` | `oeq` | ordered equal | false if NaN ✅ |
| `!=` | `une` | unordered or not-equal | true if NaN ✅ |
| `<` | `olt` | ordered less-than | false if NaN ✅ |
| `<=` | `ole` | ordered less-or-equal | false if NaN ✅ |
| `>` | `ogt` | ordered greater-than | false if NaN ✅ |
| `>=` | `oge` | ordered greater-or-equal | false if NaN ✅ |

## Test plan

- [x] All 10 test suites pass
- [x] 4 new float comparison predicate tests in `arithmetic` suite
- [x] All 12 examples compile end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)