### PR TITLE
feat(backend): ✨ implement checked signed integer overflow with trap

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -11,6 +11,7 @@
 #include "ir/mir/mir.h"
 
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalVariable.h>
@@ -474,6 +475,37 @@ auto LlvmBackend::get_value(MirValueId id, FunctionState& state) -> llvm::Value*
 }
 
 // ---------------------------------------------------------------------------
+// Checked signed integer arithmetic
+// ---------------------------------------------------------------------------
+
+auto LlvmBackend::emit_checked_signed_op(llvm::Intrinsic::ID intrinsic,
+                                           llvm::Value* lhs, llvm::Value* rhs,
+                                           const char* name,
+                                           FunctionState& state)
+    -> llvm::Value* {
+  auto* fn = llvm::Intrinsic::getDeclaration(module_.get(), intrinsic,
+                                              {lhs->getType()});
+  auto* pair = state.builder->CreateCall(fn, {lhs, rhs});
+
+  auto* result = state.builder->CreateExtractValue(pair, 0, name);
+  auto* overflow = state.builder->CreateExtractValue(pair, 1, "overflow");
+
+  auto* parent_fn = state.builder->GetInsertBlock()->getParent();
+  auto* trap_bb = llvm::BasicBlock::Create(ctx_, "overflow.trap", parent_fn);
+  auto* cont_bb = llvm::BasicBlock::Create(ctx_, "overflow.cont", parent_fn);
+
+  state.builder->CreateCondBr(overflow, trap_bb, cont_bb);
+
+  state.builder->SetInsertPoint(trap_bb);
+  auto* trap_fn = llvm::Intrinsic::getDeclaration(module_.get(), llvm::Intrinsic::trap);
+  state.builder->CreateCall(trap_fn);
+  state.builder->CreateUnreachable();
+
+  state.builder->SetInsertPoint(cont_bb);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Constant lowering
 // ---------------------------------------------------------------------------
 
@@ -600,16 +632,34 @@ auto LlvmBackend::lower_binary(const MirBinary& p, const MirInst& inst,
 
   switch (p.op) {
   case BinaryOp::Add:
-    result = is_float ? state.builder->CreateFAdd(lhs, rhs, "fadd")
-                      : state.builder->CreateAdd(lhs, rhs, "add");
+    if (is_float) {
+      result = state.builder->CreateFAdd(lhs, rhs, "fadd");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateAdd(lhs, rhs, "add");
+    } else {
+      result = emit_checked_signed_op(
+          llvm::Intrinsic::sadd_with_overflow, lhs, rhs, "add", state);
+    }
     break;
   case BinaryOp::Sub:
-    result = is_float ? state.builder->CreateFSub(lhs, rhs, "fsub")
-                      : state.builder->CreateSub(lhs, rhs, "sub");
+    if (is_float) {
+      result = state.builder->CreateFSub(lhs, rhs, "fsub");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateSub(lhs, rhs, "sub");
+    } else {
+      result = emit_checked_signed_op(
+          llvm::Intrinsic::ssub_with_overflow, lhs, rhs, "sub", state);
+    }
     break;
   case BinaryOp::Mul:
-    result = is_float ? state.builder->CreateFMul(lhs, rhs, "fmul")
-                      : state.builder->CreateMul(lhs, rhs, "mul");
+    if (is_float) {
+      result = state.builder->CreateFMul(lhs, rhs, "fmul");
+    } else if (is_unsigned_op) {
+      result = state.builder->CreateMul(lhs, rhs, "mul");
+    } else {
+      result = emit_checked_signed_op(
+          llvm::Intrinsic::smul_with_overflow, lhs, rhs, "mul", state);
+    }
     break;
   case BinaryOp::Div:
     if (is_float) {

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -8,6 +8,7 @@
 #include "ir/mir/mir.h"
 
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 
@@ -163,6 +164,12 @@ private:
                        FunctionState& state) -> bool;
   auto lower_iter_destroy(const MirIterDestroy& p, const MirInst& inst,
                           FunctionState& state) -> bool;
+
+  // Checked signed integer arithmetic — traps on overflow.
+  auto emit_checked_signed_op(llvm::Intrinsic::ID intrinsic,
+                               llvm::Value* lhs, llvm::Value* rhs,
+                               const char* name,
+                               FunctionState& state) -> llvm::Value*;
 
   // Place resolution — walk projection chains to an LLVM pointer.
   auto resolve_place(const MirPlace& place,

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -198,15 +198,19 @@ suite<"simple_functions"> simple_functions = [] {
 // ---------------------------------------------------------------------------
 
 suite<"arithmetic"> arithmetic = [] {
-  "integer arithmetic"_test = [] {
+  "signed integer arithmetic uses checked intrinsics"_test = [] {
     LlvmTestPipeline pipe(
         "fn calc(x: i32, y: i32): i32\n"
         "  return x * y + x - y\n");
     auto ir = pipe.ir();
     expect(!pipe.has_errors()) << "no backend errors";
-    expect(contains(ir, "mul")) << ir;
-    expect(contains(ir, "add")) << ir;
-    expect(contains(ir, "sub")) << ir;
+    // Signed ops use overflow-checking intrinsics.
+    expect(contains(ir, "llvm.smul.with.overflow.i32")) << ir;
+    expect(contains(ir, "llvm.sadd.with.overflow.i32")) << ir;
+    expect(contains(ir, "llvm.ssub.with.overflow.i32")) << ir;
+    // Overflow branches to trap.
+    expect(contains(ir, "overflow.trap")) << ir;
+    expect(contains(ir, "llvm.trap")) << ir;
   };
 
   "float arithmetic"_test = [] {

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -308,8 +308,19 @@ Priority: **high** — correctness baseline for existing types.
   predicates (ordered vs unordered), NaN propagation, signed-zero
   preservation
 - freeze integer overflow policy for i32: decide checked vs wrapping
-  default, implement the chosen behavior, add wrapping/saturating
-  alternate operations
+  default, implement the chosen behavior
+
+#### Tier A+ — Post-baseline (no blocking dependency)
+
+Priority: **medium** — enriches the numeric surface but does not
+block other tiers.
+
+- explicit wrapping operations: `wrapping_add`, `wrapping_sub`,
+  `wrapping_mul`
+- explicit saturating operations: `saturating_add`, `saturating_sub`,
+  `saturating_mul`
+- explicit checked operations: `checked_add`, `checked_sub`,
+  `checked_mul` (return error/status on overflow)
 
 #### Tier B — Phase 6 prerequisite
 

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -91,26 +91,41 @@ is representable in the type's range.
 
 ### 4.2 Overflow
 
-Signed integer overflow must not be language-level undefined behavior.
-The compiler must not exploit overflow as an optimization assumption
-in ways that change observable program behavior.
+Signed integer overflow is **checked by default**. Overflow in the
+default arithmetic operators (`+`, `-`, `*`) causes a **trap**
+(runtime abort). The compiler must not treat signed integer overflow
+as undefined behavior and must not silently lower default signed
+arithmetic to wrapping semantics.
 
-The default overflow policy for signed integer arithmetic:
+Rules:
 
-- default arithmetic operators produce defined behavior on overflow
-- the specific defined behavior (checked/trapping, wrapping, or
-  mode-dependent) is not yet frozen; what is frozen is that overflow
-  is never undefined
+1. default `+`, `-`, `*` on signed integers are checked — overflow
+   traps
+2. the trap is a defined runtime abort, not undefined behavior
+3. the compiler may not exploit overflow for optimization
+4. `mode unsafe =>` does **not** change the semantics of integer
+   arithmetic operators — `unsafe` governs pointer/memory/FFI
+   safety, not arithmetic behavior
+5. the operator means the same thing in every build mode unless
+   the language explicitly says otherwise — no debug/release
+   semantic split
 
-When the overflow policy is fully frozen, the language must provide:
+Future explicit operations (not yet implemented):
 
-- default operators with the chosen overflow behavior
-- explicit wrapping operations as alternate APIs or intrinsics
-- explicit saturating operations as alternate APIs or intrinsics
-- explicit checked operations that report overflow
+- `wrapping_add`, `wrapping_sub`, `wrapping_mul` — two's complement
+  wrap, no trap
+- `saturating_add`, `saturating_sub`, `saturating_mul` — clamp to
+  min/max representable value
+- `checked_add`, `checked_sub`, `checked_mul` — return an error
+  value or status on overflow
 
-Status: **Partially specified** — overflow is defined as non-UB;
-specific policy deferred
+If Dao later wants relaxed arithmetic for high-performance numerics,
+it must be introduced as an explicit mode, operator family, or
+intrinsic family — not by overloading `unsafe` or by making
+semantics build-configuration-dependent.
+
+Status: **Specified, implemented** (i32 checked add/sub/mul with
+trap on overflow)
 
 ### 4.3 Division and remainder
 
@@ -371,7 +386,7 @@ The compiler and backend must:
 | Feature                          | Specified | Implemented       |
 |----------------------------------|-----------|-------------------|
 | `i32` arithmetic                 | Yes       | Yes               |
-| `i32` overflow non-UB            | Yes       | Partial (wraps)   |
+| `i32` checked overflow (trap)    | Yes       | Yes               |
 | `f64` IEEE 754 binary64          | Yes       | Partial           |
 | `f64` NaN/Inf/−0.0 semantics    | Yes       | Partial (codegen) |
 | `f64` comparison partial-order   | Yes       | Partial           |
@@ -383,7 +398,7 @@ The compiler and backend must:
 | Decimal types                    | Posture   | Deferred          |
 | Rounding-mode control            | Forbidden | N/A               |
 | Fast-math / relaxed mode         | Opt-in    | Deferred          |
-| Integer overflow policy freeze   | Partial   | Deferred          |
+| Integer overflow policy freeze   | Yes       | Implemented       |
 | String conversion (f64)          | Partial   | Implemented       |
 | Mixed-type operator rejection    | Yes       | Implemented       |
 


### PR DESCRIPTION
## Summary

Signed integer arithmetic (`+`, `-`, `*`) now uses LLVM overflow-checking intrinsics that trap on overflow. This implements the overflow policy frozen in `CONTRACT_NUMERIC_SEMANTICS.md` — checked by default, `unsafe` does not change arithmetic semantics, wrapping/saturating are future explicit operations only.

Previously, signed integer overflow silently wrapped (two's complement) because the backend emitted plain LLVM `add`/`sub`/`mul`. Now it emits `llvm.sadd.with.overflow.i32` / `llvm.ssub.with.overflow.i32` / `llvm.smul.with.overflow.i32`, extracts the overflow flag, and branches to a trap block on overflow.

## Highlights

- Replace `CreateAdd`/`CreateSub`/`CreateMul` for signed integers with `emit_checked_signed_op` using LLVM overflow intrinsics
- Trap block: `llvm.trap()` + `unreachable` — defined runtime abort, not UB
- Unsigned ops remain unchecked (wrapping is correct per type semantics)
- Float ops unchanged (no overflow concept in IEEE 754)
- Contract section 4.2 frozen: checked default, `unsafe` orthogonal, explicit wrapping/saturating reserved for future APIs
- Backend test updated to verify `llvm.s{add,sub,mul}.with.overflow.i32`, `overflow.trap`, and `llvm.trap` in emitted IR

## Test plan

- [x] All 10 test suites pass
- [x] All 12 examples compile and produce correct output
- [x] LLVM IR verified: overflow intrinsics + trap blocks emitted for signed arithmetic
- [x] Float arithmetic unchanged (verified by existing `fadd` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)