### PR TITLE
feat(runtime): ✨ add explicit numeric type conversions

### DIFF
--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -762,9 +762,22 @@ suite<"runtime_abi"> runtime_abi = [] {
         "  return\n");
     auto ir = pipe.ir();
     expect(!pipe.has_errors()) << "no backend errors";
+    // IO
     expect(contains(ir, "declare void @__dao_io_write_stdout")) << ir;
+    // Equality
     expect(contains(ir, "declare i1 @__dao_eq_i32")) << ir;
+    expect(contains(ir, "declare i1 @__dao_eq_i64")) << ir;
     expect(contains(ir, "declare i1 @__dao_eq_f64")) << ir;
+    // Conversion (to_string)
+    expect(contains(ir, "@__dao_conv_i32_to_string")) << ir;
+    expect(contains(ir, "@__dao_conv_i64_to_string")) << ir;
+    // Numeric conversions
+    expect(contains(ir, "declare double @__dao_conv_i32_to_f64(i32)")) << ir;
+    expect(contains(ir, "declare i64 @__dao_conv_i32_to_i64(i32)")) << ir;
+    expect(contains(ir, "declare i32 @__dao_conv_f64_to_i32(double)")) << ir;
+    expect(contains(ir, "declare i32 @__dao_conv_i64_to_i32(i64)")) << ir;
+    // String
+    expect(contains(ir, "@__dao_str_length")) << ir;
   };
 };
 

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -107,6 +107,23 @@ void LlvmRuntimeHooks::declare_conversion_hooks() {
   auto* i1 = llvm::Type::getInt1Ty(ctx);
   ensure_declared(runtime_hooks::kConvBoolToString,
                   llvm::FunctionType::get(str_type, {i1}, false));
+
+  // Numeric type conversions
+  // __dao_conv_i32_to_f64(x: i32): f64
+  ensure_declared(runtime_hooks::kConvI32ToF64,
+                  llvm::FunctionType::get(f64, {i32}, false));
+
+  // __dao_conv_i32_to_i64(x: i32): i64
+  ensure_declared(runtime_hooks::kConvI32ToI64,
+                  llvm::FunctionType::get(i64, {i32}, false));
+
+  // __dao_conv_f64_to_i32(x: f64): i32
+  ensure_declared(runtime_hooks::kConvF64ToI32,
+                  llvm::FunctionType::get(i32, {f64}, false));
+
+  // __dao_conv_i64_to_i32(x: i64): i32
+  ensure_declared(runtime_hooks::kConvI64ToI32,
+                  llvm::FunctionType::get(i32, {i64}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -45,6 +45,12 @@ inline constexpr std::string_view kConvI64ToString  = "__dao_conv_i64_to_string"
 inline constexpr std::string_view kConvF64ToString  = "__dao_conv_f64_to_string";
 inline constexpr std::string_view kConvBoolToString = "__dao_conv_bool_to_string";
 
+// Conversion domain (numeric type conversions)
+inline constexpr std::string_view kConvI32ToF64  = "__dao_conv_i32_to_f64";
+inline constexpr std::string_view kConvI32ToI64  = "__dao_conv_i32_to_i64";
+inline constexpr std::string_view kConvF64ToI32  = "__dao_conv_f64_to_i32";
+inline constexpr std::string_view kConvI64ToI32  = "__dao_conv_i64_to_i32";
+
 // Generator domain
 inline constexpr std::string_view kGenAlloc = "__dao_gen_alloc";
 inline constexpr std::string_view kGenFree  = "__dao_gen_free";
@@ -62,6 +68,7 @@ inline constexpr std::string_view kAllHooks[] = {
     kWriteStdout,
     kEqI32,    kEqI64,    kEqF64,    kEqBool,    kEqString,
     kConvI32ToString, kConvI64ToString, kConvF64ToString, kConvBoolToString,
+    kConvI32ToF64, kConvI32ToI64, kConvF64ToI32, kConvI64ToI32,
     kGenAlloc, kGenFree,
     kMemResourceEnter, kMemResourceExit,
     kStrConcat, kStrLength,

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -39,7 +39,7 @@ optimization-driven weakening.
 | `i8`  | 8     | yes    | Deferred            |
 | `i16` | 16    | yes    | Deferred            |
 | `i32` | 32    | yes    | Implemented         |
-| `i64` | 64    | yes    | Deferred            |
+| `i64` | 64    | yes    | Implemented         |
 | `u8`  | 8     | no     | Deferred            |
 | `u16` | 16    | no     | Deferred            |
 | `u32` | 32    | no     | Deferred            |
@@ -211,7 +211,8 @@ rules in the initial language model.
 - narrowing conversions are explicit and checked
 - sign-changing conversions (signed ↔ unsigned) are explicit
 
-Status: **Deferred** — only `i32` is currently surfaced
+Status: **Partially implemented** — `i32` ↔ `i64` conversions
+available via `to_i64` / `i64_to_i32` (trapping on narrowing)
 
 ### 6.3 Integer to float
 
@@ -221,7 +222,8 @@ Status: **Deferred** — only `i32` is currently surfaced
 - `i32` → `f64` is exact (all i32 values are representable in f64)
 - `i64` → `f64` may lose precision and requires explicit conversion
 
-Status: **Deferred** — no cross-type conversions implemented yet
+Status: **Partially implemented** — `i32` → `f64` available via
+`to_f64` (exact)
 
 ### 6.4 Float to integer
 
@@ -234,7 +236,8 @@ Status: **Deferred** — no cross-type conversions implemented yet
 - float-to-integer conversion must not be silent or undefined on
   out-of-range inputs
 
-Status: **Deferred**
+Status: **Partially implemented** — `f64` → `i32` available via
+`f64_to_i32` (truncating, trapping on NaN/Inf/out-of-range)
 
 ### 6.5 f64 to f32 / f32 to f64
 
@@ -391,10 +394,11 @@ The compiler and backend must:
 | `f64` NaN/Inf/−0.0 semantics    | Yes       | Partial (codegen) |
 | `f64` comparison partial-order   | Yes       | Partial           |
 | `f32` IEEE 754 binary32          | Yes       | Deferred          |
-| Integer widths beyond i32        | Yes       | Deferred          |
+| `i64` arithmetic + overflow      | Yes       | Yes               |
+| Integer widths beyond i32/i64    | Yes       | Deferred          |
 | Unsigned integers                | Yes       | Deferred          |
-| Numeric conversions              | Yes       | Deferred          |
-| Float-to-int trapping            | Yes       | Deferred          |
+| Numeric conversions (i32↔i64↔f64)| Yes       | Partial           |
+| Float-to-int trapping (f64→i32)  | Yes       | Yes               |
 | Decimal types                    | Posture   | Deferred          |
 | Rounding-mode control            | Forbidden | N/A               |
 | Fast-math / relaxed mode         | Opt-in    | Deferred          |

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -77,6 +77,10 @@ Examples:
 | `__dao_gen_free`          | `(ptr: *void): void`                 |
 | `__dao_mem_resource_enter`| `(): *void`                           |
 | `__dao_mem_resource_exit` | `(domain: *void): void`              |
+| `__dao_conv_i32_to_f64`  | `(x: i32): f64`                       |
+| `__dao_conv_i32_to_i64`  | `(x: i32): i64`                       |
+| `__dao_conv_f64_to_i32`  | `(x: f64): i32`                       |
+| `__dao_conv_i64_to_i32`  | `(x: i64): i32`                       |
 | `__dao_str_concat`       | `(a: string, b: string): string`      |
 | `__dao_str_length`       | `(s: string): i64`                    |
 

--- a/examples/conversions.dao
+++ b/examples/conversions.dao
@@ -1,0 +1,26 @@
+fn main(): i32
+  let x: i32 = 42
+  let y: f64 = to_f64(x)
+  print("i32 42 as f64:")
+  print(y)
+
+  let big: i64 = to_i64(x)
+  print("i32 42 as i64:")
+  print(big)
+
+  let pi: f64 = 3.14
+  let truncated: i32 = f64_to_i32(pi)
+  print("f64 3.14 as i32 (truncated):")
+  print(truncated)
+
+  let neg: f64 = 0.0 - 2.71
+  let neg_trunc: i32 = f64_to_i32(neg)
+  print("f64 -2.71 as i32 (truncated toward zero):")
+  print(neg_trunc)
+
+  let wide: i64 = 100
+  let narrow: i32 = i64_to_i32(wide)
+  print("i64 100 as i32:")
+  print(narrow)
+
+  return 0

--- a/runtime/core/convert.c
+++ b/runtime/core/convert.c
@@ -1,16 +1,16 @@
-// convert.c — Dao runtime scalar-to-string conversion hooks.
+// convert.c — Dao runtime conversion hooks.
 //
-// Implements: __dao_conv_i32_to_string, __dao_conv_i64_to_string,
-//             __dao_conv_f64_to_string, __dao_conv_bool_to_string
+// Implements: scalar-to-string, numeric type conversions
 // Authority:  docs/contracts/CONTRACT_RUNTIME_ABI.md
 //
-// Conversion results use thread-local transient buffers. The returned
-// dao_string is valid until the next call to the same hook on the
-// same thread. Callers must consume or copy before re-calling.
+// String conversion results use thread-local transient buffers.
+// Numeric conversions trap (abort) on out-of-range or invalid inputs.
 
 #include "dao_abi.h"
 
+#include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 struct dao_string __dao_conv_i32_to_string(int32_t x) {
   static _Thread_local char buf[32];
@@ -35,4 +35,32 @@ struct dao_string __dao_conv_bool_to_string(bool x) {
     return (struct dao_string){.ptr = "true", .len = 4};
   }
   return (struct dao_string){.ptr = "false", .len = 5};
+}
+
+// ---------------------------------------------------------------------------
+// Numeric type conversions
+// ---------------------------------------------------------------------------
+
+// i32 -> f64: exact (all i32 values are representable in f64).
+double __dao_conv_i32_to_f64(int32_t x) { return (double)x; }
+
+// i32 -> i64: exact (lossless widening).
+int64_t __dao_conv_i32_to_i64(int32_t x) { return (int64_t)x; }
+
+// f64 -> i32: truncates toward zero. Traps on NaN, Inf, or out-of-range.
+int32_t __dao_conv_f64_to_i32(double x) {
+  if (isnan(x) || isinf(x) || x < -2147483648.0 || x > 2147483647.0) {
+    fprintf(stderr, "dao: numeric conversion error: f64 value out of i32 range\n");
+    abort();
+  }
+  return (int32_t)x;
+}
+
+// i64 -> i32: traps if value does not fit.
+int32_t __dao_conv_i64_to_i32(int64_t x) {
+  if (x < INT32_MIN || x > INT32_MAX) {
+    fprintf(stderr, "dao: numeric conversion error: i64 value out of i32 range\n");
+    abort();
+  }
+  return (int32_t)x;
 }

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -66,6 +66,14 @@ struct dao_string __dao_conv_i64_to_string(int64_t x);
 struct dao_string __dao_conv_f64_to_string(double x);
 struct dao_string __dao_conv_bool_to_string(bool x);
 
+// Numeric type conversions.
+// Lossless conversions are exact. Narrowing conversions trap (abort)
+// on NaN, Inf, or out-of-range values.
+double __dao_conv_i32_to_f64(int32_t x);
+int64_t __dao_conv_i32_to_i64(int32_t x);
+int32_t __dao_conv_f64_to_i32(double x);
+int32_t __dao_conv_i64_to_i32(int64_t x);
+
 // ---------------------------------------------------------------------------
 // Runtime hook declarations — Generator domain
 // ---------------------------------------------------------------------------

--- a/stdlib/core/convert.dao
+++ b/stdlib/core/convert.dao
@@ -1,0 +1,9 @@
+extern fn __dao_conv_i32_to_f64(x: i32): f64
+extern fn __dao_conv_i32_to_i64(x: i32): i64
+extern fn __dao_conv_f64_to_i32(x: f64): i32
+extern fn __dao_conv_i64_to_i32(x: i64): i32
+
+fn to_f64(x: i32): f64 -> __dao_conv_i32_to_f64(x)
+fn to_i64(x: i32): i64 -> __dao_conv_i32_to_i64(x)
+fn f64_to_i32(x: f64): i32 -> __dao_conv_f64_to_i32(x)
+fn i64_to_i32(x: i64): i32 -> __dao_conv_i64_to_i32(x)

--- a/testdata/ast/examples_conversions.ast
+++ b/testdata/ast/examples_conversions.ast
@@ -1,0 +1,105 @@
+File
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement x: i32
+      IntLiteral 42
+    LetStatement y: f64
+      CallExpr
+        Callee
+          Identifier to_f64
+        Args
+          Identifier x
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "i32 42 as f64:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier y
+    LetStatement big: i64
+      CallExpr
+        Callee
+          Identifier to_i64
+        Args
+          Identifier x
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "i32 42 as i64:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier big
+    LetStatement pi: f64
+      FloatLiteral 3.14
+    LetStatement truncated: i32
+      CallExpr
+        Callee
+          Identifier f64_to_i32
+        Args
+          Identifier pi
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "f64 3.14 as i32 (truncated):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier truncated
+    LetStatement neg: f64
+      BinaryExpr -
+        FloatLiteral 0.0
+        FloatLiteral 2.71
+    LetStatement neg_trunc: i32
+      CallExpr
+        Callee
+          Identifier f64_to_i32
+        Args
+          Identifier neg
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "f64 -2.71 as i32 (truncated toward zero):"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier neg_trunc
+    LetStatement wide: i64
+      IntLiteral 100
+    LetStatement narrow: i32
+      CallExpr
+        Callee
+          Identifier i64_to_i32
+        Args
+          Identifier wide
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "i64 100 as i32:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier narrow
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/stdlib_core_convert.ast
+++ b/testdata/ast/stdlib_core_convert.ast
@@ -1,0 +1,49 @@
+File
+  ExternFunctionDecl __dao_conv_i32_to_f64
+    Param x: i32
+    ReturnType: f64
+  ExternFunctionDecl __dao_conv_i32_to_i64
+    Param x: i32
+    ReturnType: i64
+  ExternFunctionDecl __dao_conv_f64_to_i32
+    Param x: f64
+    ReturnType: i32
+  ExternFunctionDecl __dao_conv_i64_to_i32
+    Param x: i64
+    ReturnType: i32
+  FunctionDecl to_f64
+    Param x: i32
+    ReturnType: f64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_i32_to_f64
+        Args
+          Identifier x
+  FunctionDecl to_i64
+    Param x: i32
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_i32_to_i64
+        Args
+          Identifier x
+  FunctionDecl f64_to_i32
+    Param x: f64
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_f64_to_i32
+        Args
+          Identifier x
+  FunctionDecl i64_to_i32
+    Param x: i64
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_i64_to_i32
+        Args
+          Identifier x


### PR DESCRIPTION
## Summary

Adds explicit numeric conversion functions between `i32`, `i64`, and `f64` — the final Task 14 Tier B deliverable. Lossless conversions are exact; narrowing conversions trap on out-of-range, NaN, or Inf inputs per `CONTRACT_NUMERIC_SEMANTICS.md`.

## Highlights

- Add 4 conversion hooks to `CONTRACT_RUNTIME_ABI.md`: `__dao_conv_i32_to_f64`, `__dao_conv_i32_to_i64`, `__dao_conv_f64_to_i32`, `__dao_conv_i64_to_i32`
- C implementations: `f64→i32` truncates toward zero and traps on NaN/Inf/out-of-range; `i64→i32` traps if value outside INT32 range
- LLVM hook declarations for all 4 conversions
- `stdlib/core/convert.dao` with `to_f64`, `to_i64`, `f64_to_i32`, `i64_to_i32`
- `examples/conversions.dao` exercising all paths including negative truncation

### Task 14 Tier B — now complete

| Deliverable | Status |
|-------------|--------|
| i64 surface exposure | ✅ #136 |
| Explicit i32↔f64 conversions | ✅ this PR |
| Explicit i32↔i64 conversions | ✅ this PR |
| Widen `__dao_str_length` to i64 | ✅ #136 |

## Test plan

- [x] All 10 test suites pass
- [x] All 14 examples compile end-to-end
- [x] `conversions.dao` output correct: 42→42.0, 42→42, 3.14→3, -2.71→-2, 100→100

🤖 Generated with [Claude Code](https://claude.com/claude-code)