### PR TITLE
docs(contracts): 📝 add CONTRACT_C_ABI_INTEROP and TASK_15

### DIFF
--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -20,7 +20,7 @@ Normative behavior lives in `CLAUDE.md` and `docs/contracts/`.
 Contracts and explanatory material.
 
 - `ARCH_INDEX.md` — this file
-- `contracts/` — normative contracts for structure, syntax, execution contexts, compiler architecture, bootstrap/interop posture, tooling boundaries, runtime ABI, and numeric semantics
+- `contracts/` — normative contracts for structure, syntax, execution contexts, compiler architecture, bootstrap/interop posture, tooling boundaries, runtime ABI, numeric semantics, and C ABI interop
 - `ROADMAP.md` — staged implementation plan from frontend skeleton to self-hosting, tooling maturity, and GPU expansion
 - `IMPLEMENTATION_PLAN.md` — concrete task sequence, toolchain decisions, and delivery order for Tasks 0–5
 - `task_specs/` — detailed per-task design specs for Tasks 6+

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -1,0 +1,181 @@
+# CONTRACT_C_ABI_INTEROP
+
+Status: normative
+Scope: Dao foreign function interop via the C ABI
+Authority: language and compiler boundary contract
+
+## 1. Purpose
+
+This contract defines the boundary between Dao programs and external
+code via the platform C ABI. It specifies what `extern fn` means
+semantically, which types are supported, what the compiler guarantees
+at the boundary, and what is explicitly out of scope.
+
+## 2. Core doctrine
+
+C ABI interop is an **explicit foreign boundary**, not a general-
+purpose extension mechanism. It complements, but does not redefine,
+Dao's runtime, stdlib, or semantic model.
+
+Rules:
+
+- `extern fn` declares a function whose calling convention and data
+  representation are governed by the target platform C ABI
+- Dao semantics do not automatically project onto foreign code
+- crossing the boundary is explicit and narrow
+- C ABI interop is a capability, not a substitute for designing
+  Dao's own runtime and stdlib properly
+
+## 3. What `extern fn` means
+
+An `extern fn` declaration states:
+
+- this function exists in external object code
+- its symbol name is exactly as written
+- its calling convention is the platform C ABI
+- the compiler emits an LLVM `declare` with the appropriate
+  signature and linkage
+- the compiler does not generate a body, verify the implementation,
+  or enforce Dao semantics on the foreign side
+
+The function must be provided at link time via an object file,
+static archive, or shared/system library.
+
+## 4. Supported types at the ABI boundary
+
+### 4.1 Initial supported types (v1)
+
+| Dao type  | C ABI type       | Direction       |
+|-----------|------------------|-----------------|
+| `i32`     | `int32_t`        | arg + return    |
+| `i64`     | `int64_t`        | arg + return    |
+| `f64`     | `double`         | arg + return    |
+| `bool`    | `_Bool` (1 byte) | arg + return    |
+| `*T`      | `T*`             | arg + return    |
+| `void`    | `void`           | return only     |
+
+### 4.2 Pointer semantics at the boundary
+
+- pointer values are foreign addresses — no ownership implied
+- no aliasing or lifetime safety is promised across FFI
+- dereference of foreign pointers requires `mode unsafe =>`
+- opaque pointers (`*void` equivalent) are the primary interop
+  mechanism for foreign aggregate data
+
+### 4.3 Types explicitly not supported in v1
+
+- Dao `string` as C `char*` (requires explicit conversion)
+- struct/class by value (target-specific ABI rules)
+- function pointers / callbacks
+- variadic functions (`printf`-style)
+- C enums
+- C unions
+- arrays / slices by value
+
+If an `extern fn` declaration uses an unsupported type, the compiler
+must reject it with a clear diagnostic during type checking or
+backend lowering.
+
+### 4.4 Future type expansions
+
+The following may be added in later versions:
+
+- `c_string` or explicit null-terminated byte string type
+- by-value struct passing (once Dao struct ABI is stabilized)
+- function pointer types for callbacks
+- `f32` (when surfaced)
+
+Each expansion requires updating this contract before implementation.
+
+## 5. Name and linkage model
+
+- the symbol name in `extern fn foo(...)` is `foo` — no mangling,
+  no prefix
+- Dao runtime hooks use the `__dao_` prefix to avoid collisions
+  with user-declared foreign symbols
+- C++ mangled names are not supported; use `extern "C"` on the
+  C++ side
+- weak linkage, visibility attributes, and linker scripts are
+  not part of the initial model
+
+## 6. Ownership and safety rules
+
+- no ownership transfer is implied by `extern fn` calls
+- the caller (Dao side) retains ownership of any data it passes
+  unless the foreign function's documentation states otherwise
+- the compiler does not insert cleanup, reference counting, or
+  lifetime tracking for values passed to or received from foreign
+  code
+- foreign pointer dereference is an unsafe operation
+- integer overflow checking is **not** applied to values received
+  from foreign code (they enter Dao's value space as-is)
+
+## 7. Compiler obligations
+
+### 7.1 Frontend
+
+- `extern fn` declarations are parsed and type-checked like other
+  function declarations
+- the body must be absent (syntax error if present)
+- parameter and return types must be in the supported set
+- unsupported types must be rejected with a diagnostic
+
+### 7.2 Backend
+
+- `extern fn` is lowered to an LLVM `declare` with
+  `ExternalLinkage`
+- calling convention follows the platform C ABI (LLVM default)
+- argument and return types are lowered per the existing type
+  lowering rules
+- no body is emitted
+
+### 7.3 Driver
+
+- the driver must support linking additional external inputs:
+  - object files (`.o`)
+  - static archives (`.a`)
+  - system/shared libraries (`-l<name>`)
+  - library search paths (`-L<path>`)
+- the mechanism for specifying external link inputs is a driver
+  concern, not a language concern
+- the initial implementation may use simple CLI passthrough to the
+  system linker
+
+## 8. What is explicitly out of scope
+
+- header parsing or `#include` integration
+- automatic bindgen / declaration generation
+- C preprocessor awareness
+- C type introspection at compile time
+- C++ name mangling or template instantiation
+- dynamic loading (`dlopen`-style)
+- platform-specific calling conventions beyond the default C ABI
+- inline assembly
+- ABI stability guarantees for Dao-defined symbols exposed to C
+  (reserved for a future "export" contract)
+
+## 9. Relationship to existing contracts
+
+- `CONTRACT_BOOTSTRAP_AND_INTEROP.md` establishes that the C ABI
+  is the initial interop target; this contract operationalizes that
+- `CONTRACT_RUNTIME_ABI.md` defines Dao's own runtime hooks, which
+  are already `extern fn` declarations consumed through this same
+  mechanism
+- `CONTRACT_SYNTAX_SURFACE.md` freezes `extern fn` as the
+  declaration form for externally-provided functions
+- `CONTRACT_NUMERIC_SEMANTICS.md` defines the type mappings that
+  apply at the ABI boundary
+
+## 10. Implementation status
+
+| Feature                          | Status          |
+|----------------------------------|-----------------|
+| `extern fn` syntax + parsing     | Implemented     |
+| `extern fn` LLVM lowering        | Implemented     |
+| Scalar types at boundary         | Implemented     |
+| Pointer types at boundary        | Implemented     |
+| Driver: link `.o` files          | Not implemented |
+| Driver: link `-l` libraries      | Not implemented |
+| Driver: `-L` search paths        | Not implemented |
+| Unsupported type rejection       | Partial         |
+| E2E foreign call example         | Not implemented |

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -72,9 +72,16 @@ static archive, or shared/system library.
 - C unions
 - arrays / slices by value
 
-If an `extern fn` declaration uses an unsupported type, the compiler
+If a user-declared `extern fn` uses an unsupported type, the compiler
 must reject it with a clear diagnostic during type checking or
 backend lowering.
+
+**Exception**: Dao runtime hooks (`__dao_*` prefix) are exempt from
+these restrictions. They use Dao-defined types (e.g. `string`) with
+Dao-defined ABI conventions specified in `CONTRACT_RUNTIME_ABI.md`.
+Runtime hooks are consumed through the same `extern fn` syntax but
+operate under a different ABI contract than user-declared foreign
+functions.
 
 ### 4.4 Future type expansions
 

--- a/docs/task_specs/TASK_15_C_ABI_INTEROP.md
+++ b/docs/task_specs/TASK_15_C_ABI_INTEROP.md
@@ -1,0 +1,106 @@
+# Task 15 — C ABI Interop
+
+## Objective
+
+Enable Dao programs to call external C ABI functions by linking
+against user-provided object files, static archives, or system
+libraries. Limited to scalar and pointer types per
+`CONTRACT_C_ABI_INTEROP.md`.
+
+## Governing contract
+
+`docs/contracts/CONTRACT_C_ABI_INTEROP.md`
+
+## Deliverables
+
+### 1. Driver: external link inputs
+
+Extend `daoc build` to accept additional link inputs:
+
+```
+daoc build program.dao helper.o
+daoc build program.dao -lm
+daoc build program.dao helper.o -lm -L/opt/libs
+```
+
+Implementation:
+
+- collect extra CLI arguments after the source file
+- pass them through to the `cc` linker invocation
+- object files (`.o`, `.a`) and linker flags (`-l`, `-L`) are
+  forwarded verbatim
+- no validation of the external inputs beyond linker errors
+
+### 2. Frontend: type validation for extern fn
+
+Verify that `extern fn` declarations only use supported types at
+the ABI boundary. Reject unsupported types (structs by value,
+function pointers, etc.) with clear diagnostics.
+
+Current state: `extern fn` is already parsed and lowered. The
+type checker accepts any type. This task adds a validation pass
+that rejects unsupported ABI types in `extern fn` declarations
+(excluding `__dao_` runtime hooks, which are handled separately).
+
+### 3. Examples
+
+Two end-to-end examples proving the feature:
+
+#### Example A: custom C helper
+
+`examples/ffi/helper.c`:
+```c
+#include <stdint.h>
+int64_t add_i64(int64_t a, int64_t b) { return a + b; }
+double scale(double x, int32_t factor) { return x * factor; }
+```
+
+`examples/ffi/ffi_helper.dao`:
+```dao
+extern fn add_i64(a: i64, b: i64): i64
+extern fn scale(x: f64, factor: i32): f64
+
+fn main(): i32
+  print(add_i64(100, 200))
+  print(scale(3.14, 2))
+  return 0
+```
+
+Build: `daoc build ffi_helper.dao helper.o`
+
+#### Example B: system library (libm)
+
+`examples/ffi/ffi_libm.dao`:
+```dao
+extern fn sqrt(x: f64): f64
+extern fn pow(base: f64, exp: f64): f64
+
+fn main(): i32
+  print(sqrt(2.0))
+  print(pow(2.0, 10.0))
+  return 0
+```
+
+Build: `daoc build ffi_libm.dao -lm`
+
+### 4. Tests
+
+- backend test: verify `extern fn` with C ABI types emits correct
+  LLVM `declare`
+- driver test (manual): compile and run both examples
+
+## Non-deliverables
+
+- no struct-by-value ABI
+- no string interop
+- no callbacks / function pointers
+- no variadics
+- no header parsing
+- no dynamic loading
+
+## Exit criteria
+
+1. `daoc build program.dao helper.o` links and runs correctly
+2. `daoc build program.dao -lm` links and runs correctly
+3. unsupported types in `extern fn` produce clear diagnostics
+4. both examples produce correct output


### PR DESCRIPTION
## Summary

Defines the normative boundary for Dao's C ABI foreign function interop and the concrete implementation task spec. V1 is deliberately narrow: scalar + pointer types only, no aggregates, strings, variadics, callbacks, or ownership semantics.

## Highlights

### CONTRACT_C_ABI_INTEROP.md

- **Doctrine**: C ABI interop is an explicit foreign boundary, not a general extension mechanism
- **Supported types (v1)**: `i32`, `i64`, `f64`, `bool`, `*T`, `void` — no structs by value, no `string` as `char*`
- **Pointer semantics**: foreign addresses, no ownership, deref requires `mode unsafe =>`
- **Name/linkage**: no mangling, no prefix, C++ requires `extern "C"` on their side
- **Ownership**: no transfer implied, no cleanup inserted
- **Driver**: must support `.o`, `.a`, `-l`, `-L` link inputs
- **Explicit non-goals**: header parsing, bindgen, variadics, callbacks, dynamic loading, inline assembly

### TASK_15_C_ABI_INTEROP.md

- Driver: extend `daoc build` to accept extra link inputs
- Frontend: validate extern fn types against supported ABI set
- Two E2E examples: custom C helper + libm (sqrt, pow)
- Exit criteria defined

## Test plan

- [x] Contract internally consistent
- [x] Aligns with CONTRACT_BOOTSTRAP_AND_INTEROP (C ABI as initial target)
- [x] Aligns with CONTRACT_RUNTIME_ABI (extern fn mechanism already used for runtime hooks)
- [x] ARCH_INDEX updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)