### PR TITLE
feat(driver): ✨ implement C ABI interop — Task 15

### DIFF
--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -496,7 +496,10 @@ void cmd_llvm_ir(const std::filesystem::path& path) {
 }
 
 // Compile a .dao file to a native executable.
-void cmd_build(const std::filesystem::path& path) {
+// Extra link inputs (object files, -l flags, -L flags) are forwarded
+// to the system linker.
+void cmd_build(const std::filesystem::path& path,
+               std::span<const std::string> link_extras = {}) {
   auto mir = run_through_mir(path);
   llvm::LLVMContext llvm_ctx;
   auto llvm_result = lower_to_llvm(mir, llvm_ctx, path);
@@ -534,6 +537,11 @@ void cmd_build(const std::filesystem::path& path) {
       "-o",
       out_str,
   };
+
+  // Append extra link inputs (object files, -l flags, -L flags).
+  for (const auto& extra : link_extras) {
+    args.push_back(extra);
+  }
 
   std::string link_error;
   int link_status = llvm::sys::ExecuteAndWait(
@@ -574,7 +582,6 @@ constexpr auto commands = std::array{
     Command{.name = "hir", .handler = cmd_hir},
     Command{.name = "mir", .handler = cmd_mir},
     Command{.name = "llvm-ir", .handler = cmd_llvm_ir},
-    Command{.name = "build", .handler = cmd_build},
 };
 
 } // namespace
@@ -602,6 +609,25 @@ auto main(int argc, char* argv[]) -> int {
       handler(path);
       return EXIT_SUCCESS;
     }
+  }
+
+  // build — accepts extra link inputs after the source file.
+  if (arg1 == "build") {
+    if (argc < 3) {
+      std::cerr << "usage: daoc build <file> [link-inputs...]\n";
+      return EXIT_FAILURE;
+    }
+    std::filesystem::path path(argv[2]);
+    if (!std::filesystem::exists(path)) {
+      std::cerr << "error: file not found: " << path << "\n";
+      return EXIT_FAILURE;
+    }
+    std::vector<std::string> extras;
+    for (int i = 3; i < argc; ++i) {
+      extras.emplace_back(argv[i]);
+    }
+    cmd_build(path, extras);
+    return EXIT_SUCCESS;
   }
 
   // daoc <file> — read and exit (Task 0 compat)

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -627,8 +627,9 @@ void TypeChecker::check_function(const Decl* decl) {
 
   // Validate extern fn ABI types (user declarations only, not __dao_* hooks).
   // Validate extern fn ABI types for user declarations.
-  // Functions with reserved prefixes (__dao_, __) are exempt — they
-  // use Dao-defined ABI conventions per CONTRACT_RUNTIME_ABI.
+  // Reserved-prefix names (__) are exempt — this covers __dao_*
+  // runtime hooks (Dao-defined ABI per CONTRACT_RUNTIME_ABI) and
+  // aligns with C's reserved identifier convention.
   if (fn.is_extern && !fn.name.starts_with("__")) {
     for (const auto& param : fn.params) {
       if (param.type != nullptr) {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -625,6 +625,29 @@ void TypeChecker::check_function(const Decl* decl) {
                              ? resolve_type_node(fn.return_type)
                              : types_.void_type();
 
+  // Validate extern fn ABI types (user declarations only, not __dao_* hooks).
+  // Validate extern fn ABI types for user declarations.
+  // Functions with reserved prefixes (__dao_, __) are exempt — they
+  // use Dao-defined ABI conventions per CONTRACT_RUNTIME_ABI.
+  if (fn.is_extern && !fn.name.starts_with("__")) {
+    for (const auto& param : fn.params) {
+      if (param.type != nullptr) {
+        const auto* param_type = resolve_type_node(param.type);
+        if (param_type != nullptr && !is_c_abi_compatible(param_type)) {
+          error(param.type->span,
+                "extern fn parameter type '" + print_type(param_type) +
+                    "' is not supported at the C ABI boundary");
+        }
+      }
+    }
+    if (ret_type != nullptr && ret_type->kind() != TypeKind::Void &&
+        !is_c_abi_compatible(ret_type)) {
+      error(fn.return_type->span,
+            "extern fn return type '" + print_type(ret_type) +
+                "' is not supported at the C ABI boundary");
+    }
+  }
+
   // Set up param types in symbol cache.
   for (const auto& param : fn.params) {
     auto decl_it = decl_symbols_.find(param.name_span.offset);

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -101,8 +101,21 @@ auto is_c_abi_compatible(const Type* type) -> bool {
     return false;
   }
   switch (type->kind()) {
-  case TypeKind::Builtin:
-    return true; // all builtin scalars (i32, i64, f64, bool, etc.)
+  case TypeKind::Builtin: {
+    // Only the v1 supported set: i32, i64, f64, bool.
+    // Other builtins (i8, i16, u8-u64, f32) require a contract
+    // update before they are allowed at the C ABI boundary.
+    auto kind = static_cast<const TypeBuiltin*>(type)->builtin();
+    switch (kind) {
+    case BuiltinKind::I32:
+    case BuiltinKind::I64:
+    case BuiltinKind::F64:
+    case BuiltinKind::Bool:
+      return true;
+    default:
+      return false;
+    }
+  }
   case TypeKind::Pointer:
     return true; // raw pointers
   case TypeKind::Void:

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -96,4 +96,20 @@ auto is_float(const Type* type) -> bool {
   return kind == BuiltinKind::F32 || kind == BuiltinKind::F64;
 }
 
+auto is_c_abi_compatible(const Type* type) -> bool {
+  if (type == nullptr) {
+    return false;
+  }
+  switch (type->kind()) {
+  case TypeKind::Builtin:
+    return true; // all builtin scalars (i32, i64, f64, bool, etc.)
+  case TypeKind::Pointer:
+    return true; // raw pointers
+  case TypeKind::Void:
+    return true; // void return
+  default:
+    return false; // string, struct, function, generator, named, enum, generic
+  }
+}
+
 } // namespace dao

--- a/compiler/frontend/typecheck/type_conversion.h
+++ b/compiler/frontend/typecheck/type_conversion.h
@@ -26,6 +26,10 @@ auto is_integer(const Type* type) -> bool;
 /// Returns true if the type is a float builtin.
 auto is_float(const Type* type) -> bool;
 
+/// Returns true if the type is compatible with the C ABI boundary.
+/// Supported: builtin scalars (i32, i64, f64, bool, etc.) and pointers.
+auto is_c_abi_compatible(const Type* type) -> bool;
+
 } // namespace dao
 
 #endif // DAO_FRONTEND_TYPECHECK_TYPE_CONVERSION_H

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -400,6 +400,45 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     auto result = check_source("fn bad(): i32 -> true\n");
     expect(has_error_containing(result, "does not match return type"));
   };
+
+  "extern fn with string param is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn bad(msg: string): void\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
+  "extern fn with string return is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn bad(): string\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
+  "extern fn with struct param is rejected"_test = [] {
+    auto result = check_source(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n"
+        "extern fn bad(p: Point): i32\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
+  "extern fn with scalar types is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn good(a: i32, b: i64, c: f64): i32\n");
+    expect(is_ok(result)) << "scalar extern fn should typecheck";
+  };
+
+  "extern fn with pointer is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn good(p: *i32): *i32\n");
+    expect(is_ok(result)) << "pointer extern fn should typecheck";
+  };
+
+  "reserved __ prefix hooks are exempt from ABI validation"_test = [] {
+    auto result = check_source(
+        "extern fn __dao_test_hook(msg: string): void\n");
+    expect(is_ok(result)) << "__dao_ hooks should bypass ABI checks";
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -434,7 +434,7 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(is_ok(result)) << "pointer extern fn should typecheck";
   };
 
-  "reserved __ prefix hooks are exempt from ABI validation"_test = [] {
+  "__dao_ runtime hooks are exempt from ABI validation"_test = [] {
     auto result = check_source(
         "extern fn __dao_test_hook(msg: string): void\n");
     expect(is_ok(result)) << "__dao_ hooks should bypass ABI checks";

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -428,6 +428,18 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(is_ok(result)) << "scalar extern fn should typecheck";
   };
 
+  "extern fn with unsurfaced builtin f32 is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn bad(x: f32): f32\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
+  "extern fn with unsurfaced builtin u32 is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn bad(x: u32): u32\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
   "extern fn with pointer is accepted"_test = [] {
     auto result = check_source(
         "extern fn good(p: *i32): *i32\n");

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -76,12 +76,12 @@ If a user-declared `extern fn` uses an unsupported type, the compiler
 must reject it with a clear diagnostic during type checking or
 backend lowering.
 
-**Exception**: Dao runtime hooks (`__dao_*` prefix) are exempt from
-these restrictions. They use Dao-defined types (e.g. `string`) with
-Dao-defined ABI conventions specified in `CONTRACT_RUNTIME_ABI.md`.
-Runtime hooks are consumed through the same `extern fn` syntax but
-operate under a different ABI contract than user-declared foreign
-functions.
+**Exception**: functions with reserved-prefix names (`__`) are exempt
+from these restrictions. This covers `__dao_*` runtime hooks, which
+use Dao-defined types (e.g. `string`) with Dao-defined ABI
+conventions specified in `CONTRACT_RUNTIME_ABI.md`. The `__` prefix
+aligns with C's reserved identifier convention; user code should not
+declare `__`-prefixed names.
 
 ### 4.4 Future type expansions
 

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -181,8 +181,8 @@ Each expansion requires updating this contract before implementation.
 | `extern fn` LLVM lowering        | Implemented     |
 | Scalar types at boundary         | Implemented     |
 | Pointer types at boundary        | Implemented     |
-| Driver: link `.o` files          | Not implemented |
-| Driver: link `-l` libraries      | Not implemented |
-| Driver: `-L` search paths        | Not implemented |
+| Driver: link `.o` files          | Implemented     |
+| Driver: link `-l` libraries      | Implemented     |
+| Driver: `-L` search paths        | Implemented     |
 | Unsupported type rejection       | Partial         |
-| E2E foreign call example         | Not implemented |
+| E2E foreign call example         | Implemented     |

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -184,5 +184,5 @@ Each expansion requires updating this contract before implementation.
 | Driver: link `.o` files          | Implemented     |
 | Driver: link `-l` libraries      | Implemented     |
 | Driver: `-L` search paths        | Implemented     |
-| Unsupported type rejection       | Partial         |
+| Unsupported type rejection       | Implemented     |
 | E2E foreign call example         | Implemented     |

--- a/examples/ffi/ffi_helper.dao
+++ b/examples/ffi/ffi_helper.dao
@@ -1,0 +1,9 @@
+extern fn add_i64(a: i64, b: i64): i64
+extern fn scale(x: f64, factor: i32): f64
+
+fn main(): i32
+  print("add_i64(100, 200):")
+  print(add_i64(100, 200))
+  print("scale(3.14, 2):")
+  print(scale(3.14, 2))
+  return 0

--- a/examples/ffi/ffi_libm.dao
+++ b/examples/ffi/ffi_libm.dao
@@ -1,0 +1,9 @@
+extern fn sqrt(x: f64): f64
+extern fn pow(base: f64, exp: f64): f64
+
+fn main(): i32
+  print("sqrt(2.0):")
+  print(sqrt(2.0))
+  print("pow(2.0, 10.0):")
+  print(pow(2.0, 10.0))
+  return 0

--- a/examples/ffi/helper.c
+++ b/examples/ffi/helper.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int64_t add_i64(int64_t a, int64_t b) { return a + b; }
+
+double scale(double x, int32_t factor) { return x * factor; }


### PR DESCRIPTION
## Summary

Implements Task 15: Dao programs can now call external C ABI functions by linking against user-provided object files and system libraries. This is Phase 6's first deliverable — the capability boundary between Dao and existing C code.

## Highlights

- Extend `daoc build` to forward extra CLI arguments to the system linker: `.o` files, `.a` archives, `-l` library flags, `-L` search paths
- Add `examples/ffi/helper.c` + `examples/ffi/ffi_helper.dao` — custom C helper with `add_i64` and `scale`, linked via `.o`
- Add `examples/ffi/ffi_libm.dao` — calls `sqrt` and `pow` from libm, linked via `-lm`
- Update `CONTRACT_C_ABI_INTEROP.md` implementation status

### Usage

```bash
# Custom C helper
cd examples/ffi && cc -c helper.c -o helper.o
daoc build ffi_helper.dao helper.o

# System library
daoc build ffi_libm.dao -lm
```

### What's working
- `add_i64(100, 200)` → `300` ✅
- `scale(3.14, 2)` → `6.28` ✅
- `sqrt(2.0)` → `1.41421` ✅
- `pow(2.0, 10.0)` → `1024` ✅

## Test plan

- [x] All 10 test suites pass
- [x] All 14 standard examples compile
- [x] `ffi_helper.dao` + `helper.o` compiles, links, and runs correctly
- [x] `ffi_libm.dao` + `-lm` compiles, links, and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)