### PR TITLE
feat(tooling): ✨ add dot completion for struct fields and methods

### DIFF
--- a/compiler/analysis/analysis_test.cpp
+++ b/compiler/analysis/analysis_test.cpp
@@ -320,4 +320,47 @@ suite<"completion"> completion = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Dot completion
+// ---------------------------------------------------------------------------
+
+suite<"dot_completion"> dot_completion = [] {
+  "struct fields offered"_test = [] {
+    AnalysisPipeline pipe(
+        "class Point:\n"
+        "  x: i32\n"
+        "  y: i32\n");
+    auto* point_type = pipe.check_result.typed.decl_type(
+        pipe.parse_result.file->declarations[0]);
+    expect(point_type != nullptr) << "Point type should exist";
+    auto items = query_dot_completions(point_type, pipe.check_result);
+    expect(has_completion(items, "x")) << "should offer field x";
+    expect(has_completion(items, "y")) << "should offer field y";
+  };
+
+  "methods from extends offered"_test = [] {
+    AnalysisPipeline pipe(
+        "extern fn __test_hook(x: i32): string\n"
+        "concept Showable:\n"
+        "  fn show(self): string\n"
+        "extend i32 as Showable:\n"
+        "  fn show(self): string -> __test_hook(self)\n");
+    // Get the i32 type via the type context.
+    auto* i32_type = pipe.types.i32();
+    auto items = query_dot_completions(i32_type, pipe.check_result);
+    expect(has_completion(items, "show")) << "should offer method show";
+  };
+
+  "dot completion on non-struct returns empty for fields"_test = [] {
+    AnalysisPipeline pipe("fn main(): i32 -> 0\n");
+    auto* bool_type = pipe.types.bool_type();
+    auto items = query_dot_completions(bool_type, pipe.check_result);
+    // bool has no fields, but may have methods from Equatable etc.
+    for (const auto& item : items) {
+      expect(item.kind != "field")
+          << "bool should not have fields: " << item.label;
+    }
+  };
+};
+
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/analysis/completion.cpp
+++ b/compiler/analysis/completion.cpp
@@ -114,4 +114,45 @@ auto query_completions(uint32_t offset,
   return items;
 }
 
+auto query_dot_completions(const Type* receiver_type,
+                            const TypeCheckResult& typed)
+    -> std::vector<CompletionItem> {
+  std::vector<CompletionItem> items;
+
+  if (receiver_type == nullptr) {
+    return items;
+  }
+
+  // Unwrap pointer for auto-deref: (*Point).| → Point fields.
+  const Type* base_type = receiver_type;
+  if (base_type->kind() == TypeKind::Pointer) {
+    base_type = static_cast<const TypePointer*>(base_type)->pointee();
+  }
+
+  // Struct fields.
+  if (base_type->kind() == TypeKind::Struct) {
+    const auto* struct_type = static_cast<const TypeStruct*>(base_type);
+    for (const auto& field : struct_type->fields()) {
+      items.push_back({
+          .label = std::string(field.name),
+          .kind = "field",
+          .type = print_type(field.type),
+      });
+    }
+  }
+
+  // Methods from concept extends (exported method table).
+  for (const auto& method : typed.methods) {
+    if (method.receiver_type == base_type) {
+      items.push_back({
+          .label = std::string(method.method_name),
+          .kind = "method",
+          .type = print_type(method.method_type),
+      });
+    }
+  }
+
+  return items;
+}
+
 } // namespace dao

--- a/compiler/analysis/completion.h
+++ b/compiler/analysis/completion.h
@@ -1,7 +1,6 @@
 #ifndef DAO_ANALYSIS_COMPLETION_H
 #define DAO_ANALYSIS_COMPLETION_H
 
-#include "frontend/diagnostics/source.h"
 #include "frontend/resolve/resolve.h"
 #include "frontend/typecheck/type_checker.h"
 
@@ -12,15 +11,21 @@ namespace dao {
 
 struct CompletionItem {
   std::string label;
-  std::string kind;  // "function", "variable", "type", "parameter", "field", etc.
+  std::string kind;  // "function", "variable", "type", "parameter", "field", "method"
   std::string type;  // printed type signature
 };
 
-/// Query completions at a byte offset in the source.
+/// Query identifier completions at a byte offset in the source.
 /// Returns all symbols visible at that position, with type info.
 auto query_completions(uint32_t offset,
                         const ResolveResult& resolve,
                         const TypeCheckResult& typed)
+    -> std::vector<CompletionItem>;
+
+/// Query dot completions for a receiver type.
+/// Returns fields (if struct) and methods (from concept extends).
+auto query_dot_completions(const Type* receiver_type,
+                            const TypeCheckResult& typed)
     -> std::vector<CompletionItem>;
 
 } // namespace dao

--- a/compiler/analysis/completion.h
+++ b/compiler/analysis/completion.h
@@ -24,6 +24,11 @@ auto query_completions(uint32_t offset,
 
 /// Query dot completions for a receiver type.
 /// Returns fields (if struct) and methods (from concept extends).
+/// The caller is responsible for determining the receiver type —
+/// currently the playground only resolves simple identifier receivers
+/// (locals and params). General expression receivers (calls, field
+/// chains, indexing) require AST-level expression lookup, which is
+/// tracked as Task 16.
 auto query_dot_completions(const Type* receiver_type,
                             const TypeCheckResult& typed)
     -> std::vector<CompletionItem>;

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -39,7 +39,15 @@ auto TypeChecker::check(const FileNode& file) -> TypeCheckResult {
     check_declaration(decl);
   }
 
-  return {.typed = std::move(typed_), .diagnostics = std::move(diagnostics_)};
+  // Export method table for tooling (completion, hover).
+  std::vector<MethodInfo> methods;
+  for (const auto& [key, entry] : method_table_) {
+    methods.push_back({key.type, key.name, entry.fn_type});
+  }
+
+  return {.typed = std::move(typed_),
+          .diagnostics = std::move(diagnostics_),
+          .methods = std::move(methods)};
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -20,9 +20,17 @@ namespace dao {
 // TypeCheckResult — output of the type-checking pass.
 // ---------------------------------------------------------------------------
 
+/// A method available on a type via concept/extend.
+struct MethodInfo {
+  const Type* receiver_type;
+  std::string_view method_name;
+  const Type* method_type; // function type (self removed)
+};
+
 struct TypeCheckResult {
   TypedResults typed;
   std::vector<Diagnostic> diagnostics;
+  std::vector<MethodInfo> methods; // exported method table for tooling
 };
 
 // ---------------------------------------------------------------------------

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -359,6 +359,36 @@ Exit criteria (Tier A+B):
 - i64 is usable end-to-end (type, codegen, runtime, examples)
 - explicit numeric conversions exist between i32 and f64
 
+### Task 16 — Error-Tolerant Parsing and Tooling Hardening
+
+**Objective**: Make the parser produce partial ASTs for incomplete
+or broken source, enabling completion and diagnostics while typing.
+
+Governing contracts: `CONTRACT_LANGUAGE_TOOLING.md`
+
+Deliverables:
+
+- error recovery at ~18 parser error points: skip to next statement
+  or insert synthetic nodes instead of bailing
+- partial AST consumers: resolver, type checker, and analysis APIs
+  must tolerate missing/error nodes gracefully
+- dot completion for general expressions: use AST expression types
+  (`typed.expr_type()`) instead of symbol-only heuristics, so
+  `make_point().`, `p.x.`, and `arr[i].` work
+- playground diagnostics suppression for incomplete constructs
+  (e.g. don't report "function not found" while user is typing
+  an opening paren)
+
+Priority: **medium** — improves day-to-day playground UX but does
+not block any phase milestone.
+
+Exit criteria:
+
+- typing `p.` mid-statement shows dot completions without parser
+  failure
+- incomplete source produces partial results instead of no results
+- diagnostics for in-progress constructs are deferred or suppressed
+
 ## Principles
 
 - The grammar in `spec/grammar/` is the parser's source of truth

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -561,8 +561,66 @@ void handle_completions(const httplib::Request& req, httplib::Response& res,
   }
 
   auto absolute_offset = pipe.prelude_bytes + user_offset;
-  auto items = dao::query_completions(absolute_offset, pipe.resolve_result,
-                                       pipe.check_result);
+  std::vector<dao::CompletionItem> items;
+
+  // Detect dot completion: check if cursor is immediately after a '.'.
+  auto contents = pipe.source.contents();
+  bool is_dot = false;
+  if (absolute_offset > 0 && absolute_offset <= contents.size()) {
+    // Scan backward past whitespace to find the trigger character.
+    auto pos = absolute_offset;
+    while (pos > 0 && (contents[pos - 1] == ' ' || contents[pos - 1] == '\t')) {
+      --pos;
+    }
+    is_dot = (pos > 0 && contents[pos - 1] == '.');
+    if (is_dot) {
+      // Find the token before the dot.
+      auto pre_dot = pos - 1;
+      while (pre_dot > 0 &&
+             (contents[pre_dot - 1] == ' ' || contents[pre_dot - 1] == '\t')) {
+        --pre_dot;
+      }
+      auto token_off = find_token_offset(pre_dot > 0 ? pre_dot - 1 : 0,
+                                          pipe.lex_result);
+      // Look up the symbol at that token to find its type.
+      auto use_it = pipe.resolve_result.uses.find(token_off);
+      if (use_it != pipe.resolve_result.uses.end()) {
+        const dao::Type* recv_type = nullptr;
+        const auto* sym = use_it->second;
+        if (sym->kind == dao::SymbolKind::Local && sym->decl != nullptr) {
+          recv_type = pipe.check_result.typed.local_type(
+              static_cast<const dao::Stmt*>(sym->decl));
+        } else if (sym->kind == dao::SymbolKind::Param &&
+                   sym->decl != nullptr) {
+          const auto* fn_decl = static_cast<const dao::Decl*>(sym->decl);
+          const auto* fn_type = pipe.check_result.typed.decl_type(fn_decl);
+          if (fn_type != nullptr &&
+              fn_type->kind() == dao::TypeKind::Function) {
+            const auto* ft =
+                static_cast<const dao::TypeFunction*>(fn_type);
+            if (fn_decl->is<dao::FunctionDecl>()) {
+              const auto& fn = fn_decl->as<dao::FunctionDecl>();
+              for (size_t idx = 0; idx < fn.params.size(); ++idx) {
+                if (fn.params[idx].name == sym->name &&
+                    idx < ft->param_types().size()) {
+                  recv_type = ft->param_types()[idx];
+                  break;
+                }
+              }
+            }
+          }
+        }
+        if (recv_type != nullptr) {
+          items = dao::query_dot_completions(recv_type, pipe.check_result);
+        }
+      }
+    }
+  }
+
+  if (!is_dot) {
+    items = dao::query_completions(absolute_offset, pipe.resolve_result,
+                                    pipe.check_result);
+  }
 
   nlohmann::json response = nlohmann::json::array();
   for (const auto& item : items) {

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -534,6 +534,81 @@ void handle_references(const httplib::Request& req, httplib::Response& res,
 // Completions
 // ---------------------------------------------------------------------------
 
+/// Scan backward from offset to find the non-whitespace character.
+/// Returns the position (1-indexed into contents), or 0 if none found.
+auto scan_back_past_whitespace(std::string_view contents, uint32_t offset)
+    -> uint32_t {
+  auto pos = offset;
+  while (pos > 0 && (contents[pos - 1] == ' ' || contents[pos - 1] == '\t')) {
+    --pos;
+  }
+  return pos;
+}
+
+/// Resolve the semantic type of a symbol from typed results.
+/// Handles locals, params, functions, and types.
+auto resolve_receiver_type(const dao::Symbol* sym,
+                            const dao::TypeCheckResult& typed)
+    -> const dao::Type* {
+  if (sym == nullptr || sym->decl == nullptr) {
+    return nullptr;
+  }
+  switch (sym->kind) {
+  case dao::SymbolKind::Local:
+    return typed.typed.local_type(
+        static_cast<const dao::Stmt*>(sym->decl));
+  case dao::SymbolKind::Param: {
+    const auto* fn_decl = static_cast<const dao::Decl*>(sym->decl);
+    const auto* fn_type = typed.typed.decl_type(fn_decl);
+    if (fn_type == nullptr || fn_type->kind() != dao::TypeKind::Function) {
+      return nullptr;
+    }
+    const auto* func = static_cast<const dao::TypeFunction*>(fn_type);
+    if (!fn_decl->is<dao::FunctionDecl>()) {
+      return nullptr;
+    }
+    const auto& decl = fn_decl->as<dao::FunctionDecl>();
+    for (size_t idx = 0; idx < decl.params.size(); ++idx) {
+      if (decl.params[idx].name == sym->name &&
+          idx < func->param_types().size()) {
+        return func->param_types()[idx];
+      }
+    }
+    return nullptr;
+  }
+  default:
+    return nullptr;
+  }
+}
+
+/// Try to detect and resolve dot completion at the given offset.
+/// Returns the receiver type if a dot trigger is found, or nullptr.
+auto try_resolve_dot_receiver(uint32_t absolute_offset,
+                               const LightPipeline& pipe)
+    -> const dao::Type* {
+  auto contents = pipe.source.contents();
+  if (absolute_offset == 0 || absolute_offset > contents.size()) {
+    return nullptr;
+  }
+
+  auto pos = scan_back_past_whitespace(contents, absolute_offset);
+  if (pos == 0 || contents[pos - 1] != '.') {
+    return nullptr;
+  }
+
+  // Find the identifier token before the dot.
+  auto pre_dot = scan_back_past_whitespace(contents, pos - 1);
+  auto token_off = find_token_offset(
+      pre_dot > 0 ? pre_dot - 1 : 0, pipe.lex_result);
+
+  auto use_it = pipe.resolve_result.uses.find(token_off);
+  if (use_it == pipe.resolve_result.uses.end()) {
+    return nullptr;
+  }
+
+  return resolve_receiver_type(use_it->second, pipe.check_result);
+}
+
 void handle_completions(const httplib::Request& req, httplib::Response& res,
                          const std::filesystem::path& repo_root) {
   nlohmann::json request;
@@ -563,61 +638,10 @@ void handle_completions(const httplib::Request& req, httplib::Response& res,
   auto absolute_offset = pipe.prelude_bytes + user_offset;
   std::vector<dao::CompletionItem> items;
 
-  // Detect dot completion: check if cursor is immediately after a '.'.
-  auto contents = pipe.source.contents();
-  bool is_dot = false;
-  if (absolute_offset > 0 && absolute_offset <= contents.size()) {
-    // Scan backward past whitespace to find the trigger character.
-    auto pos = absolute_offset;
-    while (pos > 0 && (contents[pos - 1] == ' ' || contents[pos - 1] == '\t')) {
-      --pos;
-    }
-    is_dot = (pos > 0 && contents[pos - 1] == '.');
-    if (is_dot) {
-      // Find the token before the dot.
-      auto pre_dot = pos - 1;
-      while (pre_dot > 0 &&
-             (contents[pre_dot - 1] == ' ' || contents[pre_dot - 1] == '\t')) {
-        --pre_dot;
-      }
-      auto token_off = find_token_offset(pre_dot > 0 ? pre_dot - 1 : 0,
-                                          pipe.lex_result);
-      // Look up the symbol at that token to find its type.
-      auto use_it = pipe.resolve_result.uses.find(token_off);
-      if (use_it != pipe.resolve_result.uses.end()) {
-        const dao::Type* recv_type = nullptr;
-        const auto* sym = use_it->second;
-        if (sym->kind == dao::SymbolKind::Local && sym->decl != nullptr) {
-          recv_type = pipe.check_result.typed.local_type(
-              static_cast<const dao::Stmt*>(sym->decl));
-        } else if (sym->kind == dao::SymbolKind::Param &&
-                   sym->decl != nullptr) {
-          const auto* fn_decl = static_cast<const dao::Decl*>(sym->decl);
-          const auto* fn_type = pipe.check_result.typed.decl_type(fn_decl);
-          if (fn_type != nullptr &&
-              fn_type->kind() == dao::TypeKind::Function) {
-            const auto* ft =
-                static_cast<const dao::TypeFunction*>(fn_type);
-            if (fn_decl->is<dao::FunctionDecl>()) {
-              const auto& fn = fn_decl->as<dao::FunctionDecl>();
-              for (size_t idx = 0; idx < fn.params.size(); ++idx) {
-                if (fn.params[idx].name == sym->name &&
-                    idx < ft->param_types().size()) {
-                  recv_type = ft->param_types()[idx];
-                  break;
-                }
-              }
-            }
-          }
-        }
-        if (recv_type != nullptr) {
-          items = dao::query_dot_completions(recv_type, pipe.check_result);
-        }
-      }
-    }
-  }
-
-  if (!is_dot) {
+  const auto* receiver = try_resolve_dot_receiver(absolute_offset, pipe);
+  if (receiver != nullptr) {
+    items = dao::query_dot_completions(receiver, pipe.check_result);
+  } else {
     items = dao::query_completions(absolute_offset, pipe.resolve_result,
                                     pipe.check_result);
   }


### PR DESCRIPTION
## Summary

Adds dot completion to the analysis layer — typing `p.` on a struct shows its fields, and `x.` on any type shows methods from concept extends. This is the natural capstone for Tooling T2.

## Highlights

- **Method table export**: `TypeCheckResult.methods` now contains a flat vector of `{receiver_type, method_name, method_type}` tuples, exported from the type checker's internal method table
- **`query_dot_completions(receiver_type, typed)`**: returns struct fields + concept methods for the receiver type. Auto-derefs pointers.
- **Playground detection**: the `/api/completions` endpoint scans backward from cursor to detect a `.` trigger, finds the receiver symbol, resolves its type, and dispatches to dot completion

### Example

`p.` where `p: Point` returns:
```json
[{"label": "x", "kind": "field", "type": "i32"},
 {"label": "y", "kind": "field", "type": "i32"},
 {"label": "to_string", "kind": "method", "type": "fn(): string"},
 {"label": "eq", "kind": "method", "type": "fn(Point): bool"}]
```

## Test plan

- [x] All 11 test suites pass (22 analysis tests total)
- [x] 3 new dot completion tests: struct fields, concept methods, no fields on non-struct
- [x] Playground endpoint tested manually: struct fields + derived concept methods appear
- [x] Regular identifier completion still works when no dot detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)