### PR TITLE
feat(parser): 🛡️ add error-tolerant parsing with recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,15 +24,14 @@ CMakeUserPresets.json
 .task/
 
 # Compiled executables from daoc build
-examples/hello
-examples/astar
-examples/arithmetic
-examples/control_flow
-examples/generators
-examples/iteration
-examples/pipelines
-examples/structs
-examples/unsafe
+# Ignore extensionless files in examples/ (binary outputs of daoc build).
+# Git doesn't support "ignore files without extension" natively, so we
+# ignore everything then un-ignore the patterns we want to keep.
+examples/*
+!examples/*/
+!examples/*.dao
+!examples/*.md
+!examples/*.c
 
 # Playground frontend
 tools/playground/frontend/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,13 @@ CMakeUserPresets.json
 # Ignore extensionless files in examples/ (binary outputs of daoc build).
 # Git doesn't support "ignore files without extension" natively, so we
 # ignore everything then un-ignore the patterns we want to keep.
+# The ** variants ensure nested dirs (e.g. examples/ffi/) are covered.
 examples/*
 !examples/*/
-!examples/*.dao
-!examples/*.md
-!examples/*.c
+!examples/**/*.dao
+!examples/**/*.md
+!examples/**/*.c
+!examples/**/*.h
 
 # Playground frontend
 tools/playground/frontend/node_modules/

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -13,6 +13,7 @@ auto Decl::kind() const -> NodeKind {
       [](const AliasDecl&) { return NodeKind::AliasDecl; },
       [](const ConceptDecl&) { return NodeKind::ConceptDecl; },
       [](const ExtendDecl&) { return NodeKind::ExtendDecl; },
+      [](const ErrorDeclNode&) { return NodeKind::ErrorDecl; },
   }, payload);
 }
 
@@ -28,6 +29,7 @@ auto Stmt::kind() const -> NodeKind {
       [](const ResourceBlock&) { return NodeKind::ResourceBlock; },
       [](const ReturnStatement&) { return NodeKind::ReturnStatement; },
       [](const ExpressionStatement&) { return NodeKind::ExpressionStatement; },
+      [](const ErrorStmtNode&) { return NodeKind::ErrorStmt; },
   }, payload);
 }
 
@@ -47,6 +49,7 @@ auto Expr::kind() const -> NodeKind {
       [](const ListLiteral&) { return NodeKind::ListLiteral; },
       [](const IdentifierExpr&) { return NodeKind::Identifier; },
       [](const QualifiedName&) { return NodeKind::QualifiedName; },
+      [](const ErrorExprNode&) { return NodeKind::ErrorExpr; },
   }, payload);
 }
 
@@ -132,6 +135,12 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "NamedType";
   case NodeKind::PointerType:
     return "PointerType";
+  case NodeKind::ErrorExpr:
+    return "ErrorExpr";
+  case NodeKind::ErrorStmt:
+    return "ErrorStmt";
+  case NodeKind::ErrorDecl:
+    return "ErrorDecl";
   }
   return "Unknown";
 }

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -85,6 +85,11 @@ enum class NodeKind : std::uint8_t {
   // Types
   NamedType,
   PointerType,
+
+  // Error recovery placeholders
+  ErrorExpr,
+  ErrorStmt,
+  ErrorDecl,
 };
 
 // ---------------------------------------------------------------------------
@@ -236,8 +241,15 @@ struct ExtendDecl {
   std::vector<Decl*> methods; // FunctionDecl nodes
 };
 
+// Error recovery placeholders — carry no data; diagnostics are reported
+// separately. These allow partial ASTs to flow through downstream passes.
+struct ErrorDeclNode {};
+struct ErrorStmtNode {};
+struct ErrorExprNode {};
+
 using DeclPayload =
-    std::variant<FunctionDecl, ClassDecl, AliasDecl, ConceptDecl, ExtendDecl>;
+    std::variant<FunctionDecl, ClassDecl, AliasDecl, ConceptDecl, ExtendDecl,
+                 ErrorDeclNode>;
 
 // ---------------------------------------------------------------------------
 // Statement payloads
@@ -306,7 +318,7 @@ struct ExpressionStatement {
 using StmtPayload = std::variant<
     LetStatement, Assignment, IfStatement, WhileStatement, ForStatement,
     YieldStatement, ModeBlock, ResourceBlock, ReturnStatement,
-    ExpressionStatement>;
+    ExpressionStatement, ErrorStmtNode>;
 
 // ---------------------------------------------------------------------------
 // Expression payloads
@@ -369,7 +381,7 @@ struct QualifiedName {
 using ExprPayload = std::variant<
     BinaryExpr, UnaryExpr, CallExpr, IndexExpr, FieldExpr, PipeExpr,
     LambdaExpr, IntLiteral, FloatLiteral, StringLiteral, BoolLiteral,
-    ListLiteral, IdentifierExpr, QualifiedName>;
+    ListLiteral, IdentifierExpr, QualifiedName, ErrorExprNode>;
 
 // ---------------------------------------------------------------------------
 // Type node payloads

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -71,6 +71,7 @@ private:
         [&](const AliasDecl& alias) { print_alias_decl(alias); },
         [&](const ConceptDecl& concept_) { print_concept_decl(concept_); },
         [&](const ExtendDecl& ext) { print_extend_decl(ext); },
+        [](const ErrorDeclNode&) {},
     }, decl.payload);
   }
 
@@ -327,6 +328,7 @@ private:
           Scope scope(depth_);
           print_expr(*node.expr);
         },
+        [](const ErrorStmtNode&) {},
     }, stmt.payload);
   }
 
@@ -493,6 +495,7 @@ private:
             }
           }
         },
+        [](const ErrorExprNode&) {},
     }, expr.payload);
   }
 

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -114,9 +114,14 @@ private:
     return ctx_.alloc<Expr>(peek().span, ErrorExprNode{});
   }
 
-  /// Create an error statement node at the current position.
+  /// Create an error statement node.
   auto make_error_stmt(Span span) -> Stmt* {
     return ctx_.alloc<Stmt>(span, ErrorStmtNode{});
+  }
+
+  /// Create an error declaration node.
+  auto make_error_decl(Span span) -> Decl* {
+    return ctx_.alloc<Decl>(span, ErrorDeclNode{});
   }
 
   // -----------------------------------------------------------------------
@@ -139,12 +144,16 @@ private:
       if (at_end()) {
         break;
       }
+      Span before = peek().span;
       auto* decl = parse_declaration();
       if (decl != nullptr) {
         declarations.push_back(decl);
       } else {
-        // Recovery: skip to next declaration keyword.
+        // Recovery: insert an error placeholder and skip to next declaration keyword.
         synchronize_to_declaration();
+        Span err_span = {.offset = before.offset,
+                         .length = peek().span.offset - before.offset};
+        declarations.push_back(make_error_decl(err_span));
       }
       skip_newlines();
     }
@@ -556,12 +565,16 @@ private:
       if (peek_kind() == TokenKind::Dedent || peek_kind() == TokenKind::Eof) {
         break;
       }
+      Span before = peek().span;
       auto* stmt = parse_statement();
       if (stmt != nullptr) {
         stmts.push_back(stmt);
       } else {
-        // Recovery: skip to next statement boundary and continue.
+        // Recovery: insert an error placeholder and skip to next statement boundary.
         synchronize_to_statement();
+        Span err_span = {.offset = before.offset,
+                         .length = peek().span.offset - before.offset};
+        stmts.push_back(make_error_stmt(err_span));
       }
     }
     return stmts;

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -75,6 +75,51 @@ private:
   }
 
   // -----------------------------------------------------------------------
+  // Error recovery
+  // -----------------------------------------------------------------------
+
+  /// Skip tokens until a declaration keyword or EOF.
+  void synchronize_to_declaration() {
+    while (!at_end()) {
+      switch (peek_kind()) {
+      case TokenKind::KwFn:
+      case TokenKind::KwClass:
+      case TokenKind::KwConcept:
+      case TokenKind::KwDerived:
+      case TokenKind::KwExtend:
+      case TokenKind::KwExtern:
+      case TokenKind::KwType:
+        return;
+      case TokenKind::Dedent:
+        return;
+      default:
+        advance();
+      }
+    }
+  }
+
+  /// Skip tokens until a statement boundary (NEWLINE, DEDENT, or EOF).
+  void synchronize_to_statement() {
+    while (!at_end()) {
+      if (peek_kind() == TokenKind::Newline ||
+          peek_kind() == TokenKind::Dedent) {
+        return;
+      }
+      advance();
+    }
+  }
+
+  /// Create an error expression node at the current position.
+  auto make_error_expr() -> Expr* {
+    return ctx_.alloc<Expr>(peek().span, ErrorExprNode{});
+  }
+
+  /// Create an error statement node at the current position.
+  auto make_error_stmt(Span span) -> Stmt* {
+    return ctx_.alloc<Stmt>(span, ErrorStmtNode{});
+  }
+
+  // -----------------------------------------------------------------------
   // File
   // -----------------------------------------------------------------------
 
@@ -97,6 +142,9 @@ private:
       auto* decl = parse_declaration();
       if (decl != nullptr) {
         declarations.push_back(decl);
+      } else {
+        // Recovery: skip to next declaration keyword.
+        synchronize_to_declaration();
       }
       skip_newlines();
     }
@@ -511,6 +559,9 @@ private:
       auto* stmt = parse_statement();
       if (stmt != nullptr) {
         stmts.push_back(stmt);
+      } else {
+        // Recovery: skip to next statement boundary and continue.
+        synchronize_to_statement();
       }
     }
     return stmts;
@@ -541,8 +592,7 @@ private:
 
     // Expression or assignment.
     auto* expr = parse_expression();
-    if (expr == nullptr) {
-      advance();
+    if (expr == nullptr || expr->kind() == NodeKind::ErrorExpr) {
       return nullptr;
     }
 
@@ -998,9 +1048,8 @@ private:
     }
     default:
       error("expected expression");
-      const auto& tok = advance();
-      // Return an error placeholder.
-      return ctx_.alloc<Expr>(tok.span, IdentifierExpr{tok.text});
+      advance(); // skip the offending token to guarantee progress
+      return make_error_expr();
     }
   }
 

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -723,6 +723,59 @@ suite<"self_keyword_tests"> self_keyword_tests = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Error recovery
+// ---------------------------------------------------------------------------
+
+suite<"error_recovery"> error_recovery = [] {
+  "broken declaration does not prevent parsing subsequent ones"_test = [] {
+    SourceBuffer src("test.dao",
+        "fn good1(): i32 -> 1\n"
+        "\n"
+        "this is garbage\n"
+        "\n"
+        "fn good2(): i32 -> 2\n");
+    auto lex_result = lex(src);
+    auto result = parse(lex_result.tokens);
+    expect(result.file != nullptr) << "file should be produced";
+    // good1 and good2 should both be present; garbage is skipped.
+    expect(result.file->declarations.size() >= 2_ul)
+        << "both valid declarations should survive";
+  };
+
+  "broken statement does not prevent parsing subsequent ones"_test = [] {
+    SourceBuffer src("test.dao",
+        "fn main(): i32\n"
+        "  let x: i32 = 1\n"
+        "  @@@ broken\n"
+        "  return x\n");
+    auto lex_result = lex(src);
+    auto result = parse(lex_result.tokens);
+    expect(result.file != nullptr) << "file should be produced";
+    expect(!result.file->declarations.empty())
+        << "function should be parsed";
+    if (!result.file->declarations.empty()) {
+      const auto& fn = result.file->declarations[0]->as<FunctionDecl>();
+      // Should have at least the let and return statements.
+      expect(fn.body.size() >= 2_ul)
+          << "valid statements should survive broken one";
+    }
+  };
+
+  "incomplete source still produces partial AST"_test = [] {
+    SourceBuffer src("test.dao",
+        "fn add(a: i32, b: i32): i32 -> a + b\n"
+        "\n"
+        "fn incomplete(\n");
+    auto lex_result = lex(src);
+    auto result = parse(lex_result.tokens);
+    expect(result.file != nullptr) << "file should be produced";
+    // At least the first valid function should be present.
+    expect(!result.file->declarations.empty())
+        << "valid declaration should survive incomplete one";
+  };
+};
+
 // NOLINTEND(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
 
 } // namespace

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -738,9 +738,15 @@ suite<"error_recovery"> error_recovery = [] {
     auto lex_result = lex(src);
     auto result = parse(lex_result.tokens);
     expect(result.file != nullptr) << "file should be produced";
-    // good1 and good2 should both be present; garbage is skipped.
-    expect(result.file->declarations.size() >= 2_ul)
-        << "both valid declarations should survive";
+    // good1, ErrorDecl, and good2 should all be present.
+    expect(result.file->declarations.size() == 3_ul)
+        << "should have good1 + error + good2";
+    if (result.file->declarations.size() == 3) {
+      expect(result.file->declarations[0]->kind() == NodeKind::FunctionDecl);
+      expect(result.file->declarations[1]->kind() == NodeKind::ErrorDecl)
+          << "error placeholder should be inserted for garbage";
+      expect(result.file->declarations[2]->kind() == NodeKind::FunctionDecl);
+    }
   };
 
   "broken statement does not prevent parsing subsequent ones"_test = [] {
@@ -756,9 +762,15 @@ suite<"error_recovery"> error_recovery = [] {
         << "function should be parsed";
     if (!result.file->declarations.empty()) {
       const auto& fn = result.file->declarations[0]->as<FunctionDecl>();
-      // Should have at least the let and return statements.
-      expect(fn.body.size() >= 2_ul)
-          << "valid statements should survive broken one";
+      // Should have let, ErrorStmt, and return.
+      expect(fn.body.size() >= 3_ul)
+          << "should have let + error + return";
+      if (fn.body.size() >= 3) {
+        expect(fn.body[0]->kind() == NodeKind::LetStatement);
+        expect(fn.body[1]->kind() == NodeKind::ErrorStmt)
+            << "error placeholder should be inserted for broken statement";
+        expect(fn.body[2]->kind() == NodeKind::ReturnStatement);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Add AST error placeholder nodes and parser synchronization so that broken declarations and statements don't abort the entire parse. The parser now produces a partial AST that downstream passes (tooling, diagnostics, analysis) can consume even when the source contains errors.

## Highlights

- **Error AST nodes**: `ErrorExprNode`, `ErrorStmtNode`, `ErrorDeclNode` — empty placeholders wired into the existing variant payloads; diagnostics are reported separately
- **Declaration recovery**: `synchronize_to_declaration()` skips to the next `fn`/`class`/`concept`/`extend`/`extern`/`type` keyword on parse failure
- **Statement recovery**: `synchronize_to_statement()` skips to the next newline/dedent boundary on parse failure
- **Forward progress guarantee**: `parse_primary()` advances past the offending token before returning an error expr, preventing infinite loops
- **Error expression handling**: `parse_statement()` treats error expressions as recovery triggers rather than silently wrapping them in `ExpressionStatement`
- **Tests**: Three new tests covering broken declaration recovery, broken statement recovery, and incomplete source producing a partial AST

## Test plan

- [x] All 11 existing test targets pass (lexer, parser, ast_printer, resolve, type, typecheck, hir, mir, llvm_backend, semantic_tokens, analysis)
- [x] New `error_recovery` suite passes all 3 tests
- [x] Parser no longer hangs on malformed input

🤖 Generated with [Claude Code](https://claude.com/claude-code)