### PR TITLE
fix(parser): 🐛 prevent ErrorExpr from leaking into downstream passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,10 @@ CMakeUserPresets.json
 # Compiled executables from daoc build
 # Ignore extensionless files in examples/ (binary outputs of daoc build).
 # Git doesn't support "ignore files without extension" natively, so we
-# ignore everything then un-ignore the patterns we want to keep.
-# The ** variants ensure nested dirs (e.g. examples/ffi/) are covered.
-examples/*
-!examples/*/
+# ignore everything at all depths, then un-ignore directories and
+# source files we want to keep.
+examples/**
+!examples/**/*/
 !examples/**/*.dao
 !examples/**/*.md
 !examples/**/*.c

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -623,6 +623,10 @@ private:
       }
       advance(); // =
       auto* value = parse_expression();
+      if (is_error_expr(value)) {
+        match(TokenKind::Newline);
+        return make_error_stmt(span_from(expr->span));
+      }
       // Trailing newline may have been consumed by pipe continuation.
       match(TokenKind::Newline);
       Span span = {.offset = expr->span.offset,
@@ -658,7 +662,9 @@ private:
 
     // If the initializer is an error placeholder, promote the whole
     // statement to an error so downstream passes never see it.
-    if (is_error_expr(init) && type == nullptr) {
+    // Note: init == nullptr is valid (e.g. `let x: i32`), so only
+    // check when init was actually parsed but came back as an error.
+    if (init != nullptr && init->kind() == NodeKind::ErrorExpr) {
       match(TokenKind::Newline);
       return make_error_stmt(span_from(kw.span));
     }

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -114,6 +114,11 @@ private:
     return ctx_.alloc<Expr>(peek().span, ErrorExprNode{});
   }
 
+  /// Check whether an expression is null or an error recovery placeholder.
+  static auto is_error_expr(const Expr* expr) -> bool {
+    return expr == nullptr || expr->kind() == NodeKind::ErrorExpr;
+  }
+
   /// Create an error statement node.
   auto make_error_stmt(Span span) -> Stmt* {
     return ctx_.alloc<Stmt>(span, ErrorStmtNode{});
@@ -651,6 +656,13 @@ private:
       error("expected ':' or '=' after let binding name");
     }
 
+    // If the initializer is an error placeholder, promote the whole
+    // statement to an error so downstream passes never see it.
+    if (is_error_expr(init) && type == nullptr) {
+      match(TokenKind::Newline);
+      return make_error_stmt(span_from(kw.span));
+    }
+
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
     Span span = span_from(kw.span);
@@ -661,6 +673,10 @@ private:
   auto parse_if_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwIf);
     auto* condition = parse_expression();
+    if (is_error_expr(condition)) {
+      synchronize_to_statement();
+      return make_error_stmt(span_from(kw.span));
+    }
     consume(TokenKind::Colon);
     auto then_body = parse_suite();
 
@@ -679,6 +695,10 @@ private:
   auto parse_while_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwWhile);
     auto* condition = parse_expression();
+    if (is_error_expr(condition)) {
+      synchronize_to_statement();
+      return make_error_stmt(span_from(kw.span));
+    }
     consume(TokenKind::Colon);
     auto body = parse_suite();
     Span span = span_from(kw.span);
@@ -690,6 +710,10 @@ private:
     const auto& var_tok = consume(TokenKind::Identifier);
     consume(TokenKind::KwIn);
     auto* iterable = parse_expression();
+    if (is_error_expr(iterable)) {
+      synchronize_to_statement();
+      return make_error_stmt(span_from(kw.span));
+    }
     consume(TokenKind::Colon);
     auto body = parse_suite();
     Span span = span_from(kw.span);
@@ -724,6 +748,10 @@ private:
   auto parse_yield_statement() -> Stmt* {
     const auto& kw = consume(TokenKind::KwYield);
     auto* value = parse_expression();
+    if (is_error_expr(value)) {
+      match(TokenKind::Newline);
+      return make_error_stmt(span_from(kw.span));
+    }
     match(TokenKind::Newline);
     Span span = span_from(kw.span);
     return ctx_.alloc<Stmt>(span, YieldStatement{value});
@@ -736,6 +764,10 @@ private:
         peek_kind() != TokenKind::Dedent &&
         peek_kind() != TokenKind::Eof) {
       value = parse_expression();
+      if (is_error_expr(value)) {
+        match(TokenKind::Newline);
+        return make_error_stmt(span_from(kw.span));
+      }
     }
     // Trailing newline may have been consumed by pipe continuation.
     match(TokenKind::Newline);
@@ -1059,10 +1091,12 @@ private:
       const auto& tok = advance();
       return ctx_.alloc<Expr>(tok.span, IdentifierExpr{tok.text});
     }
-    default:
+    default: {
+      auto err_span = peek().span;
       error("expected expression");
       advance(); // skip the offending token to guarantee progress
-      return make_error_expr();
+      return ctx_.alloc<Expr>(err_span, ErrorExprNode{});
+    }
     }
   }
 

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1019,6 +1019,9 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
   case NodeKind::ListLiteral:
     result = check_list_literal(expr);
     break;
+  case NodeKind::ErrorExpr:
+    // Recovery placeholder — skip silently.
+    break;
   default:
     error(expr->span, "unsupported expression in type checker");
     break;

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -409,6 +409,9 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
                                 HirLambda{std::move(params), body});
   }
 
+  case NodeKind::ErrorExpr:
+    // Recovery placeholder — skip silently.
+    return nullptr;
   default:
     error(expr->span, "unsupported expression in HIR builder");
     return nullptr;


### PR DESCRIPTION
## Summary

Error-tolerant parsing (#143) introduced recovery placeholders but only converted `ErrorExpr` to `ErrorStmt` at the bare expression-statement path. Statement parsers (`let`, `if`, `while`, `for`, `yield`, `return`) still built normal nodes wrapping `ErrorExpr` children, causing misleading downstream diagnostics like "unsupported expression in type checker" and "unsupported expression in HIR builder".

## Highlights

- **High — ErrorExpr leak prevention**: Add `is_error_expr` helper; guard all six statement parsers so they produce `ErrorStmt` when a child expression is an error recovery placeholder, preventing downstream passes from seeing partially-constructed statements
- **High — Downstream defense**: Add `NodeKind::ErrorExpr` cases in `TypeChecker::check_expr` and `HirBuilder::lower_expr` to skip silently instead of emitting spurious "unsupported expression" errors
- **Medium — ErrorExpr span fix**: Capture the offending token's span *before* advancing in `parse_primary()`, so recovery nodes point at the bad token rather than the next one
- **Low — .gitignore coverage**: Change `examples/*` to `examples/**` so extensionless binary outputs in nested directories (e.g. `examples/ffi/helper`) are correctly ignored

## Test plan

- [x] All 11 test suites pass (including `error_recovery` suite)
- [x] Full build succeeds
- [ ] Manual: parse broken source with `let x = @@@` — should produce `ErrorStmt`, not `LetStatement` wrapping `ErrorExpr`
- [ ] Manual: verify no "unsupported expression in type checker" diagnostic on broken input

🤖 Generated with [Claude Code](https://claude.com/claude-code)