### PR TITLE
feat(numeric): ✨ add wrapping and saturating arithmetic — Task 14 Tier A+

### DIFF
--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -778,6 +778,11 @@ suite<"runtime_abi"> runtime_abi = [] {
     expect(contains(ir, "declare i32 @__dao_conv_i64_to_i32(i64)")) << ir;
     // String
     expect(contains(ir, "@__dao_str_length")) << ir;
+    // Overflow (wrapping + saturating)
+    expect(contains(ir, "declare i32 @__dao_wrapping_add_i32(i32, i32)")) << ir;
+    expect(contains(ir, "declare i64 @__dao_wrapping_add_i64(i64, i64)")) << ir;
+    expect(contains(ir, "declare i32 @__dao_saturating_add_i32(i32, i32)")) << ir;
+    expect(contains(ir, "declare i64 @__dao_saturating_add_i64(i64, i64)")) << ir;
   };
 };
 

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -21,6 +21,7 @@ void LlvmRuntimeHooks::declare_all() {
   declare_io_hooks();
   declare_equality_hooks();
   declare_conversion_hooks();
+  declare_overflow_hooks();
   declare_generator_hooks();
   declare_mem_resource_hooks();
   declare_string_hooks();
@@ -124,6 +125,35 @@ void LlvmRuntimeHooks::declare_conversion_hooks() {
   // __dao_conv_i64_to_i32(x: i64): i32
   ensure_declared(runtime_hooks::kConvI64ToI32,
                   llvm::FunctionType::get(i32, {i64}, false));
+}
+
+// ---------------------------------------------------------------------------
+// Overflow hooks (wrapping + saturating)
+// ---------------------------------------------------------------------------
+
+void LlvmRuntimeHooks::declare_overflow_hooks() {
+  auto& ctx = module_.getContext();
+  auto* i32 = llvm::Type::getInt32Ty(ctx);
+  auto* i64 = llvm::Type::getInt64Ty(ctx);
+
+  // Wrapping: (T, T) -> T
+  auto* i32_bin = llvm::FunctionType::get(i32, {i32, i32}, false);
+  auto* i64_bin = llvm::FunctionType::get(i64, {i64, i64}, false);
+
+  ensure_declared(runtime_hooks::kWrappingAddI32, i32_bin);
+  ensure_declared(runtime_hooks::kWrappingSubI32, i32_bin);
+  ensure_declared(runtime_hooks::kWrappingMulI32, i32_bin);
+  ensure_declared(runtime_hooks::kWrappingAddI64, i64_bin);
+  ensure_declared(runtime_hooks::kWrappingSubI64, i64_bin);
+  ensure_declared(runtime_hooks::kWrappingMulI64, i64_bin);
+
+  // Saturating: (T, T) -> T
+  ensure_declared(runtime_hooks::kSaturatingAddI32, i32_bin);
+  ensure_declared(runtime_hooks::kSaturatingSubI32, i32_bin);
+  ensure_declared(runtime_hooks::kSaturatingMulI32, i32_bin);
+  ensure_declared(runtime_hooks::kSaturatingAddI64, i64_bin);
+  ensure_declared(runtime_hooks::kSaturatingSubI64, i64_bin);
+  ensure_declared(runtime_hooks::kSaturatingMulI64, i64_bin);
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -51,6 +51,20 @@ inline constexpr std::string_view kConvI32ToI64  = "__dao_conv_i32_to_i64";
 inline constexpr std::string_view kConvF64ToI32  = "__dao_conv_f64_to_i32";
 inline constexpr std::string_view kConvI64ToI32  = "__dao_conv_i64_to_i32";
 
+// Overflow domain (explicit operations)
+inline constexpr std::string_view kWrappingAddI32    = "__dao_wrapping_add_i32";
+inline constexpr std::string_view kWrappingSubI32    = "__dao_wrapping_sub_i32";
+inline constexpr std::string_view kWrappingMulI32    = "__dao_wrapping_mul_i32";
+inline constexpr std::string_view kWrappingAddI64    = "__dao_wrapping_add_i64";
+inline constexpr std::string_view kWrappingSubI64    = "__dao_wrapping_sub_i64";
+inline constexpr std::string_view kWrappingMulI64    = "__dao_wrapping_mul_i64";
+inline constexpr std::string_view kSaturatingAddI32  = "__dao_saturating_add_i32";
+inline constexpr std::string_view kSaturatingSubI32  = "__dao_saturating_sub_i32";
+inline constexpr std::string_view kSaturatingMulI32  = "__dao_saturating_mul_i32";
+inline constexpr std::string_view kSaturatingAddI64  = "__dao_saturating_add_i64";
+inline constexpr std::string_view kSaturatingSubI64  = "__dao_saturating_sub_i64";
+inline constexpr std::string_view kSaturatingMulI64  = "__dao_saturating_mul_i64";
+
 // Generator domain
 inline constexpr std::string_view kGenAlloc = "__dao_gen_alloc";
 inline constexpr std::string_view kGenFree  = "__dao_gen_free";
@@ -69,6 +83,10 @@ inline constexpr std::string_view kAllHooks[] = {
     kEqI32,    kEqI64,    kEqF64,    kEqBool,    kEqString,
     kConvI32ToString, kConvI64ToString, kConvF64ToString, kConvBoolToString,
     kConvI32ToF64, kConvI32ToI64, kConvF64ToI32, kConvI64ToI32,
+    kWrappingAddI32,   kWrappingSubI32,   kWrappingMulI32,
+    kWrappingAddI64,   kWrappingSubI64,   kWrappingMulI64,
+    kSaturatingAddI32, kSaturatingSubI32, kSaturatingMulI32,
+    kSaturatingAddI64, kSaturatingSubI64, kSaturatingMulI64,
     kGenAlloc, kGenFree,
     kMemResourceEnter, kMemResourceExit,
     kStrConcat, kStrLength,
@@ -98,6 +116,7 @@ private:
   void declare_io_hooks();
   void declare_equality_hooks();
   void declare_conversion_hooks();
+  void declare_overflow_hooks();
   void declare_generator_hooks();
   void declare_mem_resource_hooks();
   void declare_string_hooks();

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -29,6 +29,8 @@ auto check_source(const std::string& source) -> TypeCheckResult {
 
 /// Check user source with prelude source strings prepended.
 /// Uses source concatenation (same approach as the driver).
+/// The prelude byte offset is passed to resolve so __dao_ prefixed
+/// names in the prelude are not rejected as user code.
 auto check_with_prelude(const std::string& user_source,
                         std::span<const std::string> prelude_sources)
     -> TypeCheckResult {
@@ -37,8 +39,16 @@ auto check_with_prelude(const std::string& user_source,
     combined += pre;
     combined += '\n';
   }
+  auto prelude_bytes = static_cast<uint32_t>(combined.size());
   combined += user_source;
-  return check_source(combined);
+
+  SourceBuffer buf("test.dao", std::string(combined));
+  auto lex_result = lex(buf);
+  auto parse_result = parse(lex_result.tokens);
+  auto resolve_result = resolve(*parse_result.file, prelude_bytes);
+
+  TypeContext types;
+  return typecheck(*parse_result.file, resolve_result, types);
 }
 
 /// Returns true if any diagnostic message contains the substring.
@@ -1215,6 +1225,32 @@ suite<"typecheck_prelude"> prelude_tests = [] {
         preludes);
     expect(is_ok(result))
         << "user class should auto-derive from prelude concept";
+  };
+
+  "prelude wrapping functions typecheck"_test = [&] {
+    const std::string overflow_prelude =
+        "extern fn __dao_wrapping_add_i32(a: i32, b: i32): i32\n"
+        "fn wrapping_add(a: i32, b: i32): i32 -> __dao_wrapping_add_i32(a, b)\n";
+    std::array preludes{overflow_prelude};
+    auto result = check_with_prelude(
+        "fn test(x: i32, y: i32): i32\n"
+        "  return wrapping_add(x, y)\n",
+        preludes);
+    expect(is_ok(result))
+        << "wrapping_add should typecheck through prelude extern + wrapper";
+  };
+
+  "prelude saturating functions typecheck"_test = [&] {
+    const std::string sat_prelude =
+        "extern fn __dao_saturating_add_i32(a: i32, b: i32): i32\n"
+        "fn saturating_add(a: i32, b: i32): i32 -> __dao_saturating_add_i32(a, b)\n";
+    std::array preludes{sat_prelude};
+    auto result = check_with_prelude(
+        "fn test(x: i32, y: i32): i32\n"
+        "  return saturating_add(x, y)\n",
+        preludes);
+    expect(is_ok(result))
+        << "saturating_add should typecheck through prelude extern + wrapper";
   };
 
   "multiple prelude files compose"_test = [&] {

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -312,15 +312,18 @@ Priority: **high** — correctness baseline for existing types.
 
 #### Tier A+ — Post-baseline (no blocking dependency)
 
+Status: **wrapping and saturating complete; checked deferred**
+
 Priority: **medium** — enriches the numeric surface but does not
 block other tiers.
 
-- explicit wrapping operations: `wrapping_add`, `wrapping_sub`,
-  `wrapping_mul`
-- explicit saturating operations: `saturating_add`, `saturating_sub`,
-  `saturating_mul`
-- explicit checked operations: `checked_add`, `checked_sub`,
-  `checked_mul` (return error/status on overflow)
+- ✓ explicit wrapping operations for i32 and i64: `wrapping_add`,
+  `wrapping_sub`, `wrapping_mul` (+ `_i64` variants)
+- ✓ explicit saturating operations for i32 and i64: `saturating_add`,
+  `saturating_sub`, `saturating_mul` (+ `_i64` variants)
+- ✗ explicit checked operations: `checked_add`, `checked_sub`,
+  `checked_mul` — deferred until Dao has a Result/Option type to
+  express the error-or-value return; default operators already trap
 
 #### Tier B — Phase 6 prerequisite
 

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -110,14 +110,14 @@ Rules:
    the language explicitly says otherwise — no debug/release
    semantic split
 
-Future explicit operations (not yet implemented):
+Explicit overflow operations:
 
 - `wrapping_add`, `wrapping_sub`, `wrapping_mul` — two's complement
-  wrap, no trap
+  wrap, no trap — **implemented** for i32 and i64
 - `saturating_add`, `saturating_sub`, `saturating_mul` — clamp to
-  min/max representable value
+  min/max representable value — **implemented** for i32 and i64
 - `checked_add`, `checked_sub`, `checked_mul` — return an error
-  value or status on overflow
+  value or status on overflow — **deferred** until Result type exists
 
 If Dao later wants relaxed arithmetic for high-performance numerics,
 it must be introduced as an explicit mode, operator family, or
@@ -403,6 +403,9 @@ The compiler and backend must:
 | Rounding-mode control            | Forbidden | N/A               |
 | Fast-math / relaxed mode         | Opt-in    | Deferred          |
 | Integer overflow policy freeze   | Yes       | Implemented       |
+| Wrapping operations (i32, i64)   | Yes       | Implemented       |
+| Saturating operations (i32, i64) | Yes       | Implemented       |
+| Checked operations               | Yes       | Deferred          |
 | String conversion (f64)          | Partial   | Implemented       |
 | Mixed-type operator rejection    | Yes       | Implemented       |
 

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -58,6 +58,8 @@ Domains:
 | `gen`      | Generator frame allocation and lifetime    |
 | `mem`      | Resource domain scope and lifetime         |
 | `str`      | String operations                          |
+| `wrapping` | Wrapping (two's complement) arithmetic     |
+| `saturating`| Saturating arithmetic                     |
 
 Examples:
 
@@ -83,6 +85,18 @@ Examples:
 | `__dao_conv_i64_to_i32`  | `(x: i64): i32`                       |
 | `__dao_str_concat`       | `(a: string, b: string): string`      |
 | `__dao_str_length`       | `(s: string): i64`                    |
+| `__dao_wrapping_add_i32` | `(a: i32, b: i32): i32`              |
+| `__dao_wrapping_sub_i32` | `(a: i32, b: i32): i32`              |
+| `__dao_wrapping_mul_i32` | `(a: i32, b: i32): i32`              |
+| `__dao_wrapping_add_i64` | `(a: i64, b: i64): i64`              |
+| `__dao_wrapping_sub_i64` | `(a: i64, b: i64): i64`              |
+| `__dao_wrapping_mul_i64` | `(a: i64, b: i64): i64`              |
+| `__dao_saturating_add_i32`| `(a: i32, b: i32): i32`             |
+| `__dao_saturating_sub_i32`| `(a: i32, b: i32): i32`             |
+| `__dao_saturating_mul_i32`| `(a: i32, b: i32): i32`             |
+| `__dao_saturating_add_i64`| `(a: i64, b: i64): i64`             |
+| `__dao_saturating_sub_i64`| `(a: i64, b: i64): i64`             |
+| `__dao_saturating_mul_i64`| `(a: i64, b: i64): i64`             |
 
 These are the **only** runtime hooks in the current supported slice.
 New hooks require updating this contract before implementation.

--- a/runtime/core/CMakeLists.txt
+++ b/runtime/core/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(dao_runtime STATIC
   io.c
   equality.c
   convert.c
+  overflow.c
   generator.c
   resource.c
   string.c

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -75,6 +75,26 @@ int32_t __dao_conv_f64_to_i32(double x);
 int32_t __dao_conv_i64_to_i32(int64_t x);
 
 // ---------------------------------------------------------------------------
+// Runtime hook declarations — Overflow domain (explicit operations)
+// ---------------------------------------------------------------------------
+
+// Wrapping arithmetic: two's complement wrap, no trap.
+int32_t __dao_wrapping_add_i32(int32_t a, int32_t b);
+int32_t __dao_wrapping_sub_i32(int32_t a, int32_t b);
+int32_t __dao_wrapping_mul_i32(int32_t a, int32_t b);
+int64_t __dao_wrapping_add_i64(int64_t a, int64_t b);
+int64_t __dao_wrapping_sub_i64(int64_t a, int64_t b);
+int64_t __dao_wrapping_mul_i64(int64_t a, int64_t b);
+
+// Saturating arithmetic: clamp to min/max representable value.
+int32_t __dao_saturating_add_i32(int32_t a, int32_t b);
+int32_t __dao_saturating_sub_i32(int32_t a, int32_t b);
+int32_t __dao_saturating_mul_i32(int32_t a, int32_t b);
+int64_t __dao_saturating_add_i64(int64_t a, int64_t b);
+int64_t __dao_saturating_sub_i64(int64_t a, int64_t b);
+int64_t __dao_saturating_mul_i64(int64_t a, int64_t b);
+
+// ---------------------------------------------------------------------------
 // Runtime hook declarations — Generator domain
 // ---------------------------------------------------------------------------
 

--- a/runtime/core/overflow.c
+++ b/runtime/core/overflow.c
@@ -1,0 +1,99 @@
+// overflow.c — Dao runtime explicit overflow operation hooks.
+//
+// Implements: wrapping and saturating arithmetic for i32 and i64.
+// Authority:  docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md §4.2
+//
+// Wrapping operations use unsigned arithmetic to avoid C signed
+// overflow UB, then cast back to signed.
+//
+// Saturating operations clamp to the type's min/max on overflow.
+
+#include "dao_abi.h"
+
+#include <limits.h>
+#include <stdint.h>
+
+// ---------------------------------------------------------------------------
+// Wrapping operations — two's complement wrap, no trap
+// ---------------------------------------------------------------------------
+
+int32_t __dao_wrapping_add_i32(int32_t a, int32_t b) {
+  return (int32_t)((uint32_t)a + (uint32_t)b);
+}
+
+int32_t __dao_wrapping_sub_i32(int32_t a, int32_t b) {
+  return (int32_t)((uint32_t)a - (uint32_t)b);
+}
+
+int32_t __dao_wrapping_mul_i32(int32_t a, int32_t b) {
+  return (int32_t)((uint32_t)a * (uint32_t)b);
+}
+
+int64_t __dao_wrapping_add_i64(int64_t a, int64_t b) {
+  return (int64_t)((uint64_t)a + (uint64_t)b);
+}
+
+int64_t __dao_wrapping_sub_i64(int64_t a, int64_t b) {
+  return (int64_t)((uint64_t)a - (uint64_t)b);
+}
+
+int64_t __dao_wrapping_mul_i64(int64_t a, int64_t b) {
+  return (int64_t)((uint64_t)a * (uint64_t)b);
+}
+
+// ---------------------------------------------------------------------------
+// Saturating operations — clamp to min/max representable value
+// ---------------------------------------------------------------------------
+
+int32_t __dao_saturating_add_i32(int32_t a, int32_t b) {
+  int64_t r = (int64_t)a + (int64_t)b;
+  if (r > INT32_MAX) return INT32_MAX;
+  if (r < INT32_MIN) return INT32_MIN;
+  return (int32_t)r;
+}
+
+int32_t __dao_saturating_sub_i32(int32_t a, int32_t b) {
+  int64_t r = (int64_t)a - (int64_t)b;
+  if (r > INT32_MAX) return INT32_MAX;
+  if (r < INT32_MIN) return INT32_MIN;
+  return (int32_t)r;
+}
+
+int32_t __dao_saturating_mul_i32(int32_t a, int32_t b) {
+  int64_t r = (int64_t)a * (int64_t)b;
+  if (r > INT32_MAX) return INT32_MAX;
+  if (r < INT32_MIN) return INT32_MIN;
+  return (int32_t)r;
+}
+
+int64_t __dao_saturating_add_i64(int64_t a, int64_t b) {
+  // Cannot widen to 128-bit portably, so use overflow detection.
+  if (b > 0 && a > INT64_MAX - b) return INT64_MAX;
+  if (b < 0 && a < INT64_MIN - b) return INT64_MIN;
+  return a + b;
+}
+
+int64_t __dao_saturating_sub_i64(int64_t a, int64_t b) {
+  if (b < 0 && a > INT64_MAX + b) return INT64_MAX;
+  if (b > 0 && a < INT64_MIN + b) return INT64_MIN;
+  return a - b;
+}
+
+int64_t __dao_saturating_mul_i64(int64_t a, int64_t b) {
+  if (a == 0 || b == 0) return 0;
+  // Check overflow by dividing back.
+  if (a > 0) {
+    if (b > 0) {
+      if (a > INT64_MAX / b) return INT64_MAX;
+    } else {
+      if (b < INT64_MIN / a) return INT64_MIN;
+    }
+  } else {
+    if (b > 0) {
+      if (a < INT64_MIN / b) return INT64_MIN;
+    } else {
+      if (a < INT64_MAX / b) return INT64_MAX;
+    }
+  }
+  return a * b;
+}

--- a/runtime/core/overflow.c
+++ b/runtime/core/overflow.c
@@ -4,7 +4,10 @@
 // Authority:  docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md §4.2
 //
 // Wrapping operations use unsigned arithmetic to avoid C signed
-// overflow UB, then cast back to signed.
+// overflow UB, then memcpy the result back to signed. The memcpy
+// reinterpretation is well-defined in all C standards (unlike
+// unsigned-to-signed casts, which are implementation-defined
+// pre-C23).
 //
 // Saturating operations clamp to the type's min/max on overflow.
 
@@ -12,33 +15,39 @@
 
 #include <limits.h>
 #include <stdint.h>
+#include <string.h>
+
+// Helper: reinterpret unsigned bits as signed via memcpy.
+// Well-defined in all C standards; the compiler optimizes this to a no-op.
+static int32_t u32_to_i32(uint32_t u) { int32_t r; memcpy(&r, &u, sizeof r); return r; }
+static int64_t u64_to_i64(uint64_t u) { int64_t r; memcpy(&r, &u, sizeof r); return r; }
 
 // ---------------------------------------------------------------------------
 // Wrapping operations — two's complement wrap, no trap
 // ---------------------------------------------------------------------------
 
 int32_t __dao_wrapping_add_i32(int32_t a, int32_t b) {
-  return (int32_t)((uint32_t)a + (uint32_t)b);
+  return u32_to_i32((uint32_t)a + (uint32_t)b);
 }
 
 int32_t __dao_wrapping_sub_i32(int32_t a, int32_t b) {
-  return (int32_t)((uint32_t)a - (uint32_t)b);
+  return u32_to_i32((uint32_t)a - (uint32_t)b);
 }
 
 int32_t __dao_wrapping_mul_i32(int32_t a, int32_t b) {
-  return (int32_t)((uint32_t)a * (uint32_t)b);
+  return u32_to_i32((uint32_t)a * (uint32_t)b);
 }
 
 int64_t __dao_wrapping_add_i64(int64_t a, int64_t b) {
-  return (int64_t)((uint64_t)a + (uint64_t)b);
+  return u64_to_i64((uint64_t)a + (uint64_t)b);
 }
 
 int64_t __dao_wrapping_sub_i64(int64_t a, int64_t b) {
-  return (int64_t)((uint64_t)a - (uint64_t)b);
+  return u64_to_i64((uint64_t)a - (uint64_t)b);
 }
 
 int64_t __dao_wrapping_mul_i64(int64_t a, int64_t b) {
-  return (int64_t)((uint64_t)a * (uint64_t)b);
+  return u64_to_i64((uint64_t)a * (uint64_t)b);
 }
 
 // ---------------------------------------------------------------------------

--- a/stdlib/core/overflow.dao
+++ b/stdlib/core/overflow.dao
@@ -1,0 +1,27 @@
+extern fn __dao_wrapping_add_i32(a: i32, b: i32): i32
+extern fn __dao_wrapping_sub_i32(a: i32, b: i32): i32
+extern fn __dao_wrapping_mul_i32(a: i32, b: i32): i32
+extern fn __dao_wrapping_add_i64(a: i64, b: i64): i64
+extern fn __dao_wrapping_sub_i64(a: i64, b: i64): i64
+extern fn __dao_wrapping_mul_i64(a: i64, b: i64): i64
+
+extern fn __dao_saturating_add_i32(a: i32, b: i32): i32
+extern fn __dao_saturating_sub_i32(a: i32, b: i32): i32
+extern fn __dao_saturating_mul_i32(a: i32, b: i32): i32
+extern fn __dao_saturating_add_i64(a: i64, b: i64): i64
+extern fn __dao_saturating_sub_i64(a: i64, b: i64): i64
+extern fn __dao_saturating_mul_i64(a: i64, b: i64): i64
+
+fn wrapping_add(a: i32, b: i32): i32 -> __dao_wrapping_add_i32(a, b)
+fn wrapping_sub(a: i32, b: i32): i32 -> __dao_wrapping_sub_i32(a, b)
+fn wrapping_mul(a: i32, b: i32): i32 -> __dao_wrapping_mul_i32(a, b)
+fn wrapping_add_i64(a: i64, b: i64): i64 -> __dao_wrapping_add_i64(a, b)
+fn wrapping_sub_i64(a: i64, b: i64): i64 -> __dao_wrapping_sub_i64(a, b)
+fn wrapping_mul_i64(a: i64, b: i64): i64 -> __dao_wrapping_mul_i64(a, b)
+
+fn saturating_add(a: i32, b: i32): i32 -> __dao_saturating_add_i32(a, b)
+fn saturating_sub(a: i32, b: i32): i32 -> __dao_saturating_sub_i32(a, b)
+fn saturating_mul(a: i32, b: i32): i32 -> __dao_saturating_mul_i32(a, b)
+fn saturating_add_i64(a: i64, b: i64): i64 -> __dao_saturating_add_i64(a, b)
+fn saturating_sub_i64(a: i64, b: i64): i64 -> __dao_saturating_sub_i64(a, b)
+fn saturating_mul_i64(a: i64, b: i64): i64 -> __dao_saturating_mul_i64(a, b)

--- a/testdata/ast/stdlib_core_overflow.ast
+++ b/testdata/ast/stdlib_core_overflow.ast
@@ -1,0 +1,181 @@
+File
+  ExternFunctionDecl __dao_wrapping_add_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_wrapping_sub_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_wrapping_mul_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_wrapping_add_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  ExternFunctionDecl __dao_wrapping_sub_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  ExternFunctionDecl __dao_wrapping_mul_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  ExternFunctionDecl __dao_saturating_add_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_saturating_sub_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_saturating_mul_i32
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+  ExternFunctionDecl __dao_saturating_add_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  ExternFunctionDecl __dao_saturating_sub_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  ExternFunctionDecl __dao_saturating_mul_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+  FunctionDecl wrapping_add
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_add_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl wrapping_sub
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_sub_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl wrapping_mul
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_mul_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl wrapping_add_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_add_i64
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl wrapping_sub_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_sub_i64
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl wrapping_mul_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_wrapping_mul_i64
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_add
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_add_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_sub
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_sub_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_mul
+    Param a: i32
+    Param b: i32
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_mul_i32
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_add_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_add_i64
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_sub_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_sub_i64
+        Args
+          Identifier a
+          Identifier b
+  FunctionDecl saturating_mul_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_saturating_mul_i64
+        Args
+          Identifier a
+          Identifier b


### PR DESCRIPTION
## Summary

Implement explicit wrapping and saturating overflow operations for i32 and i64 as specified in `CONTRACT_NUMERIC_SEMANTICS.md` §4.2. These give users fine-grained control over integer overflow behavior beyond the default checked (trapping) arithmetic. Checked operations (`checked_add/sub/mul`) are deferred until Dao has a Result type to express the error-or-value return.

## Highlights

- **12 new runtime hooks** in `runtime/core/overflow.c`: `wrapping_add/sub/mul` and `saturating_add/sub/mul` for both i32 and i64
- **Wrapping**: Uses unsigned cast to avoid C signed overflow UB, then casts back — two's complement wrap semantics
- **Saturating i32**: Widens to i64 for clean overflow detection and clamping
- **Saturating i64**: Branch-based overflow checks without 128-bit dependency (handles all edge cases including `INT64_MIN * -1`)
- **LLVM backend**: 12 hook declarations and name constants, wired into `declare_all()`
- **Stdlib surface**: `stdlib/core/overflow.dao` with extern declarations + user-facing wrapper functions (i32 uses short names like `wrapping_add`, i64 uses `wrapping_add_i64`)
- **Contracts updated**: `CONTRACT_RUNTIME_ABI.md` (new hooks + overflow domains), `CONTRACT_NUMERIC_SEMANTICS.md` (status matrix + operation list)
- **Tier A+ marked as complete** (wrapping + saturating) in `IMPLEMENTATION_PLAN.md`

## Test plan

- [x] All 11 test suites pass (including golden AST for new stdlib file)
- [x] Full build succeeds
- [ ] Manual: `daoc build` a program using `wrapping_add(INT32_MAX, 1)` — should wrap to `INT32_MIN`
- [ ] Manual: `daoc build` a program using `saturating_add(INT32_MAX, 1)` — should return `INT32_MAX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)