### PR TITLE
feat(numeric): ✨ surface all integer widths and f32 — Task 14 Tier C (1/3)

### DIFF
--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -55,23 +55,40 @@ void LlvmRuntimeHooks::declare_io_hooks() {
 void LlvmRuntimeHooks::declare_equality_hooks() {
   auto& ctx = module_.getContext();
   auto* i1 = llvm::Type::getInt1Ty(ctx);
-
-  // __dao_eq_i32(a: i32, b: i32): bool
+  auto* i8 = llvm::Type::getInt8Ty(ctx);
+  auto* i16 = llvm::Type::getInt16Ty(ctx);
   auto* i32 = llvm::Type::getInt32Ty(ctx);
+  auto* i64 = llvm::Type::getInt64Ty(ctx);
+  auto* f32 = llvm::Type::getFloatTy(ctx);
+  auto* f64 = llvm::Type::getDoubleTy(ctx);
+
+  // Signed integers
+  ensure_declared(runtime_hooks::kEqI8,
+                  llvm::FunctionType::get(i1, {i8, i8}, false));
+  ensure_declared(runtime_hooks::kEqI16,
+                  llvm::FunctionType::get(i1, {i16, i16}, false));
   ensure_declared(runtime_hooks::kEqI32,
                   llvm::FunctionType::get(i1, {i32, i32}, false));
-
-  // __dao_eq_i64(a: i64, b: i64): bool
-  auto* i64 = llvm::Type::getInt64Ty(ctx);
   ensure_declared(runtime_hooks::kEqI64,
                   llvm::FunctionType::get(i1, {i64, i64}, false));
 
-  // __dao_eq_f64(a: f64, b: f64): bool
-  auto* f64 = llvm::Type::getDoubleTy(ctx);
+  // Unsigned integers (same LLVM types as signed)
+  ensure_declared(runtime_hooks::kEqU8,
+                  llvm::FunctionType::get(i1, {i8, i8}, false));
+  ensure_declared(runtime_hooks::kEqU16,
+                  llvm::FunctionType::get(i1, {i16, i16}, false));
+  ensure_declared(runtime_hooks::kEqU32,
+                  llvm::FunctionType::get(i1, {i32, i32}, false));
+  ensure_declared(runtime_hooks::kEqU64,
+                  llvm::FunctionType::get(i1, {i64, i64}, false));
+
+  // Floats
+  ensure_declared(runtime_hooks::kEqF32,
+                  llvm::FunctionType::get(i1, {f32, f32}, false));
   ensure_declared(runtime_hooks::kEqF64,
                   llvm::FunctionType::get(i1, {f64, f64}, false));
 
-  // __dao_eq_bool(a: bool, b: bool): bool
+  // Bool
   ensure_declared(runtime_hooks::kEqBool,
                   llvm::FunctionType::get(i1, {i1, i1}, false));
 
@@ -88,16 +105,31 @@ void LlvmRuntimeHooks::declare_equality_hooks() {
 void LlvmRuntimeHooks::declare_conversion_hooks() {
   auto& ctx = module_.getContext();
   auto* str_type = types_.string_type();
-
-  // __dao_conv_i32_to_string(x: i32): dao.string
+  auto* i8 = llvm::Type::getInt8Ty(ctx);
+  auto* i16 = llvm::Type::getInt16Ty(ctx);
   auto* i32 = llvm::Type::getInt32Ty(ctx);
+  auto* i64 = llvm::Type::getInt64Ty(ctx);
+  auto* f32 = llvm::Type::getFloatTy(ctx);
+
+  // to_string for all numeric types
+  ensure_declared(runtime_hooks::kConvI8ToString,
+                  llvm::FunctionType::get(str_type, {i8}, false));
+  ensure_declared(runtime_hooks::kConvI16ToString,
+                  llvm::FunctionType::get(str_type, {i16}, false));
   ensure_declared(runtime_hooks::kConvI32ToString,
                   llvm::FunctionType::get(str_type, {i32}, false));
-
-  // __dao_conv_i64_to_string(x: i64): dao.string
-  auto* i64 = llvm::Type::getInt64Ty(ctx);
   ensure_declared(runtime_hooks::kConvI64ToString,
                   llvm::FunctionType::get(str_type, {i64}, false));
+  ensure_declared(runtime_hooks::kConvU8ToString,
+                  llvm::FunctionType::get(str_type, {i8}, false));
+  ensure_declared(runtime_hooks::kConvU16ToString,
+                  llvm::FunctionType::get(str_type, {i16}, false));
+  ensure_declared(runtime_hooks::kConvU32ToString,
+                  llvm::FunctionType::get(str_type, {i32}, false));
+  ensure_declared(runtime_hooks::kConvU64ToString,
+                  llvm::FunctionType::get(str_type, {i64}, false));
+  ensure_declared(runtime_hooks::kConvF32ToString,
+                  llvm::FunctionType::get(str_type, {f32}, false));
 
   // __dao_conv_f64_to_string(x: f64): dao.string
   auto* f64 = llvm::Type::getDoubleTy(ctx);

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -33,15 +33,29 @@ namespace runtime_hooks {
 inline constexpr std::string_view kWriteStdout = "__dao_io_write_stdout";
 
 // Equality domain
+inline constexpr std::string_view kEqI8     = "__dao_eq_i8";
+inline constexpr std::string_view kEqI16    = "__dao_eq_i16";
 inline constexpr std::string_view kEqI32    = "__dao_eq_i32";
 inline constexpr std::string_view kEqI64    = "__dao_eq_i64";
+inline constexpr std::string_view kEqU8     = "__dao_eq_u8";
+inline constexpr std::string_view kEqU16    = "__dao_eq_u16";
+inline constexpr std::string_view kEqU32    = "__dao_eq_u32";
+inline constexpr std::string_view kEqU64    = "__dao_eq_u64";
+inline constexpr std::string_view kEqF32    = "__dao_eq_f32";
 inline constexpr std::string_view kEqF64    = "__dao_eq_f64";
 inline constexpr std::string_view kEqBool   = "__dao_eq_bool";
 inline constexpr std::string_view kEqString = "__dao_eq_string";
 
 // Conversion domain (to_string)
+inline constexpr std::string_view kConvI8ToString   = "__dao_conv_i8_to_string";
+inline constexpr std::string_view kConvI16ToString  = "__dao_conv_i16_to_string";
 inline constexpr std::string_view kConvI32ToString  = "__dao_conv_i32_to_string";
 inline constexpr std::string_view kConvI64ToString  = "__dao_conv_i64_to_string";
+inline constexpr std::string_view kConvU8ToString   = "__dao_conv_u8_to_string";
+inline constexpr std::string_view kConvU16ToString  = "__dao_conv_u16_to_string";
+inline constexpr std::string_view kConvU32ToString  = "__dao_conv_u32_to_string";
+inline constexpr std::string_view kConvU64ToString  = "__dao_conv_u64_to_string";
+inline constexpr std::string_view kConvF32ToString  = "__dao_conv_f32_to_string";
 inline constexpr std::string_view kConvF64ToString  = "__dao_conv_f64_to_string";
 inline constexpr std::string_view kConvBoolToString = "__dao_conv_bool_to_string";
 
@@ -80,8 +94,14 @@ inline constexpr std::string_view kStrLength  = "__dao_str_length";
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
     kWriteStdout,
-    kEqI32,    kEqI64,    kEqF64,    kEqBool,    kEqString,
-    kConvI32ToString, kConvI64ToString, kConvF64ToString, kConvBoolToString,
+    kEqI8,     kEqI16,    kEqI32,    kEqI64,
+    kEqU8,     kEqU16,    kEqU32,    kEqU64,
+    kEqF32,    kEqF64,    kEqBool,   kEqString,
+    kConvI8ToString,  kConvI16ToString,
+    kConvI32ToString, kConvI64ToString,
+    kConvU8ToString,  kConvU16ToString,
+    kConvU32ToString, kConvU64ToString,
+    kConvF32ToString, kConvF64ToString, kConvBoolToString,
     kConvI32ToF64, kConvI32ToI64, kConvF64ToI32, kConvI64ToI32,
     kWrappingAddI32,   kWrappingSubI32,   kWrappingMulI32,
     kWrappingAddI64,   kWrappingSubI64,   kWrappingMulI64,

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -102,19 +102,25 @@ auto is_c_abi_compatible(const Type* type) -> bool {
   }
   switch (type->kind()) {
   case TypeKind::Builtin: {
-    // Only the v1 supported set: i32, i64, f64, bool.
-    // Other builtins (i8, i16, u8-u64, f32) require a contract
-    // update before they are allowed at the C ABI boundary.
+    // All numeric builtins and bool are C ABI compatible — they map
+    // directly to C scalar types (int8_t through uint64_t, float,
+    // double, bool).
     auto kind = static_cast<const TypeBuiltin*>(type)->builtin();
     switch (kind) {
+    case BuiltinKind::I8:
+    case BuiltinKind::I16:
     case BuiltinKind::I32:
     case BuiltinKind::I64:
+    case BuiltinKind::U8:
+    case BuiltinKind::U16:
+    case BuiltinKind::U32:
+    case BuiltinKind::U64:
+    case BuiltinKind::F32:
     case BuiltinKind::F64:
     case BuiltinKind::Bool:
       return true;
-    default:
-      return false;
     }
+    return false;
   }
   case TypeKind::Pointer:
     return true; // raw pointers

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -438,16 +438,22 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(is_ok(result)) << "scalar extern fn should typecheck";
   };
 
-  "extern fn with unsurfaced builtin f32 is rejected"_test = [] {
+  "extern fn with f32 is accepted"_test = [] {
     auto result = check_source(
-        "extern fn bad(x: f32): f32\n");
-    expect(has_error_containing(result, "not supported at the C ABI"));
+        "extern fn good(x: f32): f32\n");
+    expect(is_ok(result)) << "f32 extern fn should typecheck";
   };
 
-  "extern fn with unsurfaced builtin u32 is rejected"_test = [] {
+  "extern fn with unsigned types is accepted"_test = [] {
     auto result = check_source(
-        "extern fn bad(x: u32): u32\n");
-    expect(has_error_containing(result, "not supported at the C ABI"));
+        "extern fn good(a: u8, b: u16, c: u32, d: u64): u32\n");
+    expect(is_ok(result)) << "unsigned extern fn should typecheck";
+  };
+
+  "extern fn with narrow signed types is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn good(a: i8, b: i16): i16\n");
+    expect(is_ok(result)) << "narrow signed extern fn should typecheck";
   };
 
   "extern fn with pointer is accepted"_test = [] {

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -97,7 +97,6 @@ The following may be added in later versions:
 - `c_string` or explicit null-terminated byte string type
 - by-value struct passing (once Dao struct ABI is stabilized)
 - function pointer types for callbacks
-- `f32` (when surfaced)
 
 Each expansion requires updating this contract before implementation.
 

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -43,12 +43,19 @@ static archive, or shared/system library.
 
 ## 4. Supported types at the ABI boundary
 
-### 4.1 Initial supported types (v1)
+### 4.1 Supported scalar types
 
 | Dao type  | C ABI type       | Direction       |
 |-----------|------------------|-----------------|
+| `i8`      | `int8_t`         | arg + return    |
+| `i16`     | `int16_t`        | arg + return    |
 | `i32`     | `int32_t`        | arg + return    |
 | `i64`     | `int64_t`        | arg + return    |
+| `u8`      | `uint8_t`        | arg + return    |
+| `u16`     | `uint16_t`       | arg + return    |
+| `u32`     | `uint32_t`       | arg + return    |
+| `u64`     | `uint64_t`       | arg + return    |
+| `f32`     | `float`          | arg + return    |
 | `f64`     | `double`         | arg + return    |
 | `bool`    | `_Bool` (1 byte) | arg + return    |
 | `*T`      | `T*`             | arg + return    |

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -36,14 +36,14 @@ optimization-driven weakening.
 
 | Type  | Width | Signed | Status              |
 |-------|-------|--------|---------------------|
-| `i8`  | 8     | yes    | Deferred            |
-| `i16` | 16    | yes    | Deferred            |
+| `i8`  | 8     | yes    | Implemented         |
+| `i16` | 16    | yes    | Implemented         |
 | `i32` | 32    | yes    | Implemented         |
 | `i64` | 64    | yes    | Implemented         |
-| `u8`  | 8     | no     | Deferred            |
-| `u16` | 16    | no     | Deferred            |
-| `u32` | 32    | no     | Deferred            |
-| `u64` | 64    | no     | Deferred            |
+| `u8`  | 8     | no     | Implemented         |
+| `u16` | 16    | no     | Implemented         |
+| `u32` | 32    | no     | Implemented         |
+| `u64` | 64    | no     | Implemented         |
 
 All integer types are fixed-width, two's-complement for signed types,
 with no padding bits.
@@ -53,7 +53,7 @@ with no padding bits.
 | Type  | IEEE 754    | Status              |
 |-------|-------------|---------------------|
 | `f64` | binary64    | Implemented         |
-| `f32` | binary32    | Deferred            |
+| `f32` | binary32    | Implemented         |
 
 Both types are part of the language design. `f32` surface exposure is
 deferred until type surface, codegen, stdlib formatting/conversion,
@@ -393,10 +393,10 @@ The compiler and backend must:
 | `f64` IEEE 754 binary64          | Yes       | Partial           |
 | `f64` NaN/Inf/−0.0 semantics    | Yes       | Partial (codegen) |
 | `f64` comparison partial-order   | Yes       | Partial           |
-| `f32` IEEE 754 binary32          | Yes       | Deferred          |
+| `f32` IEEE 754 binary32          | Yes       | Implemented       |
 | `i64` arithmetic + overflow      | Yes       | Yes               |
-| Integer widths beyond i32/i64    | Yes       | Deferred          |
-| Unsigned integers                | Yes       | Deferred          |
+| Integer widths (i8, i16)         | Yes       | Implemented       |
+| Unsigned integers (u8–u64)       | Yes       | Implemented       |
 | Numeric conversions (i32↔i64↔f64)| Yes       | Partial           |
 | Float-to-int trapping (f64→i32)  | Yes       | Yes               |
 | Decimal types                    | Posture   | Deferred          |

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -55,9 +55,9 @@ with no padding bits.
 | `f64` | binary64    | Implemented         |
 | `f32` | binary32    | Implemented         |
 
-Both types are part of the language design. `f32` surface exposure is
-deferred until type surface, codegen, stdlib formatting/conversion,
-and GPU story are ready together.
+Both types are part of the language design and are implemented. `f32`
+shares the same IEEE 754 conformance obligations as `f64`. GPU-specific
+numeric profiles for `f32` are deferred to Phase 8.
 
 ### 3.3 Decimal types
 
@@ -245,7 +245,8 @@ Status: **Partially implemented** — `f64` → `i32` available via
 - `f64` → `f32`: explicit, rounds to nearest according to the
   default rounding rule
 
-Status: **Deferred** — `f32` not yet surfaced
+Status: **Specified** — `f32` is surfaced; explicit conversion
+functions are deferred to the conversion matrix PR
 
 ### 6.6 Mixed-type binary operators
 

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -66,13 +66,27 @@ Examples:
 | Hook                      | Signature (Dao surface)              |
 |---------------------------|--------------------------------------|
 | `__dao_io_write_stdout`   | `(msg: string): void`                |
+| `__dao_eq_i8`             | `(a: i8, b: i8): bool`              |
+| `__dao_eq_i16`            | `(a: i16, b: i16): bool`            |
 | `__dao_eq_i32`            | `(a: i32, b: i32): bool`            |
 | `__dao_eq_i64`            | `(a: i64, b: i64): bool`            |
+| `__dao_eq_u8`             | `(a: u8, b: u8): bool`              |
+| `__dao_eq_u16`            | `(a: u16, b: u16): bool`            |
+| `__dao_eq_u32`            | `(a: u32, b: u32): bool`            |
+| `__dao_eq_u64`            | `(a: u64, b: u64): bool`            |
+| `__dao_eq_f32`            | `(a: f32, b: f32): bool`            |
 | `__dao_eq_f64`            | `(a: f64, b: f64): bool`            |
 | `__dao_eq_bool`           | `(a: bool, b: bool): bool`          |
 | `__dao_eq_string`         | `(a: string, b: string): bool`      |
+| `__dao_conv_i8_to_string` | `(x: i8): string`                   |
+| `__dao_conv_i16_to_string`| `(x: i16): string`                   |
 | `__dao_conv_i32_to_string`| `(x: i32): string`                   |
 | `__dao_conv_i64_to_string`| `(x: i64): string`                   |
+| `__dao_conv_u8_to_string` | `(x: u8): string`                   |
+| `__dao_conv_u16_to_string`| `(x: u16): string`                   |
+| `__dao_conv_u32_to_string`| `(x: u32): string`                   |
+| `__dao_conv_u64_to_string`| `(x: u64): string`                   |
+| `__dao_conv_f32_to_string`| `(x: f32): string`                   |
 | `__dao_conv_f64_to_string`| `(x: f64): string`                   |
 | `__dao_conv_bool_to_string`| `(x: bool): string`                 |
 | `__dao_gen_alloc`         | `(size: i64, align: i64): *void`     |

--- a/runtime/core/convert.c
+++ b/runtime/core/convert.c
@@ -12,6 +12,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+struct dao_string __dao_conv_i8_to_string(int8_t x) {
+  static _Thread_local char buf[8];
+  int len = snprintf(buf, sizeof(buf), "%d", (int)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_i16_to_string(int16_t x) {
+  static _Thread_local char buf[8];
+  int len = snprintf(buf, sizeof(buf), "%d", (int)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
 struct dao_string __dao_conv_i32_to_string(int32_t x) {
   static _Thread_local char buf[32];
   int len = snprintf(buf, sizeof(buf), "%d", x);
@@ -21,6 +33,36 @@ struct dao_string __dao_conv_i32_to_string(int32_t x) {
 struct dao_string __dao_conv_i64_to_string(int64_t x) {
   static _Thread_local char buf[32];
   int len = snprintf(buf, sizeof(buf), "%lld", (long long)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_u8_to_string(uint8_t x) {
+  static _Thread_local char buf[8];
+  int len = snprintf(buf, sizeof(buf), "%u", (unsigned)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_u16_to_string(uint16_t x) {
+  static _Thread_local char buf[8];
+  int len = snprintf(buf, sizeof(buf), "%u", (unsigned)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_u32_to_string(uint32_t x) {
+  static _Thread_local char buf[16];
+  int len = snprintf(buf, sizeof(buf), "%u", x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_u64_to_string(uint64_t x) {
+  static _Thread_local char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%llu", (unsigned long long)x);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+struct dao_string __dao_conv_f32_to_string(float x) {
+  static _Thread_local char buf[64];
+  int len = snprintf(buf, sizeof(buf), "%g", (double)x);
   return (struct dao_string){.ptr = buf, .len = len};
 }
 

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -46,8 +46,15 @@ void __dao_io_write_stdout(const struct dao_string *msg);
 // Runtime hook declarations — Equality domain
 // ---------------------------------------------------------------------------
 
+bool __dao_eq_i8(int8_t a, int8_t b);
+bool __dao_eq_i16(int16_t a, int16_t b);
 bool __dao_eq_i32(int32_t a, int32_t b);
 bool __dao_eq_i64(int64_t a, int64_t b);
+bool __dao_eq_u8(uint8_t a, uint8_t b);
+bool __dao_eq_u16(uint16_t a, uint16_t b);
+bool __dao_eq_u32(uint32_t a, uint32_t b);
+bool __dao_eq_u64(uint64_t a, uint64_t b);
+bool __dao_eq_f32(float a, float b);
 bool __dao_eq_f64(double a, double b);
 bool __dao_eq_bool(bool a, bool b);
 bool __dao_eq_string(const struct dao_string *a, const struct dao_string *b);
@@ -61,8 +68,15 @@ bool __dao_eq_string(const struct dao_string *a, const struct dao_string *b);
 // valid until the next call to the same conversion hook on the same
 // thread. Callers must consume or copy the result before the next
 // conversion call.
+struct dao_string __dao_conv_i8_to_string(int8_t x);
+struct dao_string __dao_conv_i16_to_string(int16_t x);
 struct dao_string __dao_conv_i32_to_string(int32_t x);
 struct dao_string __dao_conv_i64_to_string(int64_t x);
+struct dao_string __dao_conv_u8_to_string(uint8_t x);
+struct dao_string __dao_conv_u16_to_string(uint16_t x);
+struct dao_string __dao_conv_u32_to_string(uint32_t x);
+struct dao_string __dao_conv_u64_to_string(uint64_t x);
+struct dao_string __dao_conv_f32_to_string(float x);
 struct dao_string __dao_conv_f64_to_string(double x);
 struct dao_string __dao_conv_bool_to_string(bool x);
 

--- a/runtime/core/equality.c
+++ b/runtime/core/equality.c
@@ -1,16 +1,23 @@
 // equality.c — Dao runtime equality hooks.
 //
-// Implements: __dao_eq_i32, __dao_eq_i64, __dao_eq_f64, __dao_eq_bool, __dao_eq_string
+// Implements: __dao_eq_* for all numeric types, bool, and string
 // Authority:  docs/contracts/CONTRACT_RUNTIME_ABI.md
 
 #include "dao_abi.h"
 
 #include <string.h>
 
+bool __dao_eq_i8(int8_t a, int8_t b)   { return a == b; }
+bool __dao_eq_i16(int16_t a, int16_t b) { return a == b; }
 bool __dao_eq_i32(int32_t a, int32_t b) { return a == b; }
-
 bool __dao_eq_i64(int64_t a, int64_t b) { return a == b; }
 
+bool __dao_eq_u8(uint8_t a, uint8_t b)   { return a == b; }
+bool __dao_eq_u16(uint16_t a, uint16_t b) { return a == b; }
+bool __dao_eq_u32(uint32_t a, uint32_t b) { return a == b; }
+bool __dao_eq_u64(uint64_t a, uint64_t b) { return a == b; }
+
+bool __dao_eq_f32(float a, float b) { return a == b; }
 bool __dao_eq_f64(double a, double b) { return a == b; }
 
 bool __dao_eq_bool(bool a, bool b) { return a == b; }

--- a/stdlib/core/equatable.dao
+++ b/stdlib/core/equatable.dao
@@ -1,5 +1,12 @@
+extern fn __dao_eq_i8(a: i8, b: i8): bool
+extern fn __dao_eq_i16(a: i16, b: i16): bool
 extern fn __dao_eq_i32(a: i32, b: i32): bool
 extern fn __dao_eq_i64(a: i64, b: i64): bool
+extern fn __dao_eq_u8(a: u8, b: u8): bool
+extern fn __dao_eq_u16(a: u16, b: u16): bool
+extern fn __dao_eq_u32(a: u32, b: u32): bool
+extern fn __dao_eq_u64(a: u64, b: u64): bool
+extern fn __dao_eq_f32(a: f32, b: f32): bool
 extern fn __dao_eq_f64(a: f64, b: f64): bool
 extern fn __dao_eq_bool(a: bool, b: bool): bool
 extern fn __dao_eq_string(a: string, b: string): bool
@@ -7,11 +14,32 @@ extern fn __dao_eq_string(a: string, b: string): bool
 derived concept Equatable:
     fn eq(self, other: Equatable): bool
 
+extend i8 as Equatable:
+    fn eq(self, other: i8): bool -> __dao_eq_i8(self, other)
+
+extend i16 as Equatable:
+    fn eq(self, other: i16): bool -> __dao_eq_i16(self, other)
+
 extend i32 as Equatable:
     fn eq(self, other: i32): bool -> __dao_eq_i32(self, other)
 
 extend i64 as Equatable:
     fn eq(self, other: i64): bool -> __dao_eq_i64(self, other)
+
+extend u8 as Equatable:
+    fn eq(self, other: u8): bool -> __dao_eq_u8(self, other)
+
+extend u16 as Equatable:
+    fn eq(self, other: u16): bool -> __dao_eq_u16(self, other)
+
+extend u32 as Equatable:
+    fn eq(self, other: u32): bool -> __dao_eq_u32(self, other)
+
+extend u64 as Equatable:
+    fn eq(self, other: u64): bool -> __dao_eq_u64(self, other)
+
+extend f32 as Equatable:
+    fn eq(self, other: f32): bool -> __dao_eq_f32(self, other)
 
 extend f64 as Equatable:
     fn eq(self, other: f64): bool -> __dao_eq_f64(self, other)

--- a/stdlib/core/printable.dao
+++ b/stdlib/core/printable.dao
@@ -1,5 +1,12 @@
+extern fn __dao_conv_i8_to_string(x: i8): string
+extern fn __dao_conv_i16_to_string(x: i16): string
 extern fn __dao_conv_i32_to_string(x: i32): string
 extern fn __dao_conv_i64_to_string(x: i64): string
+extern fn __dao_conv_u8_to_string(x: u8): string
+extern fn __dao_conv_u16_to_string(x: u16): string
+extern fn __dao_conv_u32_to_string(x: u32): string
+extern fn __dao_conv_u64_to_string(x: u64): string
+extern fn __dao_conv_f32_to_string(x: f32): string
 extern fn __dao_conv_f64_to_string(x: f64): string
 extern fn __dao_conv_bool_to_string(x: bool): string
 extern fn __dao_io_write_stdout(msg: string): void
@@ -7,11 +14,32 @@ extern fn __dao_io_write_stdout(msg: string): void
 derived concept Printable:
     fn to_string(self): string
 
+extend i8 as Printable:
+    fn to_string(self): string -> __dao_conv_i8_to_string(self)
+
+extend i16 as Printable:
+    fn to_string(self): string -> __dao_conv_i16_to_string(self)
+
 extend i32 as Printable:
     fn to_string(self): string -> __dao_conv_i32_to_string(self)
 
 extend i64 as Printable:
     fn to_string(self): string -> __dao_conv_i64_to_string(self)
+
+extend u8 as Printable:
+    fn to_string(self): string -> __dao_conv_u8_to_string(self)
+
+extend u16 as Printable:
+    fn to_string(self): string -> __dao_conv_u16_to_string(self)
+
+extend u32 as Printable:
+    fn to_string(self): string -> __dao_conv_u32_to_string(self)
+
+extend u64 as Printable:
+    fn to_string(self): string -> __dao_conv_u64_to_string(self)
+
+extend f32 as Printable:
+    fn to_string(self): string -> __dao_conv_f32_to_string(self)
 
 extend f64 as Printable:
     fn to_string(self): string -> __dao_conv_f64_to_string(self)

--- a/testdata/ast/stdlib_core_equatable.ast
+++ b/testdata/ast/stdlib_core_equatable.ast
@@ -1,4 +1,12 @@
 File
+  ExternFunctionDecl __dao_eq_i8
+    Param a: i8
+    Param b: i8
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_i16
+    Param a: i16
+    Param b: i16
+    ReturnType: bool
   ExternFunctionDecl __dao_eq_i32
     Param a: i32
     Param b: i32
@@ -6,6 +14,26 @@ File
   ExternFunctionDecl __dao_eq_i64
     Param a: i64
     Param b: i64
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_u8
+    Param a: u8
+    Param b: u8
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_u16
+    Param a: u16
+    Param b: u16
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_u32
+    Param a: u32
+    Param b: u32
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_u64
+    Param a: u64
+    Param b: u64
+    ReturnType: bool
+  ExternFunctionDecl __dao_eq_f32
+    Param a: f32
+    Param b: f32
     ReturnType: bool
   ExternFunctionDecl __dao_eq_f64
     Param a: f64
@@ -24,6 +52,30 @@ File
       Param self
       Param other: Equatable
       ReturnType: bool
+  ExtendDecl i8 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: i8
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_i8
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl i16 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: i16
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_i16
+          Args
+            Identifier self
+            Identifier other
   ExtendDecl i32 as Equatable
     FunctionDecl eq
       Param self
@@ -45,6 +97,66 @@ File
         CallExpr
           Callee
             Identifier __dao_eq_i64
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl u8 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: u8
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_u8
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl u16 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: u16
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_u16
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl u32 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: u32
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_u32
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl u64 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: u64
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_u64
+          Args
+            Identifier self
+            Identifier other
+  ExtendDecl f32 as Equatable
+    FunctionDecl eq
+      Param self
+      Param other: f32
+      ReturnType: bool
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_eq_f32
           Args
             Identifier self
             Identifier other

--- a/testdata/ast/stdlib_core_printable.ast
+++ b/testdata/ast/stdlib_core_printable.ast
@@ -1,9 +1,30 @@
 File
+  ExternFunctionDecl __dao_conv_i8_to_string
+    Param x: i8
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_i16_to_string
+    Param x: i16
+    ReturnType: string
   ExternFunctionDecl __dao_conv_i32_to_string
     Param x: i32
     ReturnType: string
   ExternFunctionDecl __dao_conv_i64_to_string
     Param x: i64
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_u8_to_string
+    Param x: u8
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_u16_to_string
+    Param x: u16
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_u32_to_string
+    Param x: u32
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_u64_to_string
+    Param x: u64
+    ReturnType: string
+  ExternFunctionDecl __dao_conv_f32_to_string
+    Param x: f32
     ReturnType: string
   ExternFunctionDecl __dao_conv_f64_to_string
     Param x: f64
@@ -18,6 +39,26 @@ File
     FunctionDecl to_string
       Param self
       ReturnType: string
+  ExtendDecl i8 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_i8_to_string
+          Args
+            Identifier self
+  ExtendDecl i16 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_i16_to_string
+          Args
+            Identifier self
   ExtendDecl i32 as Printable
     FunctionDecl to_string
       Param self
@@ -36,6 +77,56 @@ File
         CallExpr
           Callee
             Identifier __dao_conv_i64_to_string
+          Args
+            Identifier self
+  ExtendDecl u8 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_u8_to_string
+          Args
+            Identifier self
+  ExtendDecl u16 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_u16_to_string
+          Args
+            Identifier self
+  ExtendDecl u32 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_u32_to_string
+          Args
+            Identifier self
+  ExtendDecl u64 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_u64_to_string
+          Args
+            Identifier self
+  ExtendDecl f32 as Printable
+    FunctionDecl to_string
+      Param self
+      ReturnType: string
+      ExprBody
+        CallExpr
+          Callee
+            Identifier __dao_conv_f32_to_string
           Args
             Identifier self
   ExtendDecl f64 as Printable


### PR DESCRIPTION
## Summary

Surface i8, i16, u8–u64, and f32 as fully usable types with equality and printing support. The compiler frontend (types, type checker, parser) and LLVM backend already handle all these types with correct signed/unsigned semantics — this PR fills the runtime hooks and stdlib gap that prevented end-to-end use.

## Highlights

- **14 new runtime hooks**: 7 equality (`__dao_eq_{i8,i16,u8,u16,u32,u64,f32}`) + 7 to_string (`__dao_conv_*_to_string`) with C implementations
- **LLVM backend**: All new hook declarations and name constants wired into `declare_all()`
- **Stdlib Equatable**: Extended for all 10 numeric types (was 3) + bool + string
- **Stdlib Printable**: Extended for all 10 numeric types (was 3) + bool + string + generic `print<T: Printable>`
- **Contract updates**: `CONTRACT_NUMERIC_SEMANTICS.md` type tables mark i8, i16, u8–u64, f32 as Implemented; `CONTRACT_RUNTIME_ABI.md` lists all new hooks
- **Golden files**: Regenerated for equatable.dao and printable.dao

This is PR 1/3 for Tier C. Remaining:
- PR 2: Numeric conversion matrix (widening/narrowing between all types)
- PR 3: Numeric/Comparable concept + overflow operations for narrow types

## Test plan

- [x] All 11 test suites pass (including regenerated golden AST files)
- [x] Full build succeeds
- [ ] Manual: `let x: u32 = 42` followed by `print(x)` should work end-to-end
- [ ] Manual: `let a: f32 = 3.14` should compile and print correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)