### PR TITLE
feat(interop): ✨ add function pointer type syntax and callback ABI — Phase 6 v2

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -497,6 +497,16 @@ private:
       visit_type(*ptr.pointee);
       break;
     }
+    case NodeKind::FunctionType: {
+      const auto& ftn = type.as<FunctionTypeNode>();
+      // Classify 'fn' keyword in the function type.
+      classify(Span{.offset = type.span.offset, .length = 2}, "keyword.fn");
+      for (const auto* param_type : ftn.param_types) {
+        visit_type(*param_type);
+      }
+      visit_type(*ftn.return_type);
+      break;
+    }
     default:
       break;
     }

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -133,6 +133,12 @@ void LlvmBackend::declare_functions(const MirModule& mir_module,
       if (LlvmTypeLowering::is_string_type(local.type)) {
         lowered_param = llvm::PointerType::getUnqual(lowered_param);
       }
+      // Function type params: lower to opaque ptr (C function pointer).
+      // llvm::FunctionType is not a first-class type — pointers to
+      // functions are represented as opaque ptr in LLVM IR.
+      if (llvm::isa<llvm::FunctionType>(lowered_param)) {
+        lowered_param = llvm::PointerType::getUnqual(lowered_param);
+      }
       // For extern fn: struct params need ABI coercion at the C boundary.
       if (mir_fn->is_extern && llvm::isa<llvm::StructType>(lowered_param) &&
           !LlvmTypeLowering::is_string_type(local.type)) {
@@ -152,6 +158,11 @@ void LlvmBackend::declare_functions(const MirModule& mir_module,
       } else {
         param_types.push_back(lowered_param);
       }
+    }
+
+    // Function type return: lower to opaque ptr.
+    if (llvm::isa<llvm::FunctionType>(ret_type)) {
+      ret_type = llvm::PointerType::getUnqual(ret_type);
     }
 
     // For extern fn: struct returns also need ABI coercion.

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -507,6 +507,19 @@ suite<"externs"> externs = [] {
     // { { f64 }, i32 } = 16 bytes: EB0=SSE(double), EB1=INTEGER(i32).
     expect(contains(ir, "declare i32 @get_tag(double, i32)")) << ir;
   };
+
+  // Function pointer params lower to ptr.
+  "extern fn with callback param lowers to ptr"_test = [] {
+    LlvmTestPipeline pipe(
+        "extern fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n"
+        "\n"
+        "fn main(): i32\n"
+        "  return 0\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    // Function pointer param → ptr in LLVM IR.
+    expect(contains(ir, "declare i32 @apply(ptr, i32, i32)")) << ir;
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -57,6 +57,7 @@ auto TypeNode::kind() const -> NodeKind {
   return std::visit(overloaded{
       [](const NamedType&) { return NodeKind::NamedType; },
       [](const PointerType&) { return NodeKind::PointerType; },
+      [](const FunctionTypeNode&) { return NodeKind::FunctionType; },
   }, payload);
 }
 
@@ -135,6 +136,8 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "NamedType";
   case NodeKind::PointerType:
     return "PointerType";
+  case NodeKind::FunctionType:
+    return "FunctionType";
   case NodeKind::ErrorExpr:
     return "ErrorExpr";
   case NodeKind::ErrorStmt:

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -85,6 +85,7 @@ enum class NodeKind : std::uint8_t {
   // Types
   NamedType,
   PointerType,
+  FunctionType,
 
   // Error recovery placeholders
   ErrorExpr,
@@ -396,7 +397,12 @@ struct PointerType {
   TypeNode* pointee;
 };
 
-using TypeNodePayload = std::variant<NamedType, PointerType>;
+struct FunctionTypeNode {
+  std::vector<TypeNode*> param_types;
+  TypeNode* return_type;
+};
+
+using TypeNodePayload = std::variant<NamedType, PointerType, FunctionTypeNode>;
 
 // ---------------------------------------------------------------------------
 // Container nodes — arena-allocated.

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -522,6 +522,17 @@ private:
           out_ << "*";
           print_type_inline(*ptr.pointee);
         },
+        [&](const FunctionTypeNode& ftn) {
+          out_ << "fn(";
+          for (size_t i = 0; i < ftn.param_types.size(); ++i) {
+            if (i > 0) {
+              out_ << ", ";
+            }
+            print_type_inline(*ftn.param_types[i]);
+          }
+          out_ << "): ";
+          print_type_inline(*ftn.return_type);
+        },
     }, type.payload);
   }
 

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1203,6 +1203,28 @@ private:
       return ctx_.alloc<TypeNode>(span, PointerType{pointee});
     }
 
+    // Function type: fn(T, U, ...): R
+    if (peek_kind() == TokenKind::KwFn) {
+      const auto& fn_tok = advance(); // consume 'fn'
+      consume(TokenKind::LParen);
+      std::vector<TypeNode*> param_types;
+      if (peek_kind() != TokenKind::RParen) {
+        param_types.push_back(parse_type());
+        while (peek_kind() == TokenKind::Comma) {
+          advance(); // consume ','
+          param_types.push_back(parse_type());
+        }
+      }
+      consume(TokenKind::RParen);
+      consume(TokenKind::Colon);
+      auto* return_type = parse_type();
+      Span span = {.offset = fn_tok.span.offset,
+                   .length = (return_type->span.offset + return_type->span.length) -
+                             fn_tok.span.offset};
+      return ctx_.alloc<TypeNode>(
+          span, FunctionTypeNode{std::move(param_types), return_type});
+    }
+
     return parse_named_type();
   }
 

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -400,6 +400,17 @@ private:
       if (node->is<PointerType>()) {
         return "*" + self(node->as<PointerType>().pointee, self);
       }
+      if (node->is<FunctionTypeNode>()) {
+        const auto& ftn = node->as<FunctionTypeNode>();
+        std::string result = "fn(";
+        for (size_t pidx = 0; pidx < ftn.param_types.size(); ++pidx) {
+          if (pidx > 0) { result += ", "; }
+          result += self(ftn.param_types[pidx], self);
+        }
+        result += "): ";
+        result += self(ftn.return_type, self);
+        return result;
+      }
       return {};
     };
     auto target_name = format_type_node(ext.target_type, format_type_node);
@@ -715,6 +726,14 @@ private:
     case NodeKind::PointerType: {
       const auto& ptr = type.as<PointerType>();
       resolve_type(*ptr.pointee, scope);
+      break;
+    }
+    case NodeKind::FunctionType: {
+      const auto& ftn = type.as<FunctionTypeNode>();
+      for (const auto* param_type : ftn.param_types) {
+        resolve_type(*param_type, scope);
+      }
+      resolve_type(*ftn.return_type, scope);
       break;
     }
     default:

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -675,6 +675,28 @@ void TypeChecker::check_function(const Decl* decl) {
     }
   }
 
+  // Reject function types in non-extern fn signatures. Indirect calls
+  // through function-typed values are not yet implemented; function
+  // types are currently only valid at the extern fn ABI boundary.
+  if (!fn.is_extern) {
+    for (const auto& param : fn.params) {
+      if (param.type != nullptr) {
+        const auto* param_type = resolve_type_node(param.type);
+        if (param_type != nullptr &&
+            param_type->kind() == TypeKind::Function) {
+          error(param.type->span,
+                "function type parameters are only supported in extern fn "
+                "declarations (indirect calls not yet implemented)");
+        }
+      }
+    }
+    if (ret_type != nullptr && ret_type->kind() == TypeKind::Function) {
+      error(fn.return_type->span,
+            "function type returns are only supported in extern fn "
+            "declarations (indirect calls not yet implemented)");
+    }
+  }
+
   // Set up param types in symbol cache.
   for (const auto& param : fn.params) {
     auto decl_it = decl_symbols_.find(param.name_span.offset);

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1440,11 +1440,37 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
     return nullptr;
   }
 
+  // Detect if the callee is an extern fn (for ABI boundary enforcement).
+  bool callee_is_extern = false;
+  if (call.callee->is<IdentifierExpr>()) {
+    auto sym_it = resolve_.uses.find(call.callee->span.offset);
+    if (sym_it != resolve_.uses.end() &&
+        sym_it->second->kind == SymbolKind::Function &&
+        sym_it->second->decl != nullptr) {
+      const auto* fn_decl = sym_it->second->decl_as_decl();
+      if (fn_decl->is<FunctionDecl>()) {
+        callee_is_extern = fn_decl->as<FunctionDecl>().is_extern;
+      }
+    }
+  }
+
   // Check arguments and infer generic type bindings from call site.
   // type_bindings maps generic param index → concrete type.
   std::unordered_map<uint32_t, const Type*> type_bindings;
 
   for (size_t i = 0; i < params.size(); ++i) {
+    // Reject lambdas in function-pointer positions of extern fn calls.
+    // Lambdas cannot cross the C ABI boundary as closures have no
+    // context pointer in a C function pointer representation.
+    // (CONTRACT_C_ABI_INTEROP §4.4.5)
+    if (callee_is_extern && params[i] != nullptr &&
+        params[i]->kind() == TypeKind::Function &&
+        call.args[i]->is<LambdaExpr>()) {
+      error(call.args[i]->span,
+            "lambda cannot be passed as a C function pointer; "
+            "use a named function instead");
+    }
+
     const auto* arg_type = check_expr(call.args[i], params[i]);
     if (arg_type == nullptr || params[i] == nullptr) {
       continue;

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -132,6 +132,24 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
     return types_.pointer_to(pointee);
   }
 
+  case NodeKind::FunctionType: {
+    const auto& ftn = node->as<FunctionTypeNode>();
+    std::vector<const Type*> param_types;
+    param_types.reserve(ftn.param_types.size());
+    for (const auto* pt : ftn.param_types) {
+      const auto* resolved = resolve_type_node(pt);
+      if (resolved == nullptr) {
+        return nullptr;
+      }
+      param_types.push_back(resolved);
+    }
+    const auto* ret_type = resolve_type_node(ftn.return_type);
+    if (ret_type == nullptr) {
+      return nullptr;
+    }
+    return types_.function_type(std::move(param_types), ret_type);
+  }
+
   default:
     error(node->span, "unsupported type syntax");
     return nullptr;

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -172,8 +172,23 @@ auto is_c_abi_compatible_impl(const Type* type,
     visiting.erase(st->decl_id());
     return true;
   }
+  case TypeKind::Function: {
+    // Function pointer type: all param and return types must be
+    // C-ABI-compatible (CONTRACT_C_ABI_INTEROP §4.4.2).
+    const auto* fn_type = static_cast<const TypeFunction*>(type);
+    for (const auto* param : fn_type->param_types()) {
+      if (!is_c_abi_compatible_impl(param, visiting)) {
+        return false;
+      }
+    }
+    if (fn_type->return_type() != nullptr &&
+        fn_type->return_type()->kind() != TypeKind::Void) {
+      return is_c_abi_compatible_impl(fn_type->return_type(), visiting);
+    }
+    return true;
+  }
   default:
-    return false; // string, function, generator, named, enum, generic
+    return false; // string, generator, named, enum, generic
   }
 }
 

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -518,6 +518,22 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(has_error_containing(result, "not supported at the C ABI"));
   };
 
+  "function type param in non-extern fn is rejected"_test = [] {
+    auto result = check_source(
+        "fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n"
+        "  return cb(a, b)\n");
+    expect(has_error_containing(result,
+        "function type parameters are only supported in extern fn"));
+  };
+
+  "function type return in non-extern fn is rejected"_test = [] {
+    auto result = check_source(
+        "fn get_op(): fn(i32, i32): i32\n"
+        "  return get_op()\n");
+    expect(has_error_containing(result,
+        "function type returns are only supported in extern fn"));
+  };
+
   "lambda passed to extern fn callback is rejected"_test = [] {
     auto result = check_source(
         "extern fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n"

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -518,6 +518,16 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(has_error_containing(result, "not supported at the C ABI"));
   };
 
+  "lambda passed to extern fn callback is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n"
+        "\n"
+        "fn main(): i32\n"
+        "  return apply(|x, y| -> x + y, 1, 2)\n");
+    expect(has_error_containing(result,
+        "lambda cannot be passed as a C function pointer"));
+  };
+
   "extern fn with scalar types is accepted"_test = [] {
     auto result = check_source(
         "extern fn good(a: i32, b: i64, c: f64): i32\n");

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -492,6 +492,32 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(has_error_containing(result, "not supported at the C ABI"));
   };
 
+  // --- Function pointer types at the ABI boundary (§4.4) ---
+
+  "extern fn with function pointer param is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n");
+    expect(is_ok(result)) << "function pointer param should be accepted";
+  };
+
+  "extern fn with function pointer return is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn get_op(): fn(i32, i32): i32\n");
+    expect(is_ok(result)) << "function pointer return should be accepted";
+  };
+
+  "extern fn with void callback is accepted"_test = [] {
+    auto result = check_source(
+        "extern fn register_cb(cb: fn(i32): void): void\n");
+    expect(is_ok(result)) << "void callback should be accepted";
+  };
+
+  "extern fn with string-param callback is rejected"_test = [] {
+    auto result = check_source(
+        "extern fn bad(cb: fn(string): void): void\n");
+    expect(has_error_containing(result, "not supported at the C ABI"));
+  };
+
   "extern fn with scalar types is accepted"_test = [] {
     auto result = check_source(
         "extern fn good(a: i32, b: i64, c: f64): i32\n");

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -119,14 +119,60 @@ compatible predicate recursively. A struct containing another struct
 is valid at the boundary if and only if the inner struct is also
 repr-C-compatible.
 
-### 4.4 Types explicitly not supported
+### 4.4 Function pointer types at the boundary
+
+Dao function types may appear as parameters and return values in
+`extern fn` declarations, representing C function pointers.
+
+#### 4.4.1 Syntax
+
+Function types are written as `fn(T, U, ...): R` in type positions,
+mirroring function declaration syntax. Parameter names are omitted —
+only types are listed.
+
+#### 4.4.2 ABI-compatible function type predicate
+
+A Dao function type is C-ABI-compatible if and only if:
+
+1. every parameter type is itself C-ABI-compatible (scalar, pointer,
+   repr-C-compatible struct, or recursively ABI-compatible function
+   type)
+2. the return type is C-ABI-compatible or void
+
+The compiler must reject extern fn signatures that use function types
+failing this predicate with a clear diagnostic.
+
+#### 4.4.3 Representation
+
+Function types at the C ABI boundary are lowered to opaque pointers
+(`ptr` in LLVM IR). This matches the C calling convention where
+function pointer parameters are pointer-sized values.
+
+#### 4.4.4 Passing functions as callbacks
+
+A named Dao function may be passed as an argument where a function
+type is expected in an extern fn call. The compiler emits the
+function's address as the argument value.
+
+#### 4.4.5 Restrictions
+
+- **No closures**: only non-capturing function references may be
+  passed across the C ABI boundary. Capturing lambdas cannot be
+  represented as C function pointers.
+- **No indirect calls from Dao**: calling through a function-typed
+  value received from C is not yet supported. The initial
+  implementation covers outbound callbacks only (Dao → C → Dao).
+- **Calling convention**: function pointers follow the platform C
+  calling convention. No other conventions are supported.
+
+### 4.5 Types explicitly not supported
 
 - Dao `string` as C `char*` (requires explicit conversion)
-- function pointers / callbacks
 - variadic functions (`printf`-style)
 - C enums
 - C unions
 - arrays / slices by value
+- capturing lambdas / closures at the C boundary
 
 If a user-declared `extern fn` uses an unsupported type, the compiler
 must reject it with a clear diagnostic during type checking or
@@ -139,13 +185,14 @@ conventions specified in `CONTRACT_RUNTIME_ABI.md`. The `__` prefix
 aligns with C's reserved identifier convention; user code should not
 declare `__`-prefixed names.
 
-### 4.5 Future type expansions
+### 4.6 Future type expansions
 
 The following may be added in later versions:
 
 - `c_string` or explicit null-terminated byte string type
-- function pointer types for callbacks
 - packed structs / explicit alignment control
+- indirect calls through function-typed values (C → Dao callbacks
+  returning function pointers)
 
 Each expansion requires updating this contract before implementation.
 
@@ -245,3 +292,8 @@ Each expansion requires updating this contract before implementation.
 | Unsupported type rejection       | Implemented     |
 | E2E foreign call example         | Implemented     |
 | E2E struct-by-value example      | Implemented     |
+| Function pointer type syntax     | Implemented     |
+| Function pointer params          | Implemented     |
+| Function pointer returns         | Implemented     |
+| Named function as callback       | Implemented     |
+| E2E callback example             | Implemented     |

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -156,12 +156,17 @@ function's address as the argument value.
 
 #### 4.4.5 Restrictions
 
-- **No closures**: only non-capturing function references may be
-  passed across the C ABI boundary. Capturing lambdas cannot be
-  represented as C function pointers.
+- **No closures**: only named function references may be passed as
+  function-pointer arguments to extern fn calls. Lambda expressions
+  in function-pointer argument positions of extern fn calls must be
+  rejected by the type checker with a clear diagnostic. Closures
+  cannot be represented as C function pointers.
 - **No indirect calls from Dao**: calling through a function-typed
   value received from C is not yet supported. The initial
   implementation covers outbound callbacks only (Dao → C → Dao).
+  Function pointer return types are accepted syntactically (e.g.
+  for passing opaque values back to C) but invoking them produces
+  a backend error.
 - **Calling convention**: function pointers follow the platform C
   calling convention. No other conventions are supported.
 
@@ -294,6 +299,8 @@ Each expansion requires updating this contract before implementation.
 | E2E struct-by-value example      | Implemented     |
 | Function pointer type syntax     | Implemented     |
 | Function pointer params          | Implemented     |
-| Function pointer returns         | Implemented     |
+| Function pointer return type     | Accepted        |
+| Indirect call through fn ptr     | Not implemented |
 | Named function as callback       | Implemented     |
+| Lambda rejection at ABI boundary | Implemented     |
 | E2E callback example             | Implemented     |

--- a/examples/ffi/callback_helper.c
+++ b/examples/ffi/callback_helper.c
@@ -1,0 +1,41 @@
+// callback_helper.c — C-side helpers for function pointer ABI E2E tests.
+//
+// These functions accept Dao function pointers as callbacks and call
+// them, verifying that the callback ABI matches between Dao and C.
+//
+// Authority: docs/contracts/CONTRACT_C_ABI_INTEROP.md §4.4
+
+#include <stdint.h>
+
+// Accept a binary operation callback and apply it.
+int32_t apply_op(int32_t (*op)(int32_t, int32_t), int32_t a, int32_t b) {
+  return op(a, b);
+}
+
+// Accept a predicate callback and count how many elements pass.
+int32_t count_if(const int32_t* arr, int32_t len,
+                 int32_t (*pred)(int32_t)) {
+  int32_t count = 0;
+  for (int32_t i = 0; i < len; i++) {
+    if (pred(arr[i])) {
+      count++;
+    }
+  }
+  return count;
+}
+
+// Accept a void callback and call it with a value.
+static int32_t last_seen = 0;
+
+void call_with(void (*cb)(int32_t), int32_t val) {
+  cb(val);
+}
+
+int32_t get_last_seen(void) {
+  return last_seen;
+}
+
+// Accept a callback that returns a double.
+double transform(double (*fn)(double), double x) {
+  return fn(x);
+}

--- a/examples/ffi/ffi_callback.dao
+++ b/examples/ffi/ffi_callback.dao
@@ -1,0 +1,23 @@
+extern fn apply_op(op: fn(i32, i32): i32, a: i32, b: i32): i32
+extern fn transform(f: fn(f64): f64, x: f64): f64
+
+fn add(a: i32, b: i32): i32
+  return a + b
+
+fn mul(a: i32, b: i32): i32
+  return a * b
+
+fn double_it(x: f64): f64
+  return x + x
+
+fn main(): i32
+  print("--- callback: add(3, 4) ---")
+  print(apply_op(add, 3, 4))
+
+  print("--- callback: mul(5, 6) ---")
+  print(apply_op(mul, 5, 6))
+
+  print("--- callback: double_it(3.14) ---")
+  print(transform(double_it, 3.14))
+
+  return 0

--- a/spec/grammar/dao.ebnf
+++ b/spec/grammar/dao.ebnf
@@ -182,10 +182,14 @@ literal :=
 
 type :=
       pointer_type
+    | function_type
     | named_type
 
 pointer_type :=
     "*" type
+
+function_type :=
+    "fn" "(" type_list? ")" ":" type
 
 named_type :=
     qualified_name ("[" type_list "]")?


### PR DESCRIPTION
## Summary

Add function pointer types at the C ABI boundary, enabling named Dao functions to be passed as callbacks to C libraries. This completes the callback arm of Phase 6 v2 interop.

## Highlights

- **Grammar**: new `fn(T, U, ...): R` type production for function pointer types
- **Full frontend pipeline**: parser → AST `FunctionTypeNode` → resolver → type checker → `TypeFunction` at extern fn boundary
- **ABI-compatible predicate**: function types accepted at the boundary only if all param/return types are themselves C-ABI-compatible (scalars, pointers, structs, or recursively function types)
- **Backend**: function-type params/returns lower to `ptr` (opaque pointer) in extern fn declarations; named function references pass as `ptr @fn_name` — no special calling convention handling needed
- **Contract**: `CONTRACT_C_ABI_INTEROP.md` §4.4 — function pointer rules, repr, passing semantics, restrictions (no closures, no indirect calls from Dao)
- **Semantic tokens**: `fn` keyword in function types classified for syntax highlighting
- **E2E tests**: `apply_op(add, 3, 4)` → 7, `apply_op(mul, 5, 6)` → 30, `transform(double_it, 3.14)` → 6.28

## Architecture notes

In LLVM's opaque pointer world, function pointers are just `ptr`. Named function references (`llvm::Function*`) already have type `ptr`. So the backend change is minimal — detect `llvm::FunctionType` in the lowered type and wrap it in `PointerType::getUnqual()`. At call sites, no coercion is needed since function refs are already pointer-typed values.

The key restriction: **no closures at the C boundary**. C function pointers have no environment/context pointer, so only non-capturing function references can cross. Lambda codegen is a separate future task.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] 4 new typecheck tests: fn ptr param accepted, fn ptr return accepted, void callback accepted, string-param callback rejected
- [x] 1 new backend IR test: callback param lowers to `ptr`
- [x] E2E: `ffi_callback.dao` + `callback_helper.c` — 3 callback scenarios (integer binop, integer binop 2, f64 transform)
- [x] Verified IR: `declare i32 @apply_op(ptr, i32, i32)` with `call i32 @apply_op(ptr @add, i32 3, i32 4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)