### PR TITLE
feat(stdlib): ✨ add string == != + operators via concept dispatch and runtime hooks

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -739,7 +739,57 @@ auto LlvmBackend::lower_binary(const MirBinary& p, const MirInst& inst,
   auto lhs_type_it = state.value_types.find(p.lhs.id);
   const Type* operand_type = lhs_type_it != state.value_types.end() ? lhs_type_it->second : inst.type;
   bool is_unsigned_op = LlvmTypeLowering::is_unsigned(operand_type);
+  bool is_string_op = LlvmTypeLowering::is_string_type(operand_type);
   llvm::Value* result = nullptr;
+
+  // String operators: dispatch to runtime hooks.
+  if (is_string_op) {
+    auto* str_type = types_.string_type();
+    auto* str_ptr = llvm::PointerType::getUnqual(str_type);
+
+    if (p.op == BinaryOp::Add) {
+      // String concatenation: call __dao_str_concat(ptr, ptr) → dao.string
+      auto* concat_fn = module_->getFunction(
+          std::string(runtime_hooks::kStrConcat));
+      if (concat_fn == nullptr) {
+        emit_diagnostic(inst.span, "string concat hook not declared");
+        return false;
+      }
+      auto* lhs_tmp = state.builder->CreateAlloca(str_type, nullptr, "str.lhs");
+      auto* rhs_tmp = state.builder->CreateAlloca(str_type, nullptr, "str.rhs");
+      state.builder->CreateStore(lhs, lhs_tmp);
+      state.builder->CreateStore(rhs, rhs_tmp);
+      result = state.builder->CreateCall(
+          concat_fn->getFunctionType(), concat_fn, {lhs_tmp, rhs_tmp}, "concat");
+    } else if (p.op == BinaryOp::EqEq || p.op == BinaryOp::BangEq) {
+      // String equality: call __dao_eq_string(ptr, ptr) → i1
+      auto* eq_fn = module_->getFunction(
+          std::string(runtime_hooks::kEqString));
+      if (eq_fn == nullptr) {
+        emit_diagnostic(inst.span, "string equality hook not declared");
+        return false;
+      }
+      auto* lhs_tmp = state.builder->CreateAlloca(str_type, nullptr, "str.lhs");
+      auto* rhs_tmp = state.builder->CreateAlloca(str_type, nullptr, "str.rhs");
+      state.builder->CreateStore(lhs, lhs_tmp);
+      state.builder->CreateStore(rhs, rhs_tmp);
+      result = state.builder->CreateCall(
+          eq_fn->getFunctionType(), eq_fn, {lhs_tmp, rhs_tmp}, "str.eq");
+      if (p.op == BinaryOp::BangEq) {
+        result = state.builder->CreateNot(result, "str.ne");
+      }
+    } else {
+      emit_diagnostic(inst.span,
+                      "unsupported operator on string type");
+      return false;
+    }
+
+    if (result != nullptr) {
+      state.values[inst.result.id] = result;
+      state.value_types[inst.result.id] = inst.type;
+    }
+    return result != nullptr;
+  }
 
   switch (p.op) {
   case BinaryOp::Add:

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -296,6 +296,25 @@ suite<"arithmetic"> arithmetic = [] {
     expect(!pipe.has_errors()) << "no backend errors";
     expect(contains(ir, "fcmp olt")) << ir;
   };
+
+  // String operators dispatch to runtime hooks.
+  "string == calls __dao_eq_string"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn eq(a: string, b: string): bool\n"
+        "  return a == b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "call i1 @__dao_eq_string(")) << ir;
+  };
+
+  "string + calls __dao_str_concat"_test = [] {
+    LlvmTestPipeline pipe(
+        "fn cat(a: string, b: string): string\n"
+        "  return a + b\n");
+    auto ir = pipe.ir();
+    expect(!pipe.has_errors()) << "no backend errors";
+    expect(contains(ir, "call %dao.string @__dao_str_concat(")) << ir;
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1147,7 +1147,30 @@ auto TypeChecker::check_binary(const Expr* expr) -> const Type* {
 
   switch (bin.op) {
   // Arithmetic: same numeric type required.
-  case BinaryOp::Add:
+  case BinaryOp::Add: {
+    // String concatenation: string + string → string.
+    if (is_string(lhs)) {
+      if (!is_assignable(lhs, rhs)) {
+        error(expr->span,
+              "mismatched types in string concatenation: '" +
+                  print_type(lhs) + "' and '" + print_type(rhs) + "'");
+        return nullptr;
+      }
+      return lhs;
+    }
+    if (!is_numeric(lhs)) {
+      error(bin.left->span,
+            "'+' requires numeric or string type, got '" + print_type(lhs) + "'");
+      return nullptr;
+    }
+    if (!is_assignable(lhs, rhs)) {
+      error(expr->span,
+            "mismatched types in arithmetic: '" + print_type(lhs) +
+                "' and '" + print_type(rhs) + "'");
+      return nullptr;
+    }
+    return lhs;
+  }
   case BinaryOp::Sub:
   case BinaryOp::Mul:
   case BinaryOp::Div:

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -101,6 +101,13 @@ auto is_integer(const Type* type) -> bool {
   }
 }
 
+auto is_string(const Type* type) -> bool {
+  if (type == nullptr || type->kind() != TypeKind::Named) {
+    return false;
+  }
+  return static_cast<const TypeNamed*>(type)->name() == "string";
+}
+
 auto is_float(const Type* type) -> bool {
   if (type == nullptr || type->kind() != TypeKind::Builtin) {
     return false;

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -105,7 +105,12 @@ auto is_string(const Type* type) -> bool {
   if (type == nullptr || type->kind() != TypeKind::Named) {
     return false;
   }
-  return static_cast<const TypeNamed*>(type)->name() == "string";
+  const auto* named = static_cast<const TypeNamed*>(type);
+  // The predeclared string type has name "string" AND null decl_id,
+  // distinguishing it from any user-defined nominal type named "string".
+  // This must match the backend's authoritative predicate in
+  // LlvmTypeLowering::is_string_type().
+  return named->name() == "string" && named->decl_id() == nullptr;
 }
 
 auto is_float(const Type* type) -> bool {

--- a/compiler/frontend/typecheck/type_conversion.h
+++ b/compiler/frontend/typecheck/type_conversion.h
@@ -26,6 +26,9 @@ auto is_integer(const Type* type) -> bool;
 /// Returns true if the type is a float builtin.
 auto is_float(const Type* type) -> bool;
 
+/// Returns true if the type is the predeclared string type.
+auto is_string(const Type* type) -> bool;
+
 /// Returns true if the type is compatible with the C ABI boundary.
 /// Supported: builtin scalars (i32, i64, f64, bool, etc.), pointers,
 /// and repr-C-compatible structs (non-empty, all fields recursively

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -241,6 +241,31 @@ suite<"typecheck_arithmetic"> typecheck_arithmetic = [] {
     auto result = check_source("fn both(a: bool, b: bool): bool -> a and b\n");
     expect(is_ok(result));
   };
+
+  // String operators
+  "string concatenation with +"_test = [] {
+    auto result = check_source(
+        "fn cat(a: string, b: string): string -> a + b\n");
+    expect(is_ok(result));
+  };
+
+  "string equality with =="_test = [] {
+    auto result = check_source(
+        "fn eq(a: string, b: string): bool -> a == b\n");
+    expect(is_ok(result));
+  };
+
+  "string inequality with !="_test = [] {
+    auto result = check_source(
+        "fn ne(a: string, b: string): bool -> a != b\n");
+    expect(is_ok(result));
+  };
+
+  "string - is rejected"_test = [] {
+    auto result = check_source(
+        "fn bad(a: string, b: string): string -> a - b\n");
+    expect(has_error_containing(result, "arithmetic requires numeric type"));
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
+++ b/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
@@ -234,7 +234,58 @@ Specifically:
 - semantic types belong in `compiler/frontend/types/`
 - type checking belongs in `compiler/frontend/typecheck/`
 
-## 13. Non-goals of this contract
+## 13. Operator semantics
+
+### 13.1 Equality operators (`==`, `!=`)
+
+The equality operators have two dispatch paths:
+
+1. **Builtin scalars** (all integer types, float types, bool): the
+   compiler emits intrinsic comparison instructions directly (LLVM
+   `icmp`/`fcmp`). This is the fast path with no function call
+   overhead.
+2. **Non-builtin types**: the compiler dispatches through the
+   `Equatable` concept's runtime equality hook for the operand type.
+   Currently this covers `string` (via `__dao_eq_string`). When
+   struct equality is implemented, the same path will apply to any
+   type conforming to `Equatable`.
+
+`!=` is derived from `==` via logical negation. There is no separate
+not-equal hook or concept method.
+
+Both operands must have the same type. The result type is always
+`bool`.
+
+### 13.2 Arithmetic operators (`+`, `-`, `*`, `/`, `%`)
+
+Arithmetic operators require numeric operands with the following
+exception:
+
+- **`+` on strings**: `string + string` dispatches to the runtime
+  string concatenation hook (`__dao_str_concat`) and returns
+  `string`. This is a special case, not a general operator
+  overloading mechanism.
+
+All other arithmetic operators (`-`, `*`, `/`, `%`) reject non-numeric
+operands with a diagnostic.
+
+Both operands must have the same type. The result type matches the
+operand type.
+
+### 13.3 Comparison operators (`<`, `<=`, `>`, `>=`)
+
+Comparison operators currently require numeric operands. Extending
+them to non-numeric types via `Comparable` is a future task.
+
+### 13.4 General operator overloading
+
+Dao does not currently support user-defined operator overloading.
+The operator-to-concept dispatch for `==` and the string `+` special
+case are the only non-builtin operator behaviors. A general operator
+overloading mechanism is deferred and would require updating this
+contract and `CONTRACT_SYNTAX_SURFACE.md`.
+
+## 14. Non-goals of this contract
 
 This contract does not freeze:
 
@@ -250,7 +301,7 @@ This contract does not freeze:
 - higher-kinded types
 - dependent typing
 
-## 14. Implementation consequences
+## 15. Implementation consequences
 
 Compiler work may rely on the following architectural assumptions:
 
@@ -260,7 +311,7 @@ Compiler work may rely on the following architectural assumptions:
   tooling
 - `types/` must not depend on `typecheck/`
 
-## 15. Stability rule
+## 16. Stability rule
 
 Any change that would alter Dao from:
 


### PR DESCRIPTION
## Summary

Make `==`, `!=`, and `+` work on strings as natural operators instead of requiring explicit function calls (`eq`, `concat`). This is the first step in the Phase 5 stdlib breadth work — operator semantics cleanup before string surface expansion.

## Highlights

- **`==` / `!=` on strings**: type checker already accepted same-type equality; backend now detects string operands and emits `call @__dao_eq_string` instead of `icmp`. `!=` derived via `CreateNot` — no separate hook.
- **`+` on strings**: type checker now accepts `string + string` (returns `string`); backend emits `call @__dao_str_concat`. Other arithmetic ops (`-`, `*`, `/`, `%`) on strings are rejected with a clear diagnostic.
- **`is_string()` helper**: new predicate in `type_conversion.h` for string type detection across the frontend.
- **No builtin regression**: integer/float `==` and `+` keep their direct `icmp`/`fcmp`/`fadd` lowering. The string path is an early-out before the scalar switch.
- **Design**: string `==`/`!=` dispatches through the existing `__dao_eq_string` runtime hook (same one backing the `Equatable` concept). This is the principled path — when struct `==` via Equatable is needed later, the same pattern applies.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] 4 new typecheck tests: `string +` accepted, `string ==` accepted, `string !=` accepted, `string -` rejected
- [x] 2 new backend IR tests: `string ==` → `call @__dao_eq_string`, `string +` → `call @__dao_str_concat`
- [x] E2E: `"hello" + " world"` → `"hello world"`, `==`/`!=` on string literals and variables all produce correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)