### PR TITLE
feat(stdlib): ✨ add string operations — char_at, substring, index_of, starts/ends_with, compare

### DIFF
--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -874,6 +874,32 @@ suite<"runtime_abi"> runtime_abi = [] {
 
     auto* conv_bool = module->getFunction("__dao_conv_bool_to_string");
     expect(conv_bool != nullptr) << "conv_bool_to_string declared";
+
+    // String operation hooks
+    auto* char_at = module->getFunction("__dao_str_char_at");
+    expect(char_at != nullptr) << "str_char_at declared";
+    expect(char_at->getReturnType()->isIntegerTy(32)) << "returns i32";
+    expect(char_at->arg_size() == 2u) << "2 params (str_ptr, i64)";
+
+    auto* substr = module->getFunction("__dao_str_substring");
+    expect(substr != nullptr) << "str_substring declared";
+    expect(substr->getReturnType()->isStructTy()) << "returns dao.string";
+    expect(substr->arg_size() == 3u) << "3 params (str_ptr, i64, i64)";
+
+    auto* indexof = module->getFunction("__dao_str_index_of");
+    expect(indexof != nullptr) << "str_index_of declared";
+    expect(indexof->getReturnType()->isIntegerTy(64)) << "returns i64";
+
+    auto* sw = module->getFunction("__dao_str_starts_with");
+    expect(sw != nullptr) << "str_starts_with declared";
+    expect(sw->getReturnType()->isIntegerTy(1)) << "returns i1";
+
+    auto* ew = module->getFunction("__dao_str_ends_with");
+    expect(ew != nullptr) << "str_ends_with declared";
+
+    auto* cmp = module->getFunction("__dao_str_compare");
+    expect(cmp != nullptr) << "str_compare declared";
+    expect(cmp->getReturnType()->isIntegerTy(32)) << "returns i32";
   };
 
   "string ABI shape matches contract"_test = [] {
@@ -898,6 +924,12 @@ suite<"runtime_abi"> runtime_abi = [] {
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_conv_i32_to_string"));
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_conv_f64_to_string"));
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_conv_bool_to_string"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_char_at"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_substring"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_index_of"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_starts_with"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_ends_with"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_str_compare"));
     expect(!LlvmRuntimeHooks::is_runtime_hook("__write_stdout"));
     expect(!LlvmRuntimeHooks::is_runtime_hook("user_function"));
   };

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -322,6 +322,33 @@ void LlvmRuntimeHooks::declare_string_hooks() {
   // __dao_str_length(s: *dao.string): i64
   ensure_declared(runtime_hooks::kStrLength,
                   llvm::FunctionType::get(i64, {str_ptr}, false));
+
+  auto* i1 = llvm::Type::getInt1Ty(ctx);
+  auto* i32 = llvm::Type::getInt32Ty(ctx);
+
+  // __dao_str_char_at(s: *dao.string, index: i64): i32
+  ensure_declared(runtime_hooks::kStrCharAt,
+                  llvm::FunctionType::get(i32, {str_ptr, i64}, false));
+
+  // __dao_str_substring(s: *dao.string, start: i64, len: i64): dao.string
+  ensure_declared(runtime_hooks::kStrSubstring,
+                  llvm::FunctionType::get(str_type, {str_ptr, i64, i64}, false));
+
+  // __dao_str_index_of(s: *dao.string, needle: *dao.string): i64
+  ensure_declared(runtime_hooks::kStrIndexOf,
+                  llvm::FunctionType::get(i64, {str_ptr, str_ptr}, false));
+
+  // __dao_str_starts_with(s: *dao.string, prefix: *dao.string): bool
+  ensure_declared(runtime_hooks::kStrStartsWith,
+                  llvm::FunctionType::get(i1, {str_ptr, str_ptr}, false));
+
+  // __dao_str_ends_with(s: *dao.string, suffix: *dao.string): bool
+  ensure_declared(runtime_hooks::kStrEndsWith,
+                  llvm::FunctionType::get(i1, {str_ptr, str_ptr}, false));
+
+  // __dao_str_compare(a: *dao.string, b: *dao.string): i32
+  ensure_declared(runtime_hooks::kStrCompare,
+                  llvm::FunctionType::get(i32, {str_ptr, str_ptr}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -132,8 +132,14 @@ inline constexpr std::string_view kMemResourceEnter = "__dao_mem_resource_enter"
 inline constexpr std::string_view kMemResourceExit  = "__dao_mem_resource_exit";
 
 // String domain
-inline constexpr std::string_view kStrConcat  = "__dao_str_concat";
-inline constexpr std::string_view kStrLength  = "__dao_str_length";
+inline constexpr std::string_view kStrConcat     = "__dao_str_concat";
+inline constexpr std::string_view kStrLength     = "__dao_str_length";
+inline constexpr std::string_view kStrCharAt     = "__dao_str_char_at";
+inline constexpr std::string_view kStrSubstring  = "__dao_str_substring";
+inline constexpr std::string_view kStrIndexOf    = "__dao_str_index_of";
+inline constexpr std::string_view kStrStartsWith = "__dao_str_starts_with";
+inline constexpr std::string_view kStrEndsWith   = "__dao_str_ends_with";
+inline constexpr std::string_view kStrCompare    = "__dao_str_compare";
 
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
@@ -166,6 +172,8 @@ inline constexpr std::string_view kAllHooks[] = {
     kGenAlloc, kGenFree,
     kMemResourceEnter, kMemResourceExit,
     kStrConcat, kStrLength,
+    kStrCharAt, kStrSubstring, kStrIndexOf,
+    kStrStartsWith, kStrEndsWith, kStrCompare,
 };
 
 } // namespace runtime_hooks

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -125,6 +125,12 @@ Examples:
 | `__dao_conv_u64_to_i64`  | `(x: u64): i64`                       |
 | `__dao_str_concat`       | `(a: string, b: string): string`      |
 | `__dao_str_length`       | `(s: string): i64`                    |
+| `__dao_str_char_at`      | `(s: string, index: i64): i32`        |
+| `__dao_str_substring`    | `(s: string, start: i64, len: i64): string` |
+| `__dao_str_index_of`     | `(s: string, needle: string): i64`    |
+| `__dao_str_starts_with`  | `(s: string, prefix: string): bool`   |
+| `__dao_str_ends_with`    | `(s: string, suffix: string): bool`   |
+| `__dao_str_compare`      | `(a: string, b: string): i32`         |
 | `__dao_wrapping_add_i8`  | `(a: i8, b: i8): i8`                 |
 | `__dao_wrapping_sub_i8`  | `(a: i8, b: i8): i8`                 |
 | `__dao_wrapping_mul_i8`  | `(a: i8, b: i8): i8`                 |

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -183,6 +183,30 @@ struct dao_string __dao_str_concat(const struct dao_string *a,
 // Return the byte length of a string as i64.
 int64_t __dao_str_length(const struct dao_string *s);
 
+// Return the byte value at the given index as i32. Traps on out-of-range.
+int32_t __dao_str_char_at(const struct dao_string *s, int64_t index);
+
+// Extract a substring starting at `start` with byte length `len`.
+// Traps if the range is out of bounds. Returns a heap-allocated copy.
+struct dao_string __dao_str_substring(const struct dao_string *s,
+                                      int64_t start, int64_t len);
+
+// Find the first occurrence of needle in s. Returns byte offset or -1.
+int64_t __dao_str_index_of(const struct dao_string *s,
+                            const struct dao_string *needle);
+
+// Check if s starts with prefix.
+bool __dao_str_starts_with(const struct dao_string *s,
+                            const struct dao_string *prefix);
+
+// Check if s ends with suffix.
+bool __dao_str_ends_with(const struct dao_string *s,
+                          const struct dao_string *suffix);
+
+// Lexicographic comparison. Returns -1 if a < b, 0 if equal, 1 if a > b.
+int32_t __dao_str_compare(const struct dao_string *a,
+                           const struct dao_string *b);
+
 // ---------------------------------------------------------------------------
 // Runtime hook declarations — Memory/resource domain
 // ---------------------------------------------------------------------------

--- a/runtime/core/string.c
+++ b/runtime/core/string.c
@@ -2,6 +2,8 @@
 
 #include "dao_abi.h"
 
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,4 +42,89 @@ int64_t __dao_str_length(const struct dao_string *s) {
     return 0;
   }
   return s->len;
+}
+
+// Return the byte value at the given index. Traps on out-of-range.
+int32_t __dao_str_char_at(const struct dao_string *s, int64_t index) {
+  if (s == NULL || index < 0 || index >= s->len) {
+    fprintf(stderr, "dao: string index out of range: %lld (length %lld)\n",
+            (long long)index, (long long)(s ? s->len : 0));
+    abort();
+  }
+  return (int32_t)(unsigned char)s->ptr[index];
+}
+
+// Extract a substring starting at `start` with byte length `len`.
+// Traps if the range is out of bounds. Returns a heap-allocated copy.
+struct dao_string __dao_str_substring(const struct dao_string *s,
+                                      int64_t start, int64_t len) {
+  int64_t s_len = (s != NULL) ? s->len : 0;
+  if (start < 0 || len < 0 || start + len > s_len) {
+    fprintf(stderr,
+            "dao: substring out of range: start=%lld len=%lld (string length %lld)\n",
+            (long long)start, (long long)len, (long long)s_len);
+    abort();
+  }
+  if (len == 0) {
+    return (struct dao_string){.ptr = NULL, .len = 0};
+  }
+  char *buf = (char *)malloc((size_t)len);
+  if (buf == NULL) {
+    return (struct dao_string){.ptr = NULL, .len = 0};
+  }
+  memcpy(buf, s->ptr + start, (size_t)len);
+  return (struct dao_string){.ptr = buf, .len = len};
+}
+
+// Find the first occurrence of needle in s. Returns byte offset or -1.
+int64_t __dao_str_index_of(const struct dao_string *s,
+                            const struct dao_string *needle) {
+  if (s == NULL || needle == NULL) return -1;
+  if (needle->len == 0) return 0;
+  if (needle->len > s->len) return -1;
+
+  int64_t limit = s->len - needle->len;
+  for (int64_t i = 0; i <= limit; i++) {
+    if (memcmp(s->ptr + i, needle->ptr, (size_t)needle->len) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Check if s starts with prefix.
+bool __dao_str_starts_with(const struct dao_string *s,
+                            const struct dao_string *prefix) {
+  if (s == NULL || prefix == NULL) return false;
+  if (prefix->len == 0) return true;
+  if (prefix->len > s->len) return false;
+  return memcmp(s->ptr, prefix->ptr, (size_t)prefix->len) == 0;
+}
+
+// Check if s ends with suffix.
+bool __dao_str_ends_with(const struct dao_string *s,
+                          const struct dao_string *suffix) {
+  if (s == NULL || suffix == NULL) return false;
+  if (suffix->len == 0) return true;
+  if (suffix->len > s->len) return false;
+  int64_t offset = s->len - suffix->len;
+  return memcmp(s->ptr + offset, suffix->ptr, (size_t)suffix->len) == 0;
+}
+
+// Lexicographic comparison. Returns -1 if a < b, 0 if equal, 1 if a > b.
+int32_t __dao_str_compare(const struct dao_string *a,
+                           const struct dao_string *b) {
+  int64_t a_len = (a != NULL) ? a->len : 0;
+  int64_t b_len = (b != NULL) ? b->len : 0;
+  int64_t min_len = (a_len < b_len) ? a_len : b_len;
+
+  if (min_len > 0 && a->ptr != NULL && b->ptr != NULL) {
+    int cmp = memcmp(a->ptr, b->ptr, (size_t)min_len);
+    if (cmp < 0) return -1;
+    if (cmp > 0) return 1;
+  }
+
+  if (a_len < b_len) return -1;
+  if (a_len > b_len) return 1;
+  return 0;
 }

--- a/runtime/core/string.c
+++ b/runtime/core/string.c
@@ -59,7 +59,10 @@ int32_t __dao_str_char_at(const struct dao_string *s, int64_t index) {
 struct dao_string __dao_str_substring(const struct dao_string *s,
                                       int64_t start, int64_t len) {
   int64_t s_len = (s != NULL) ? s->len : 0;
-  if (start < 0 || len < 0 || start + len > s_len) {
+  // Use overflow-safe check: after ruling out negatives, compare
+  // start > s_len - len instead of start + len > s_len (which can
+  // overflow signed int64_t for large positive inputs, invoking UB).
+  if (start < 0 || len < 0 || len > s_len || start > s_len - len) {
     fprintf(stderr,
             "dao: substring out of range: start=%lld len=%lld (string length %lld)\n",
             (long long)start, (long long)len, (long long)s_len);

--- a/stdlib/core/string.dao
+++ b/stdlib/core/string.dao
@@ -1,5 +1,17 @@
 extern fn __dao_str_concat(a: string, b: string): string
 extern fn __dao_str_length(s: string): i64
+extern fn __dao_str_char_at(s: string, index: i64): i32
+extern fn __dao_str_substring(s: string, start: i64, len: i64): string
+extern fn __dao_str_index_of(s: string, needle: string): i64
+extern fn __dao_str_starts_with(s: string, prefix: string): bool
+extern fn __dao_str_ends_with(s: string, suffix: string): bool
+extern fn __dao_str_compare(a: string, b: string): i32
 
 fn concat(a: string, b: string): string -> __dao_str_concat(a, b)
 fn length(s: string): i64 -> __dao_str_length(s)
+fn char_at(s: string, index: i64): i32 -> __dao_str_char_at(s, index)
+fn substring(s: string, start: i64, len: i64): string -> __dao_str_substring(s, start, len)
+fn index_of(s: string, needle: string): i64 -> __dao_str_index_of(s, needle)
+fn starts_with(s: string, prefix: string): bool -> __dao_str_starts_with(s, prefix)
+fn ends_with(s: string, suffix: string): bool -> __dao_str_ends_with(s, suffix)
+fn str_compare(a: string, b: string): i32 -> __dao_str_compare(a, b)

--- a/testdata/ast/stdlib_core_string.ast
+++ b/testdata/ast/stdlib_core_string.ast
@@ -6,6 +6,31 @@ File
   ExternFunctionDecl __dao_str_length
     Param s: string
     ReturnType: i64
+  ExternFunctionDecl __dao_str_char_at
+    Param s: string
+    Param index: i64
+    ReturnType: i32
+  ExternFunctionDecl __dao_str_substring
+    Param s: string
+    Param start: i64
+    Param len: i64
+    ReturnType: string
+  ExternFunctionDecl __dao_str_index_of
+    Param s: string
+    Param needle: string
+    ReturnType: i64
+  ExternFunctionDecl __dao_str_starts_with
+    Param s: string
+    Param prefix: string
+    ReturnType: bool
+  ExternFunctionDecl __dao_str_ends_with
+    Param s: string
+    Param suffix: string
+    ReturnType: bool
+  ExternFunctionDecl __dao_str_compare
+    Param a: string
+    Param b: string
+    ReturnType: i32
   FunctionDecl concat
     Param a: string
     Param b: string
@@ -26,3 +51,71 @@ File
           Identifier __dao_str_length
         Args
           Identifier s
+  FunctionDecl char_at
+    Param s: string
+    Param index: i64
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_char_at
+        Args
+          Identifier s
+          Identifier index
+  FunctionDecl substring
+    Param s: string
+    Param start: i64
+    Param len: i64
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_substring
+        Args
+          Identifier s
+          Identifier start
+          Identifier len
+  FunctionDecl index_of
+    Param s: string
+    Param needle: string
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_index_of
+        Args
+          Identifier s
+          Identifier needle
+  FunctionDecl starts_with
+    Param s: string
+    Param prefix: string
+    ReturnType: bool
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_starts_with
+        Args
+          Identifier s
+          Identifier prefix
+  FunctionDecl ends_with
+    Param s: string
+    Param suffix: string
+    ReturnType: bool
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_ends_with
+        Args
+          Identifier s
+          Identifier suffix
+  FunctionDecl str_compare
+    Param a: string
+    Param b: string
+    ReturnType: i32
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_compare
+        Args
+          Identifier a
+          Identifier b


### PR DESCRIPTION
## Summary

Expand the string surface with 6 new runtime hooks and stdlib wrappers, making strings usable for real text processing. This is the core of the Phase 5 bootstrap-readiness string slice.

## Highlights

- **`char_at(s, index)`** → `i32`: byte value at index, traps on out-of-range
- **`substring(s, start, len)`** → `string`: extract substring, traps on OOB, heap-allocated copy
- **`index_of(s, needle)`** → `i64`: first occurrence byte offset, -1 if not found
- **`starts_with(s, prefix)`** → `bool`: prefix check via memcmp
- **`ends_with(s, suffix)`** → `bool`: suffix check via memcmp
- **`str_compare(a, b)`** → `i32`: lexicographic comparison returning -1/0/1
- **CONTRACT_RUNTIME_ABI.md** updated with all 6 new hooks in the hook table
- **LLVM backend**: all hooks registered with correct signatures and included in `is_runtime_hook` validation

## Design decisions

- `char_at` returns `i32` (byte value), not a character type — Dao doesn't have a char type yet. This is the raw byte access primitive.
- `substring` returns a heap-allocated copy (same ownership model as `concat`). No slice/view type exists yet.
- `str_compare` returns `i32` (-1/0/1) rather than bool, enabling future `Comparable` extension for strings.
- All hooks follow the existing string ABI: params passed by `*dao.string` pointer, string returns by value.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] Backend tests: 6 new hook declaration assertions + 6 `is_runtime_hook` checks
- [x] AST golden file updated for expanded `string.dao`
- [x] E2E: all operations verified — `char_at("hello", 0)` → 104, `substring("hello world", 0, 5)` → "hello", `index_of("hello world", "world")` → 6, `starts_with`/`ends_with` correct, `str_compare` returns -1/0/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)