### PR TITLE
feat(stdlib): ✨ add range_from and range_step generators

### DIFF
--- a/stdlib/core/range.dao
+++ b/stdlib/core/range.dao
@@ -1,5 +1,23 @@
 fn range(n: i32): Generator<i32>
-    let i = 0
-    while i < n:
+  let i: i32 = 0
+  while i < n:
+    yield i
+    i = i + 1
+
+fn range_from(start: i32, end: i32): Generator<i32>
+  let i: i32 = start
+  while i < end:
+    yield i
+    i = i + 1
+
+fn range_step(start: i32, end: i32, step: i32): Generator<i32>
+  let i: i32 = start
+  if step > 0:
+    while i < end:
+      yield i
+      i = i + step
+  else:
+    if step < 0:
+      while i > end:
         yield i
-        i = i + 1
+        i = i + step

--- a/testdata/ast/stdlib_core_range.ast
+++ b/testdata/ast/stdlib_core_range.ast
@@ -2,7 +2,7 @@ File
   FunctionDecl range
     Param n: i32
     ReturnType: Generator<i32>
-    LetStatement i
+    LetStatement i: i32
       IntLiteral 0
     WhileStatement
       Condition
@@ -18,3 +18,71 @@ File
           BinaryExpr +
             Identifier i
             IntLiteral 1
+  FunctionDecl range_from
+    Param start: i32
+    Param end: i32
+    ReturnType: Generator<i32>
+    LetStatement i: i32
+      Identifier start
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier end
+      YieldStatement
+        Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+  FunctionDecl range_step
+    Param start: i32
+    Param end: i32
+    Param step: i32
+    ReturnType: Generator<i32>
+    LetStatement i: i32
+      Identifier start
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier step
+          IntLiteral 0
+      Then
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier i
+              Identifier end
+          YieldStatement
+            Identifier i
+          Assignment
+            Target
+              Identifier i
+            Value
+              BinaryExpr +
+                Identifier i
+                Identifier step
+      Else
+        IfStatement
+          Condition
+            BinaryExpr <
+              Identifier step
+              IntLiteral 0
+          Then
+            WhileStatement
+              Condition
+                BinaryExpr >
+                  Identifier i
+                  Identifier end
+              YieldStatement
+                Identifier i
+              Assignment
+                Target
+                  Identifier i
+                Value
+                  BinaryExpr +
+                    Identifier i
+                    Identifier step


### PR DESCRIPTION
## Summary

Expand the range surface from single-arg `range(n)` to three variants covering common iteration patterns needed for bootstrap-readiness.

## Highlights

- **`range(n)`**: existing, yields `0..n-1` (reformatted to consistent 2-space indent)
- **`range_from(start, end)`**: yields `start..end-1` (exclusive upper bound)
- **`range_step(start, end, step)`**: yields with step; positive step counts up while `i < end`, negative step counts down while `i > end`, zero step produces no iterations safely

No compiler or runtime changes — these are pure Dao generator functions using the existing `yield`/`while` infrastructure.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] AST golden file updated for expanded `range.dao`
- [x] E2E: `range(5)` → 0-4, `range_from(3, 7)` → 3-6, `range_step(0, 10, 2)` → 0,2,4,6,8, `range_step(10, 0, -3)` → 10,7,4,1, empty range → no output, `range_from(1, 11)` sum → 55

🤖 Generated with [Claude Code](https://claude.com/claude-code)