### PR TITLE
feat(lang): ✨ add arity-based function overloading and overloaded range()

### DIFF
--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -203,28 +203,51 @@ private:
           decl.kind() == NodeKind::FunctionDecl &&
           existing->decl != nullptr) {
         const auto& new_fn = decl.as<FunctionDecl>();
-        const auto* existing_decl = static_cast<const Decl*>(existing->decl);
-        if (existing_decl->is<FunctionDecl>()) {
-          size_t new_arity = new_fn.params.size();
-          size_t existing_arity =
-              existing_decl->as<FunctionDecl>().params.size();
-          if (new_arity != existing_arity) {
-            // Different arity → register as overload with mangled name.
-            auto mangled = ctx_.intern(
-                std::string(name) + "$" + std::to_string(new_arity));
-            auto* sym = ctx_.make_symbol(kind, mangled, name_span, &decl);
-            file_scope_->declare_overload(name, mangled, sym);
+        size_t new_arity = new_fn.params.size();
 
-            // Also register the original as an overload if not already.
-            if (!file_scope_->has_overloads(name)) {
-              auto orig_mangled = ctx_.intern(
-                  std::string(name) + "$" +
-                  std::to_string(existing_arity));
-              // Re-register existing under mangled name + overload set.
-              file_scope_->declare_overload(name, orig_mangled, existing);
+        // Check for same-arity collision against ALL existing overloads
+        // (not just the original declaration). Without this, a third
+        // declaration like fn foo(x, y) after fn foo(a) / fn foo(a, b)
+        // would slip past the lookup_local check since the original
+        // declaration has a different arity.
+        bool arity_collision = false;
+        const auto* overloads = file_scope_->lookup_overloads(name);
+        if (overloads != nullptr) {
+          for (const auto* sym : *overloads) {
+            if (sym->decl != nullptr) {
+              const auto* od = static_cast<const Decl*>(sym->decl);
+              if (od->is<FunctionDecl>() &&
+                  od->as<FunctionDecl>().params.size() == new_arity) {
+                arity_collision = true;
+                break;
+              }
             }
-            return; // success — no duplicate error
           }
+        }
+        // Also check the original (unmangled) declaration's arity.
+        const auto* existing_decl = static_cast<const Decl*>(existing->decl);
+        if (!arity_collision && existing_decl->is<FunctionDecl>() &&
+            existing_decl->as<FunctionDecl>().params.size() == new_arity) {
+          arity_collision = true;
+        }
+
+        if (!arity_collision) {
+          // Different arity → register as overload with mangled name.
+          auto mangled = ctx_.intern(
+              std::string(name) + "$" + std::to_string(new_arity));
+          auto* sym = ctx_.make_symbol(kind, mangled, name_span, &decl);
+          file_scope_->declare_overload(name, mangled, sym);
+
+          // Also register the original as an overload if not already.
+          if (!file_scope_->has_overloads(name)) {
+            size_t existing_arity =
+                existing_decl->as<FunctionDecl>().params.size();
+            auto orig_mangled = ctx_.intern(
+                std::string(name) + "$" +
+                std::to_string(existing_arity));
+            file_scope_->declare_overload(name, orig_mangled, existing);
+          }
+          return; // success — no duplicate error
         }
       }
       diagnostics_.push_back(Diagnostic::error(
@@ -710,7 +733,36 @@ private:
     case NodeKind::PipeExpr: {
       const auto& pipe = expr.as<PipeExpr>();
       resolve_expr(*pipe.left, scope);
-      resolve_expr(*pipe.right, scope);
+      // For overloaded functions on the RHS of a pipe, the effective
+      // arity is 1 (the piped LHS value). Select the matching overload.
+      if (pipe.right->is<IdentifierExpr>()) {
+        const auto& ident = pipe.right->as<IdentifierExpr>();
+        if (scope->has_overloads(ident.name)) {
+          const auto* overloads = scope->find_overloads(ident.name);
+          if (overloads != nullptr) {
+            Symbol* match = nullptr;
+            for (auto* sym : *overloads) {
+              if (sym->decl != nullptr) {
+                const auto* fn_decl = static_cast<const Decl*>(sym->decl);
+                if (fn_decl->is<FunctionDecl>() &&
+                    fn_decl->as<FunctionDecl>().params.size() == 1) {
+                  match = sym;
+                  break;
+                }
+              }
+            }
+            if (match != nullptr) {
+              uses_[pipe.right->span.offset] = match;
+            } else {
+              resolve_expr(*pipe.right, scope);
+            }
+          }
+        } else {
+          resolve_expr(*pipe.right, scope);
+        }
+      } else {
+        resolve_expr(*pipe.right, scope);
+      }
       break;
     }
     case NodeKind::Lambda: {

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -193,7 +193,40 @@ private:
       return;
     }
 
-    if (file_scope_->lookup_local(name) != nullptr) {
+    auto* existing = file_scope_->lookup_local(name);
+    if (existing != nullptr) {
+      // Allow arity-based function overloading: same name, different
+      // parameter counts. Both the existing and new declaration must
+      // be functions.
+      if (kind == SymbolKind::Function &&
+          existing->kind == SymbolKind::Function &&
+          decl.kind() == NodeKind::FunctionDecl &&
+          existing->decl != nullptr) {
+        const auto& new_fn = decl.as<FunctionDecl>();
+        const auto* existing_decl = static_cast<const Decl*>(existing->decl);
+        if (existing_decl->is<FunctionDecl>()) {
+          size_t new_arity = new_fn.params.size();
+          size_t existing_arity =
+              existing_decl->as<FunctionDecl>().params.size();
+          if (new_arity != existing_arity) {
+            // Different arity → register as overload with mangled name.
+            auto mangled = ctx_.intern(
+                std::string(name) + "$" + std::to_string(new_arity));
+            auto* sym = ctx_.make_symbol(kind, mangled, name_span, &decl);
+            file_scope_->declare_overload(name, mangled, sym);
+
+            // Also register the original as an overload if not already.
+            if (!file_scope_->has_overloads(name)) {
+              auto orig_mangled = ctx_.intern(
+                  std::string(name) + "$" +
+                  std::to_string(existing_arity));
+              // Re-register existing under mangled name + overload set.
+              file_scope_->declare_overload(name, orig_mangled, existing);
+            }
+            return; // success — no duplicate error
+          }
+        }
+      }
       diagnostics_.push_back(Diagnostic::error(
           name_span,
           "duplicate top-level declaration '" + std::string(name) + "'"));
@@ -621,7 +654,40 @@ private:
     }
     case NodeKind::CallExpr: {
       const auto& call = expr.as<CallExpr>();
-      resolve_expr(*call.callee, scope);
+      // For overloaded functions, resolve the callee by name + arity
+      // instead of just name. This selects the correct overload before
+      // the type checker sees it.
+      if (call.callee->is<IdentifierExpr>()) {
+        const auto& ident = call.callee->as<IdentifierExpr>();
+        if (scope->has_overloads(ident.name)) {
+          // Find the overload matching the call's argument count.
+          const auto* overloads = scope->find_overloads(ident.name);
+          if (overloads != nullptr) {
+            Symbol* match = nullptr;
+            for (auto* sym : *overloads) {
+              if (sym->decl != nullptr) {
+                const auto* fn_decl = static_cast<const Decl*>(sym->decl);
+                if (fn_decl->is<FunctionDecl>() &&
+                    fn_decl->as<FunctionDecl>().params.size() ==
+                        call.args.size()) {
+                  match = sym;
+                  break;
+                }
+              }
+            }
+            if (match != nullptr) {
+              uses_[call.callee->span.offset] = match;
+            } else {
+              // No arity match — resolve normally (will fail in type checker).
+              resolve_expr(*call.callee, scope);
+            }
+          }
+        } else {
+          resolve_expr(*call.callee, scope);
+        }
+      } else {
+        resolve_expr(*call.callee, scope);
+      }
       for (const auto* arg : call.args) {
         resolve_expr(*arg, scope);
       }

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -196,58 +196,40 @@ private:
     auto* existing = file_scope_->lookup_local(name);
     if (existing != nullptr) {
       // Allow arity-based function overloading: same name, different
-      // parameter counts. Both the existing and new declaration must
-      // be functions.
+      // parameter counts. Both must be functions.
       if (kind == SymbolKind::Function &&
           existing->kind == SymbolKind::Function &&
           decl.kind() == NodeKind::FunctionDecl &&
           existing->decl != nullptr) {
-        const auto& new_fn = decl.as<FunctionDecl>();
-        size_t new_arity = new_fn.params.size();
-
-        // Check for same-arity collision against ALL existing overloads
-        // (not just the original declaration). Without this, a third
-        // declaration like fn foo(x, y) after fn foo(a) / fn foo(a, b)
-        // would slip past the lookup_local check since the original
-        // declaration has a different arity.
-        bool arity_collision = false;
-        const auto* overloads = file_scope_->lookup_overloads(name);
-        if (overloads != nullptr) {
-          for (const auto* sym : *overloads) {
-            if (sym->decl != nullptr) {
-              const auto* od = static_cast<const Decl*>(sym->decl);
-              if (od->is<FunctionDecl>() &&
-                  od->as<FunctionDecl>().params.size() == new_arity) {
-                arity_collision = true;
-                break;
-              }
-            }
-          }
-        }
-        // Also check the original (unmangled) declaration's arity.
+        size_t new_arity = decl.as<FunctionDecl>().params.size();
         const auto* existing_decl = static_cast<const Decl*>(existing->decl);
-        if (!arity_collision && existing_decl->is<FunctionDecl>() &&
+
+        // Check arity collision against the overload set AND the
+        // original declaration.
+        bool collision = overload_has_arity(name, new_arity);
+        if (!collision && existing_decl->is<FunctionDecl>() &&
             existing_decl->as<FunctionDecl>().params.size() == new_arity) {
-          arity_collision = true;
+          collision = true;
         }
 
-        if (!arity_collision) {
-          // Different arity → register as overload with mangled name.
+        if (!collision) {
+          // Register the new overload with a mangled internal name.
           auto mangled = ctx_.intern(
               std::string(name) + "$" + std::to_string(new_arity));
           auto* sym = ctx_.make_symbol(kind, mangled, name_span, &decl);
           file_scope_->declare_overload(name, mangled, sym);
 
-          // Also register the original as an overload if not already.
-          if (!file_scope_->has_overloads(name)) {
-            size_t existing_arity =
+          // Bootstrap the overload set with the original declaration
+          // if this is the first overload being added.
+          if (file_scope_->lookup_overloads(name) != nullptr &&
+              file_scope_->lookup_overloads(name)->size() == 1) {
+            size_t orig_arity =
                 existing_decl->as<FunctionDecl>().params.size();
             auto orig_mangled = ctx_.intern(
-                std::string(name) + "$" +
-                std::to_string(existing_arity));
+                std::string(name) + "$" + std::to_string(orig_arity));
             file_scope_->declare_overload(name, orig_mangled, existing);
           }
-          return; // success — no duplicate error
+          return;
         }
       }
       diagnostics_.push_back(Diagnostic::error(
@@ -257,6 +239,63 @@ private:
       auto* sym = ctx_.make_symbol(kind, name, name_span, &decl);
       file_scope_->declare(name, sym);
     }
+  }
+
+  // --- Overload helpers ---
+
+  /// Check if any overload of `name` has the given parameter count.
+  auto overload_has_arity(std::string_view name, size_t arity) -> bool {
+    const auto* overloads = file_scope_->lookup_overloads(name);
+    if (overloads != nullptr) {
+      for (const auto* sym : *overloads) {
+        if (sym->decl != nullptr) {
+          const auto* decl = static_cast<const Decl*>(sym->decl);
+          if (decl->is<FunctionDecl>() &&
+              decl->as<FunctionDecl>().params.size() == arity) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Find the overload of `name` with the given arity in the scope chain.
+  /// Returns nullptr if no match.
+  auto find_overload_by_arity(std::string_view name, size_t arity,
+                               Scope* scope) -> Symbol* {
+    const auto* overloads = scope->find_overloads(name);
+    if (overloads == nullptr) {
+      return nullptr;
+    }
+    for (auto* sym : *overloads) {
+      if (sym->decl != nullptr) {
+        const auto* decl = static_cast<const Decl*>(sym->decl);
+        if (decl->is<FunctionDecl>() &&
+            decl->as<FunctionDecl>().params.size() == arity) {
+          return sym;
+        }
+      }
+    }
+    return nullptr;
+  }
+
+  /// Try to resolve an identifier to an overloaded function by arity.
+  /// If the name is overloaded and a match is found, records the use
+  /// and returns true. Otherwise returns false (caller should fall
+  /// through to normal resolution).
+  auto try_resolve_overload(const Expr& ident_expr,
+                             std::string_view name, size_t arity,
+                             Scope* scope) -> bool {
+    if (!scope->has_overloads(name)) {
+      return false;
+    }
+    auto* match = find_overload_by_arity(name, arity, scope);
+    if (match != nullptr) {
+      uses_[ident_expr.span.offset] = match;
+      return true;
+    }
+    return false;
   }
 
   // --- Pass 2: Resolve bodies ---
@@ -677,38 +716,15 @@ private:
     }
     case NodeKind::CallExpr: {
       const auto& call = expr.as<CallExpr>();
-      // For overloaded functions, resolve the callee by name + arity
-      // instead of just name. This selects the correct overload before
-      // the type checker sees it.
+      // For overloaded functions, select the overload matching the
+      // argument count. Falls through to normal resolution otherwise.
+      bool resolved = false;
       if (call.callee->is<IdentifierExpr>()) {
-        const auto& ident = call.callee->as<IdentifierExpr>();
-        if (scope->has_overloads(ident.name)) {
-          // Find the overload matching the call's argument count.
-          const auto* overloads = scope->find_overloads(ident.name);
-          if (overloads != nullptr) {
-            Symbol* match = nullptr;
-            for (auto* sym : *overloads) {
-              if (sym->decl != nullptr) {
-                const auto* fn_decl = static_cast<const Decl*>(sym->decl);
-                if (fn_decl->is<FunctionDecl>() &&
-                    fn_decl->as<FunctionDecl>().params.size() ==
-                        call.args.size()) {
-                  match = sym;
-                  break;
-                }
-              }
-            }
-            if (match != nullptr) {
-              uses_[call.callee->span.offset] = match;
-            } else {
-              // No arity match — resolve normally (will fail in type checker).
-              resolve_expr(*call.callee, scope);
-            }
-          }
-        } else {
-          resolve_expr(*call.callee, scope);
-        }
-      } else {
+        resolved = try_resolve_overload(
+            *call.callee, call.callee->as<IdentifierExpr>().name,
+            call.args.size(), scope);
+      }
+      if (!resolved) {
         resolve_expr(*call.callee, scope);
       }
       for (const auto* arg : call.args) {
@@ -733,34 +749,14 @@ private:
     case NodeKind::PipeExpr: {
       const auto& pipe = expr.as<PipeExpr>();
       resolve_expr(*pipe.left, scope);
-      // For overloaded functions on the RHS of a pipe, the effective
-      // arity is 1 (the piped LHS value). Select the matching overload.
+      // Pipe passes the LHS as a single argument → effective arity 1.
+      bool resolved = false;
       if (pipe.right->is<IdentifierExpr>()) {
-        const auto& ident = pipe.right->as<IdentifierExpr>();
-        if (scope->has_overloads(ident.name)) {
-          const auto* overloads = scope->find_overloads(ident.name);
-          if (overloads != nullptr) {
-            Symbol* match = nullptr;
-            for (auto* sym : *overloads) {
-              if (sym->decl != nullptr) {
-                const auto* fn_decl = static_cast<const Decl*>(sym->decl);
-                if (fn_decl->is<FunctionDecl>() &&
-                    fn_decl->as<FunctionDecl>().params.size() == 1) {
-                  match = sym;
-                  break;
-                }
-              }
-            }
-            if (match != nullptr) {
-              uses_[pipe.right->span.offset] = match;
-            } else {
-              resolve_expr(*pipe.right, scope);
-            }
-          }
-        } else {
-          resolve_expr(*pipe.right, scope);
-        }
-      } else {
+        resolved = try_resolve_overload(
+            *pipe.right, pipe.right->as<IdentifierExpr>().name,
+            1, scope);
+      }
+      if (!resolved) {
         resolve_expr(*pipe.right, scope);
       }
       break;

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -238,6 +238,42 @@ suite<"resolve_duplicates"> resolve_duplicates = [] {
   };
 };
 
+suite<"resolve_overloads"> resolve_overloads = [] {
+  "arity-based overloading is allowed"_test = [] {
+    auto result = resolve_source("test",
+        "fn foo(a: i32): i32 -> a\n"
+        "fn foo(a: i32, b: i32): i32 -> a\n");
+    expect(result.resolve_result.diagnostics.empty())
+        << "different arities should not be a duplicate error";
+  };
+
+  "same-arity duplicate is still rejected"_test = [] {
+    auto result = resolve_source("test",
+        "fn foo(a: i32): i32 -> a\n"
+        "fn foo(b: i32): i32 -> b\n");
+    expect(has_diagnostic_containing(result.resolve_result,
+        "duplicate top-level declaration 'foo'"));
+  };
+
+  "three overloads with different arities"_test = [] {
+    auto result = resolve_source("test",
+        "fn bar(): i32 -> 0\n"
+        "fn bar(a: i32): i32 -> a\n"
+        "fn bar(a: i32, b: i32): i32 -> a\n");
+    expect(result.resolve_result.diagnostics.empty())
+        << "three different arities should all be allowed";
+  };
+
+  "non-function duplicate with same name is still rejected"_test = [] {
+    auto result = resolve_source("test",
+        "fn foo(a: i32): i32 -> a\n"
+        "class foo:\n"
+        "  x: i32\n");
+    expect(has_diagnostic_containing(result.resolve_result,
+        "duplicate top-level declaration 'foo'"));
+  };
+};
+
 suite<"resolve_types"> resolve_types = [] {
   "builtin type resolves"_test = [] {
     auto result = resolve_source("test", "fn foo(x: i32): i32 -> x");

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -264,6 +264,15 @@ suite<"resolve_overloads"> resolve_overloads = [] {
         << "three different arities should all be allowed";
   };
 
+  "same-arity duplicate after overload set exists is rejected"_test = [] {
+    auto result = resolve_source("test",
+        "fn foo(a: i32): i32 -> a\n"
+        "fn foo(a: i32, b: i32): i32 -> a\n"
+        "fn foo(x: i32, y: i32): i32 -> x\n");
+    expect(has_diagnostic_containing(result.resolve_result,
+        "duplicate top-level declaration 'foo'"));
+  };
+
   "non-function duplicate with same name is still rejected"_test = [] {
     auto result = resolve_source("test",
         "fn foo(a: i32): i32 -> a\n"

--- a/compiler/frontend/resolve/scope.h
+++ b/compiler/frontend/resolve/scope.h
@@ -83,12 +83,57 @@ public:
     return inserted;
   }
 
+  // Register an overloaded function. The symbol is stored under its
+  // mangled name (e.g. "range$2") in declarations_, and also recorded
+  // in the overload set keyed by the base name.
+  void declare_overload(std::string_view base_name,
+                         std::string_view mangled_name, Symbol* sym) {
+    declarations_[mangled_name] = sym;
+    overloads_[base_name].push_back(sym);
+  }
+
+  // Return the overload set for a name (local scope only).
+  // Returns nullptr if no overloads exist.
+  [[nodiscard]] auto lookup_overloads(std::string_view name) const
+      -> const std::vector<Symbol*>* {
+    auto it = overloads_.find(name);
+    if (it != overloads_.end() && !it->second.empty()) {
+      return &it->second;
+    }
+    return nullptr;
+  }
+
+  // Check if a name has overloaded declarations in this scope chain.
+  [[nodiscard]] auto has_overloads(std::string_view name) const -> bool {
+    if (lookup_overloads(name) != nullptr) {
+      return true;
+    }
+    if (parent_ != nullptr) {
+      return parent_->has_overloads(name);
+    }
+    return false;
+  }
+
+  // Look up overloads traversing the scope chain.
+  [[nodiscard]] auto find_overloads(std::string_view name) const
+      -> const std::vector<Symbol*>* {
+    auto* local = lookup_overloads(name);
+    if (local != nullptr) {
+      return local;
+    }
+    if (parent_ != nullptr) {
+      return parent_->find_overloads(name);
+    }
+    return nullptr;
+  }
+
 private:
   ScopeKind kind_;
   Scope* parent_;
   Span range_{};
   std::vector<Scope*> children_;
   std::unordered_map<std::string_view, Symbol*> declarations_;
+  std::unordered_map<std::string_view, std::vector<Symbol*>> overloads_;
 };
 
 } // namespace dao

--- a/stdlib/core/range.dao
+++ b/stdlib/core/range.dao
@@ -1,5 +1,23 @@
 fn range(n: i32): Generator<i32>
-    let i = 0
-    while i < n:
+  let i: i32 = 0
+  while i < n:
+    yield i
+    i = i + 1
+
+fn range(start: i32, end: i32): Generator<i32>
+  let i: i32 = start
+  while i < end:
+    yield i
+    i = i + 1
+
+fn range(start: i32, end: i32, step: i32): Generator<i32>
+  let i: i32 = start
+  if step > 0:
+    while i < end:
+      yield i
+      i = i + step
+  else:
+    if step < 0:
+      while i > end:
         yield i
-        i = i + 1
+        i = i + step

--- a/testdata/ast/stdlib_core_range.ast
+++ b/testdata/ast/stdlib_core_range.ast
@@ -2,7 +2,7 @@ File
   FunctionDecl range
     Param n: i32
     ReturnType: Generator<i32>
-    LetStatement i
+    LetStatement i: i32
       IntLiteral 0
     WhileStatement
       Condition
@@ -18,3 +18,71 @@ File
           BinaryExpr +
             Identifier i
             IntLiteral 1
+  FunctionDecl range
+    Param start: i32
+    Param end: i32
+    ReturnType: Generator<i32>
+    LetStatement i: i32
+      Identifier start
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          Identifier end
+      YieldStatement
+        Identifier i
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+  FunctionDecl range
+    Param start: i32
+    Param end: i32
+    Param step: i32
+    ReturnType: Generator<i32>
+    LetStatement i: i32
+      Identifier start
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier step
+          IntLiteral 0
+      Then
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier i
+              Identifier end
+          YieldStatement
+            Identifier i
+          Assignment
+            Target
+              Identifier i
+            Value
+              BinaryExpr +
+                Identifier i
+                Identifier step
+      Else
+        IfStatement
+          Condition
+            BinaryExpr <
+              Identifier step
+              IntLiteral 0
+          Then
+            WhileStatement
+              Condition
+                BinaryExpr >
+                  Identifier i
+                  Identifier end
+              YieldStatement
+                Identifier i
+              Assignment
+                Target
+                  Identifier i
+                Value
+                  BinaryExpr +
+                    Identifier i
+                    Identifier step


### PR DESCRIPTION
## Summary

Add arity-based function overloading — multiple functions with the same name but different parameter counts. This enables the natural `range(n)`, `range(start, end)`, `range(start, end, step)` API instead of the clunky `range_from`/`range_step` names.

## Highlights

- **Resolver overload detection**: when a duplicate function name is found, check param counts. Different arity → register as overload with mangled internal name (`name$N`), tracked in a per-scope overload set. Same arity → still rejected as duplicate.
- **Call-site arity resolution**: at `CallExpr` nodes, the resolver detects overloaded names and selects the overload matching the argument count before the type checker runs. Non-matching arities fall through to normal resolution (type checker reports the error).
- **Scope infrastructure**: `declare_overload()`, `lookup_overloads()`, `has_overloads()`, `find_overloads()` manage overload sets with scope chain traversal.
- **LLVM naming**: overloaded functions use mangled names (`range$2`, `range$3`) in LLVM IR. The original arity keeps its unmangled name.
- **range() stdlib**: `range(n)` yields 0..n-1, `range(start, end)` yields start..end-1, `range(start, end, step)` yields with step (positive or negative). Zero step is a safe no-op.

## Design constraints

- **Arity-only**: no type-based overloading. Two functions with the same name and same param count are still rejected, even if param types differ.
- **Top-level functions only**: method overloading is not addressed (methods use concept dispatch).
- **No ambiguity**: exactly one overload can match a given argument count for a given name.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] 4 new resolver tests: overloading allowed, same-arity rejected, three-overload allowed, non-function collision rejected
- [x] E2E: `add(5)` → 6, `add(3, 4)` → 7, `add(1, 2, 3)` → 6
- [x] E2E: `range(5)`, `range(3, 7)`, `range(0, 10, 2)`, `range(10, 0, -3)`, `range(1, 11)` sum → 55
- [x] AST golden file updated for overloaded `range.dao`

🤖 Generated with [Claude Code](https://claude.com/claude-code)