### PR TITLE
feat(stdlib): ✨ add file IO — read_file, write_file, file_exists, eprint

### DIFF
--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -839,12 +839,29 @@ suite<"runtime_abi"> runtime_abi = [] {
     LlvmRuntimeHooks hooks(*module, types);
     hooks.declare_all();
 
-    // IO hook
+    // IO hooks
     auto* write_fn = module->getFunction("__dao_io_write_stdout");
     expect(write_fn != nullptr) << "write_stdout declared";
     expect(write_fn->getReturnType()->isVoidTy()) << "returns void";
     expect(write_fn->arg_size() == 1u) << "1 param";
     expect(write_fn->getArg(0)->getType()->isPointerTy()) << "string ptr param";
+
+    auto* write_err = module->getFunction("__dao_io_write_stderr");
+    expect(write_err != nullptr) << "write_stderr declared";
+    expect(write_err->getReturnType()->isVoidTy()) << "returns void";
+
+    auto* read_fn = module->getFunction("__dao_io_read_file");
+    expect(read_fn != nullptr) << "read_file declared";
+    expect(read_fn->getReturnType()->isStructTy()) << "returns dao.string";
+
+    auto* write_file_fn = module->getFunction("__dao_io_write_file");
+    expect(write_file_fn != nullptr) << "write_file declared";
+    expect(write_file_fn->getReturnType()->isIntegerTy(1)) << "returns bool";
+    expect(write_file_fn->arg_size() == 2u) << "2 params";
+
+    auto* exists_fn = module->getFunction("__dao_io_file_exists");
+    expect(exists_fn != nullptr) << "file_exists declared";
+    expect(exists_fn->getReturnType()->isIntegerTy(1)) << "returns bool";
 
     // Equality hooks
     auto* eq_i32 = module->getFunction("__dao_eq_i32");
@@ -917,6 +934,10 @@ suite<"runtime_abi"> runtime_abi = [] {
 
   "is_runtime_hook recognizes all hooks"_test = [] {
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_io_write_stdout"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_io_write_stderr"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_io_read_file"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_io_write_file"));
+    expect(LlvmRuntimeHooks::is_runtime_hook("__dao_io_file_exists"));
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_eq_i32"));
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_eq_f64"));
     expect(LlvmRuntimeHooks::is_runtime_hook("__dao_eq_bool"));

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -40,12 +40,30 @@ auto LlvmRuntimeHooks::is_runtime_hook(std::string_view name) -> bool {
 
 void LlvmRuntimeHooks::declare_io_hooks() {
   auto& ctx = module_.getContext();
+  auto* str_type = types_.string_type();
+  auto* str_ptr = llvm::PointerType::getUnqual(str_type);
+  auto* void_ty = llvm::Type::getVoidTy(ctx);
+  auto* i1 = llvm::Type::getInt1Ty(ctx);
 
   // __dao_io_write_stdout(msg: *dao.string): void
-  auto* str_ptr = llvm::PointerType::getUnqual(types_.string_type());
-  auto* fn_type = llvm::FunctionType::get(
-      llvm::Type::getVoidTy(ctx), {str_ptr}, /*isVarArg=*/false);
-  ensure_declared(runtime_hooks::kWriteStdout, fn_type);
+  ensure_declared(runtime_hooks::kWriteStdout,
+                  llvm::FunctionType::get(void_ty, {str_ptr}, false));
+
+  // __dao_io_write_stderr(msg: *dao.string): void
+  ensure_declared(runtime_hooks::kWriteStderr,
+                  llvm::FunctionType::get(void_ty, {str_ptr}, false));
+
+  // __dao_io_read_file(path: *dao.string): dao.string
+  ensure_declared(runtime_hooks::kReadFile,
+                  llvm::FunctionType::get(str_type, {str_ptr}, false));
+
+  // __dao_io_write_file(path: *dao.string, content: *dao.string): bool
+  ensure_declared(runtime_hooks::kWriteFile,
+                  llvm::FunctionType::get(i1, {str_ptr, str_ptr}, false));
+
+  // __dao_io_file_exists(path: *dao.string): bool
+  ensure_declared(runtime_hooks::kFileExists,
+                  llvm::FunctionType::get(i1, {str_ptr}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -30,7 +30,11 @@ class LlvmTypeLowering;
 namespace runtime_hooks {
 
 // IO domain
-inline constexpr std::string_view kWriteStdout = "__dao_io_write_stdout";
+inline constexpr std::string_view kWriteStdout  = "__dao_io_write_stdout";
+inline constexpr std::string_view kWriteStderr  = "__dao_io_write_stderr";
+inline constexpr std::string_view kReadFile     = "__dao_io_read_file";
+inline constexpr std::string_view kWriteFile    = "__dao_io_write_file";
+inline constexpr std::string_view kFileExists   = "__dao_io_file_exists";
 
 // Equality domain
 inline constexpr std::string_view kEqI8     = "__dao_eq_i8";
@@ -143,7 +147,7 @@ inline constexpr std::string_view kStrCompare    = "__dao_str_compare";
 
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
-    kWriteStdout,
+    kWriteStdout, kWriteStderr, kReadFile, kWriteFile, kFileExists,
     kEqI8,     kEqI16,    kEqI32,    kEqI64,
     kEqU8,     kEqU16,    kEqU32,    kEqU64,
     kEqF32,    kEqF64,    kEqBool,   kEqString,

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -129,19 +129,26 @@ auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
 
 auto load_prelude_source() -> std::string {
   std::filesystem::path root(DAO_SOURCE_DIR);
-  auto stdlib_core = root / "stdlib" / "core";
   std::string prelude;
 
-  if (!std::filesystem::exists(stdlib_core)) {
-    return prelude;
-  }
+  // Load stdlib directories in order: core first, then io.
+  // concepts/ is not auto-loaded yet (Iterable needs more infra).
+  const std::filesystem::path dirs[] = {
+      root / "stdlib" / "core",
+      root / "stdlib" / "io",
+  };
 
-  for (const auto& entry : std::filesystem::directory_iterator(stdlib_core)) {
-    if (entry.path().extension() != ".dao") {
+  for (const auto& dir : dirs) {
+    if (!std::filesystem::exists(dir)) {
       continue;
     }
-    prelude += read_file(entry.path());
-    prelude += '\n';
+    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+      if (entry.path().extension() != ".dao") {
+        continue;
+      }
+      prelude += read_file(entry.path());
+      prelude += '\n';
+    }
   }
   return prelude;
 }

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -66,6 +66,10 @@ Examples:
 | Hook                      | Signature (Dao surface)              |
 |---------------------------|--------------------------------------|
 | `__dao_io_write_stdout`   | `(msg: string): void`                |
+| `__dao_io_write_stderr`   | `(msg: string): void`                |
+| `__dao_io_read_file`      | `(path: string): string`             |
+| `__dao_io_write_file`     | `(path: string, content: string): bool` |
+| `__dao_io_file_exists`    | `(path: string): bool`               |
 | `__dao_eq_i8`             | `(a: i8, b: i8): bool`              |
 | `__dao_eq_i16`            | `(a: i16, b: i16): bool`            |
 | `__dao_eq_i32`            | `(a: i32, b: i32): bool`            |

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -42,6 +42,19 @@ struct dao_string {
 // Borrows msg for the duration of the call; no ownership transfer.
 void __dao_io_write_stdout(const struct dao_string *msg);
 
+// Write a string to stderr followed by a newline.
+void __dao_io_write_stderr(const struct dao_string *msg);
+
+// Read an entire file into a heap-allocated string. Traps on error.
+struct dao_string __dao_io_read_file(const struct dao_string *path);
+
+// Write a string to a file. Returns true on success, false on failure.
+bool __dao_io_write_file(const struct dao_string *path,
+                          const struct dao_string *content);
+
+// Check if a file exists.
+bool __dao_io_file_exists(const struct dao_string *path);
+
 // ---------------------------------------------------------------------------
 // Runtime hook declarations — Equality domain
 // ---------------------------------------------------------------------------

--- a/runtime/core/io.c
+++ b/runtime/core/io.c
@@ -1,11 +1,14 @@
 // io.c — Dao runtime IO hooks.
 //
-// Implements: __dao_io_write_stdout
-// Authority:  docs/contracts/CONTRACT_RUNTIME_ABI.md
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
 
 #include "dao_abi.h"
 
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 
 void __dao_io_write_stdout(const struct dao_string *msg) {
   if (msg == NULL || msg->ptr == NULL || msg->len <= 0) {
@@ -15,4 +18,121 @@ void __dao_io_write_stdout(const struct dao_string *msg) {
 
   fwrite(msg->ptr, 1, (size_t)msg->len, stdout);
   fputc('\n', stdout);
+}
+
+void __dao_io_write_stderr(const struct dao_string *msg) {
+  if (msg == NULL || msg->ptr == NULL || msg->len <= 0) {
+    fputc('\n', stderr);
+    return;
+  }
+
+  fwrite(msg->ptr, 1, (size_t)msg->len, stderr);
+  fputc('\n', stderr);
+}
+
+// Read an entire file into a heap-allocated string. Traps on error.
+struct dao_string __dao_io_read_file(const struct dao_string *path) {
+  if (path == NULL || path->ptr == NULL || path->len <= 0) {
+    fprintf(stderr, "dao: read_file: empty path\n");
+    abort();
+  }
+
+  // Null-terminate the path for fopen.
+  char *cpath = (char *)malloc((size_t)path->len + 1);
+  if (cpath == NULL) {
+    fprintf(stderr, "dao: read_file: allocation failed\n");
+    abort();
+  }
+  memcpy(cpath, path->ptr, (size_t)path->len);
+  cpath[path->len] = '\0';
+
+  FILE *file = fopen(cpath, "rb");
+  if (file == NULL) {
+    fprintf(stderr, "dao: read_file: cannot open '%s'\n", cpath);
+    free(cpath);
+    abort();
+  }
+
+  // Get file size.
+  fseek(file, 0, SEEK_END);
+  long size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+
+  if (size < 0) {
+    fprintf(stderr, "dao: read_file: cannot determine size of '%s'\n", cpath);
+    fclose(file);
+    free(cpath);
+    abort();
+  }
+
+  if (size == 0) {
+    fclose(file);
+    free(cpath);
+    return (struct dao_string){.ptr = NULL, .len = 0};
+  }
+
+  char *buf = (char *)malloc((size_t)size);
+  if (buf == NULL) {
+    fprintf(stderr, "dao: read_file: allocation failed for '%s'\n", cpath);
+    fclose(file);
+    free(cpath);
+    abort();
+  }
+
+  size_t read_bytes = fread(buf, 1, (size_t)size, file);
+  fclose(file);
+  free(cpath);
+
+  return (struct dao_string){.ptr = buf, .len = (int64_t)read_bytes};
+}
+
+// Write a string to a file. Returns true on success, false on failure.
+bool __dao_io_write_file(const struct dao_string *path,
+                          const struct dao_string *content) {
+  if (path == NULL || path->ptr == NULL || path->len <= 0) {
+    return false;
+  }
+
+  char *cpath = (char *)malloc((size_t)path->len + 1);
+  if (cpath == NULL) {
+    return false;
+  }
+  memcpy(cpath, path->ptr, (size_t)path->len);
+  cpath[path->len] = '\0';
+
+  FILE *file = fopen(cpath, "wb");
+  if (file == NULL) {
+    free(cpath);
+    return false;
+  }
+
+  size_t written = 0;
+  if (content != NULL && content->ptr != NULL && content->len > 0) {
+    written = fwrite(content->ptr, 1, (size_t)content->len, file);
+  }
+
+  fclose(file);
+  free(cpath);
+
+  return content == NULL || content->len <= 0 ||
+         written == (size_t)content->len;
+}
+
+// Check if a file exists.
+bool __dao_io_file_exists(const struct dao_string *path) {
+  if (path == NULL || path->ptr == NULL || path->len <= 0) {
+    return false;
+  }
+
+  char *cpath = (char *)malloc((size_t)path->len + 1);
+  if (cpath == NULL) {
+    return false;
+  }
+  memcpy(cpath, path->ptr, (size_t)path->len);
+  cpath[path->len] = '\0';
+
+  struct stat st;
+  bool exists = (stat(cpath, &st) == 0);
+  free(cpath);
+  return exists;
 }

--- a/runtime/core/io.c
+++ b/runtime/core/io.c
@@ -80,9 +80,19 @@ struct dao_string __dao_io_read_file(const struct dao_string *path) {
   }
 
   size_t read_bytes = fread(buf, 1, (size_t)size, file);
+  int read_err = ferror(file);
   fclose(file);
-  free(cpath);
 
+  if (read_err || read_bytes != (size_t)size) {
+    fprintf(stderr, "dao: read_file: read error for '%s' "
+            "(expected %ld bytes, got %zu)\n",
+            cpath, size, read_bytes);
+    free(buf);
+    free(cpath);
+    abort();
+  }
+
+  free(cpath);
   return (struct dao_string){.ptr = buf, .len = (int64_t)read_bytes};
 }
 
@@ -111,9 +121,14 @@ bool __dao_io_write_file(const struct dao_string *path,
     written = fwrite(content->ptr, 1, (size_t)content->len, file);
   }
 
-  fclose(file);
+  // fclose flushes buffered data — check its return value to catch
+  // disk-full or deferred write errors that fwrite did not report.
+  int close_err = fclose(file);
   free(cpath);
 
+  if (close_err != 0) {
+    return false;
+  }
   return content == NULL || content->len <= 0 ||
          written == (size_t)content->len;
 }

--- a/stdlib/io/file.dao
+++ b/stdlib/io/file.dao
@@ -1,0 +1,9 @@
+extern fn __dao_io_write_stderr(msg: string): void
+extern fn __dao_io_read_file(path: string): string
+extern fn __dao_io_write_file(path: string, content: string): bool
+extern fn __dao_io_file_exists(path: string): bool
+
+fn eprint(msg: string): void -> __dao_io_write_stderr(msg)
+fn read_file(path: string): string -> __dao_io_read_file(path)
+fn write_file(path: string, content: string): bool -> __dao_io_write_file(path, content)
+fn file_exists(path: string): bool -> __dao_io_file_exists(path)


### PR DESCRIPTION
## Summary

Add basic file IO to the stdlib, enabling Dao programs to read/write files and write to stderr. This completes the bootstrap-readiness IO slice — compiler utility code can now read source files and write output without C escape hatches.

## Highlights

- **`read_file(path: string): string`** — reads entire file into heap-allocated string; traps on error (missing file, allocation failure)
- **`write_file(path: string, content: string): bool`** — writes string to file; returns false on error (no trap)
- **`file_exists(path: string): bool`** — stat-based existence check
- **`eprint(msg: string): void`** — write to stderr (for diagnostics/errors)
- **Prelude loader**: extended to include `stdlib/io/` directory alongside `stdlib/core/`
- **CONTRACT_RUNTIME_ABI.md**: 4 new hooks documented in the hook table

## Design decisions

- `read_file` traps on error rather than returning an error type — Dao doesn't have Result/Option yet. This matches the existing convention (char_at, substring all trap on invalid input).
- `write_file` returns `bool` instead of trapping — write failures are recoverable and callers should handle them.
- Path strings are null-terminated internally via temporary malloc+copy, since `dao_string` is not null-terminated but POSIX APIs require it.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] Backend tests: 4 new IO hook declaration assertions + 4 `is_runtime_hook` checks
- [x] E2E: write file → verify exists → read back → check content + length → eprint to stderr → check missing file

🤖 Generated with [Claude Code](https://claude.com/claude-code)