### PR TITLE
feat(lang): ✨ add // line comments

### DIFF
--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -260,6 +260,15 @@ private:
       }
     }
 
+    // Comment-only line — treat like a blank line.
+    if (pos_ + 1 < src_.size() && src_[pos_] == '/' && src_[pos_ + 1] == '/') {
+      // Skip comment text to end of line.
+      while (pos_ < src_.size() && src_[pos_] != '\n') {
+        ++pos_;
+      }
+      // Fall through to blank-line handling below.
+    }
+
     // Blank line — skip without affecting indentation.
     if (pos_ >= src_.size() || src_[pos_] == '\n' || src_[pos_] == '\r') {
       at_line_start_ = false;
@@ -414,6 +423,13 @@ private:
       emit(TokenKind::Star, start, 1);
       return;
     case '/':
+      if (peek() == '/') {
+        // Line comment: skip to end of line (or end of file).
+        while (pos_ < src_.size() && src_[pos_] != '\n') {
+          ++pos_;
+        }
+        return;
+      }
       emit(TokenKind::Slash, start, 1);
       return;
 

--- a/compiler/frontend/lexer/lexer_test.cpp
+++ b/compiler/frontend/lexer/lexer_test.cpp
@@ -246,6 +246,44 @@ suite<"span_tests"> span_tests = [] {
   };
 };
 
+suite<"comment_tests"> comment_tests = [] {
+  "line comment is skipped"_test = [] {
+    auto output = lex_string("fn foo(): i32 // comment\n  return 0\n");
+    expect(output.result.diagnostics.empty());
+    bool has_slash = false;
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind == TokenKind::Slash) {
+        has_slash = true;
+      }
+    }
+    expect(!has_slash) << "comment should not produce slash token";
+  };
+
+  "comment-only line does not affect indentation"_test = [] {
+    auto output = lex_string("fn foo(): i32\n  // comment\n  return 0\n");
+    expect(output.result.diagnostics.empty());
+  };
+
+  "top-level comment before fn"_test = [] {
+    auto output = lex_string("// top\nfn foo(): i32\n  return 0\n");
+    expect(output.result.diagnostics.empty());
+    expect(output.result.tokens[0].kind == TokenKind::KwFn)
+        << "first real token should be fn";
+  };
+
+  "slash still works as operator"_test = [] {
+    auto output = lex_string("10 / 3\n");
+    expect(output.result.diagnostics.empty());
+    bool has_slash = false;
+    for (const auto& tok : output.result.tokens) {
+      if (tok.kind == TokenKind::Slash) {
+        has_slash = true;
+      }
+    }
+    expect(has_slash) << "single slash should be an operator";
+  };
+};
+
 suite<"file_tests"> file_tests = [] {
   "examples lex without error"_test = [] {
     std::filesystem::path root(DAO_SOURCE_DIR);

--- a/spec/grammar/dao.ebnf
+++ b/spec/grammar/dao.ebnf
@@ -198,6 +198,10 @@ type_list :=
     type ("," type)*
 
 
+# Comments
+
+line_comment := "//" (any character except newline)* newline
+
 # Lexical placeholders
 identifier := IDENT
 integer_literal := INT


### PR DESCRIPTION
## Summary

Add `//` line comment support to the Dao lexer. Identified as the #1 blocker in the bootstrap probe — the language is not inhabitable for real code without comments.

## Highlights

- **Line comments**: `//` starts a comment that extends to end of line (or EOF). The comment text is silently skipped; no tokens are emitted.
- **Indentation safety**: comment-only lines (whitespace + `//`) are treated as blank lines. They do not emit INDENT/DEDENT tokens and do not disrupt indentation tracking.
- **Division preserved**: single `/` remains the division operator. Only `//` triggers comment handling.
- **Grammar**: `line_comment` production added to `dao.ebnf`.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] 4 new lexer tests: comment skipped (no Slash token), comment-only line safe for indentation, top-level comment before fn, slash still works as operator
- [x] E2E: program with top-level, body, and end-of-line comments compiles and runs correctly
- [x] Division still works: `10 / 3` → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)