### PR TITLE
feat(stdlib): ✨ add scalar to_string functions for string building

### DIFF
--- a/stdlib/core/to_string.dao
+++ b/stdlib/core/to_string.dao
@@ -1,0 +1,5 @@
+fn i32_to_string(x: i32): string -> __dao_conv_i32_to_string(x)
+fn i64_to_string(x: i64): string -> __dao_conv_i64_to_string(x)
+fn f64_to_string(x: f64): string -> __dao_conv_f64_to_string(x)
+fn f32_to_string(x: f32): string -> __dao_conv_f32_to_string(x)
+fn bool_to_string(x: bool): string -> __dao_conv_bool_to_string(x)

--- a/testdata/ast/stdlib_core_to_string.ast
+++ b/testdata/ast/stdlib_core_to_string.ast
@@ -1,0 +1,46 @@
+File
+  FunctionDecl i32_to_string
+    Param x: i32
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_i32_to_string
+        Args
+          Identifier x
+  FunctionDecl i64_to_string
+    Param x: i64
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_i64_to_string
+        Args
+          Identifier x
+  FunctionDecl f64_to_string
+    Param x: f64
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_f64_to_string
+        Args
+          Identifier x
+  FunctionDecl f32_to_string
+    Param x: f32
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_f32_to_string
+        Args
+          Identifier x
+  FunctionDecl bool_to_string
+    Param x: bool
+    ReturnType: string
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_conv_bool_to_string
+        Args
+          Identifier x


### PR DESCRIPTION
## Summary

Expose `i32_to_string`, `i64_to_string`, `f64_to_string`, `f32_to_string`, `bool_to_string` as stdlib surface functions. These wrap the existing `__dao_conv_*_to_string` runtime hooks, enabling string building like `"count: " + i32_to_string(42)`.

## Highlights

- **5 new stdlib functions** in `stdlib/core/to_string.dao`: one per commonly-used scalar type
- **No runtime or compiler changes** — these are thin wrappers over existing hooks
- Named `T_to_string` (not overloaded `to_string`) because Dao only has arity-based overloading and these all take one parameter

## Why these names

Dao doesn't have type-based overloading yet, so `to_string(x: i32)` and `to_string(x: i64)` would collide (same arity). The `T_to_string` pattern matches the existing conversion naming (`to_f64`, `i64_to_i32`, etc.).

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] AST golden file generated
- [x] E2E: `"count: " + i32_to_string(42)` → `"count: 42"`, all scalar types verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)