### PR TITLE
feat(lang): ✨ add indirect calls through function-typed values

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -396,6 +396,10 @@ auto LlvmBackend::lower_function(const MirFunction& fn) -> bool {
       emit_diagnostic(local.span, "cannot lower local type: " + types_.error());
       return false;
     }
+    // Function-typed locals are stored as opaque pointers.
+    if (llvm::isa<llvm::FunctionType>(local_type)) {
+      local_type = llvm::PointerType::getUnqual(local_type);
+    }
     // String locals store the struct, not a pointer.
     auto* alloca = builder.CreateAlloca(
         local_type, nullptr,
@@ -1054,6 +1058,10 @@ auto LlvmBackend::lower_load(const MirLoad& p, const MirInst& inst,
     emit_diagnostic(inst.span, "cannot lower load type: " + types_.error());
     return false;
   }
+  // Function-typed loads: the alloca stores a ptr, not a FunctionType.
+  if (llvm::isa<llvm::FunctionType>(local_type)) {
+    local_type = llvm::PointerType::getUnqual(local_type);
+  }
 
   auto* val = state.builder->CreateLoad(local_type, it->second, "load");
   state.values[inst.result.id] = val;
@@ -1119,9 +1127,55 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
   }
 
   auto* callee_fn = llvm::dyn_cast<llvm::Function>(callee_val);
+
+  // Indirect call: callee is a function pointer (ptr), not a direct
+  // function reference. Look up the semantic function type to build
+  // the LLVM call. No ABI coercion — this is a Dao-to-Dao call.
   if (callee_fn == nullptr) {
-    emit_diagnostic(inst.span, "call callee is not a function");
-    return false;
+    auto callee_type_it = state.value_types.find(p.callee.id);
+    if (callee_type_it == state.value_types.end() ||
+        callee_type_it->second == nullptr ||
+        callee_type_it->second->kind() != TypeKind::Function) {
+      emit_diagnostic(inst.span, "call callee is not a function");
+      return false;
+    }
+    auto* fn_llvm_type = types_.lower(callee_type_it->second);
+    if (fn_llvm_type == nullptr || !llvm::isa<llvm::FunctionType>(fn_llvm_type)) {
+      emit_diagnostic(inst.span, "cannot lower callee function type");
+      return false;
+    }
+    auto* llvm_fn_type = llvm::cast<llvm::FunctionType>(fn_llvm_type);
+
+    std::vector<llvm::Value*> indirect_args;
+    if (p.args != nullptr) {
+      for (size_t i = 0; i < p.args->size(); ++i) {
+        auto* arg_val = get_value((*p.args)[i], state);
+        if (arg_val == nullptr) {
+          emit_diagnostic(inst.span, "call argument not found");
+          return false;
+        }
+        // String → pointer coercion for indirect calls too.
+        if (i < llvm_fn_type->getNumParams()) {
+          auto* param_type = llvm_fn_type->getParamType(i);
+          if (param_type->isPointerTy() &&
+              arg_val->getType() == types_.string_type()) {
+            auto* tmp = state.builder->CreateAlloca(
+                types_.string_type(), nullptr, "str.arg");
+            state.builder->CreateStore(arg_val, tmp);
+            arg_val = tmp;
+          }
+        }
+        indirect_args.push_back(arg_val);
+      }
+    }
+
+    auto* call = state.builder->CreateCall(
+        llvm_fn_type, callee_val, indirect_args, "icall");
+    if (!llvm_fn_type->getReturnType()->isVoidTy() && inst.result.valid()) {
+      state.values[inst.result.id] = call;
+      state.value_types[inst.result.id] = inst.type;
+    }
+    return true;
   }
 
   std::vector<llvm::Value*> args;

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -1129,8 +1129,9 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
   auto* callee_fn = llvm::dyn_cast<llvm::Function>(callee_val);
 
   // Indirect call: callee is a function pointer (ptr), not a direct
-  // function reference. Look up the semantic function type to build
-  // the LLVM call. No ABI coercion — this is a Dao-to-Dao call.
+  // function reference. Reconstruct the LLVM function type from the
+  // semantic TypeFunction, applying the same adjustments used when
+  // functions are declared (string → ptr, function type → ptr).
   if (callee_fn == nullptr) {
     auto callee_type_it = state.value_types.find(p.callee.id);
     if (callee_type_it == state.value_types.end() ||
@@ -1139,12 +1140,33 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
       emit_diagnostic(inst.span, "call callee is not a function");
       return false;
     }
-    auto* fn_llvm_type = types_.lower(callee_type_it->second);
-    if (fn_llvm_type == nullptr || !llvm::isa<llvm::FunctionType>(fn_llvm_type)) {
-      emit_diagnostic(inst.span, "cannot lower callee function type");
+    const auto* sem_fn = static_cast<const TypeFunction*>(callee_type_it->second);
+
+    // Build adjusted parameter types matching declare_functions rules.
+    std::vector<llvm::Type*> adj_params;
+    for (const auto* param_type : sem_fn->param_types()) {
+      auto* lowered = types_.lower(param_type);
+      if (lowered == nullptr) {
+        emit_diagnostic(inst.span, "cannot lower indirect call param");
+        return false;
+      }
+      if (LlvmTypeLowering::is_string_type(param_type)) {
+        lowered = llvm::PointerType::getUnqual(lowered);
+      }
+      if (llvm::isa<llvm::FunctionType>(lowered)) {
+        lowered = llvm::PointerType::getUnqual(lowered);
+      }
+      adj_params.push_back(lowered);
+    }
+    auto* adj_ret = types_.lower(sem_fn->return_type());
+    if (adj_ret == nullptr) {
+      emit_diagnostic(inst.span, "cannot lower indirect call return");
       return false;
     }
-    auto* llvm_fn_type = llvm::cast<llvm::FunctionType>(fn_llvm_type);
+    if (llvm::isa<llvm::FunctionType>(adj_ret)) {
+      adj_ret = llvm::PointerType::getUnqual(adj_ret);
+    }
+    auto* llvm_fn_type = llvm::FunctionType::get(adj_ret, adj_params, false);
 
     std::vector<llvm::Value*> indirect_args;
     if (p.args != nullptr) {
@@ -1154,7 +1176,7 @@ auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
           emit_diagnostic(inst.span, "call argument not found");
           return false;
         }
-        // String → pointer coercion for indirect calls too.
+        // String → pointer coercion.
         if (i < llvm_fn_type->getNumParams()) {
           auto* param_type = llvm_fn_type->getParamType(i);
           if (param_type->isPointerTy() &&

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -675,27 +675,8 @@ void TypeChecker::check_function(const Decl* decl) {
     }
   }
 
-  // Reject function types in non-extern fn signatures. Indirect calls
-  // through function-typed values are not yet implemented; function
-  // types are currently only valid at the extern fn ABI boundary.
-  if (!fn.is_extern) {
-    for (const auto& param : fn.params) {
-      if (param.type != nullptr) {
-        const auto* param_type = resolve_type_node(param.type);
-        if (param_type != nullptr &&
-            param_type->kind() == TypeKind::Function) {
-          error(param.type->span,
-                "function type parameters are only supported in extern fn "
-                "declarations (indirect calls not yet implemented)");
-        }
-      }
-    }
-    if (ret_type != nullptr && ret_type->kind() == TypeKind::Function) {
-      error(fn.return_type->span,
-            "function type returns are only supported in extern fn "
-            "declarations (indirect calls not yet implemented)");
-    }
-  }
+  // Function types are allowed in all function signatures. The backend
+  // supports indirect calls through function-typed values.
 
   // Set up param types in symbol cache.
   for (const auto& param : fn.params) {

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -543,20 +543,11 @@ suite<"typecheck_negative"> typecheck_negative = [] {
     expect(has_error_containing(result, "not supported at the C ABI"));
   };
 
-  "function type param in non-extern fn is rejected"_test = [] {
+  "function type param in non-extern fn is accepted"_test = [] {
     auto result = check_source(
         "fn apply(cb: fn(i32, i32): i32, a: i32, b: i32): i32\n"
         "  return cb(a, b)\n");
-    expect(has_error_containing(result,
-        "function type parameters are only supported in extern fn"));
-  };
-
-  "function type return in non-extern fn is rejected"_test = [] {
-    auto result = check_source(
-        "fn get_op(): fn(i32, i32): i32\n"
-        "  return get_op()\n");
-    expect(has_error_containing(result,
-        "function type returns are only supported in extern fn"));
+    expect(is_ok(result)) << "function-typed params with indirect call should work";
   };
 
   "lambda passed to extern fn callback is rejected"_test = [] {

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -161,12 +161,10 @@ function's address as the argument value.
   in function-pointer argument positions of extern fn calls must be
   rejected by the type checker with a clear diagnostic. Closures
   cannot be represented as C function pointers.
-- **No indirect calls from Dao**: calling through a function-typed
-  value received from C is not yet supported. The initial
-  implementation covers outbound callbacks only (Dao → C → Dao).
-  Function pointer return types are accepted syntactically (e.g.
-  for passing opaque values back to C) but invoking them produces
-  a backend error.
+- **Indirect calls supported**: calling through a function-typed
+  value is supported for Dao-to-Dao calls (higher-order functions).
+  Indirect calls through function pointers received from C are also
+  supported as long as the function type signature matches.
 - **Calling convention**: function pointers follow the platform C
   calling convention. No other conventions are supported.
 
@@ -299,8 +297,8 @@ Each expansion requires updating this contract before implementation.
 | E2E struct-by-value example      | Implemented     |
 | Function pointer type syntax     | Implemented     |
 | Function pointer params          | Implemented     |
-| Function pointer return type     | Accepted        |
-| Indirect call through fn ptr     | Not implemented |
+| Function pointer return type     | Implemented     |
+| Indirect call through fn ptr     | Implemented     |
 | Named function as callback       | Implemented     |
 | Lambda rejection at ABI boundary | Implemented     |
 | E2E callback example             | Implemented     |

--- a/docs/contracts/CONTRACT_C_ABI_INTEROP.md
+++ b/docs/contracts/CONTRACT_C_ABI_INTEROP.md
@@ -161,10 +161,15 @@ function's address as the argument value.
   in function-pointer argument positions of extern fn calls must be
   rejected by the type checker with a clear diagnostic. Closures
   cannot be represented as C function pointers.
-- **Indirect calls supported**: calling through a function-typed
-  value is supported for Dao-to-Dao calls (higher-order functions).
-  Indirect calls through function pointers received from C are also
-  supported as long as the function type signature matches.
+- **Indirect calls (Dao-to-Dao)**: calling through a function-typed
+  value is supported for Dao-to-Dao higher-order functions. The
+  indirect call path applies the same parameter adjustments as
+  direct calls (string → pointer, function type → pointer).
+- **Indirect calls (C-origin)**: calling through a function pointer
+  received from C works for scalar-only signatures. C-origin
+  function pointers with struct-by-value parameters or returns
+  would require C ABI coercion in the indirect call path, which
+  is not yet implemented.
 - **Calling convention**: function pointers follow the platform C
   calling convention. No other conventions are supported.
 
@@ -298,7 +303,8 @@ Each expansion requires updating this contract before implementation.
 | Function pointer type syntax     | Implemented     |
 | Function pointer params          | Implemented     |
 | Function pointer return type     | Implemented     |
-| Indirect call through fn ptr     | Implemented     |
+| Indirect call (Dao-to-Dao)       | Implemented     |
+| Indirect call (C-origin struct)  | Not implemented |
 | Named function as callback       | Implemented     |
 | Lambda rejection at ABI boundary | Implemented     |
 | E2E callback example             | Implemented     |


### PR DESCRIPTION
## Summary

Enable calling through function-typed parameters and values, unlocking higher-order functions in Dao. This was the #2 blocker identified in the bootstrap probe — code like `skip_while(source, pos, is_digit)` previously failed because indirect calls weren't implemented.

## Highlights

- **Backend indirect call path**: when the callee is a `ptr` (loaded from a function-typed local), look up the semantic `TypeFunction`, lower it to an LLVM `FunctionType`, and emit an indirect call via `CreateCall(fn_type, ptr_value, args)`. String → pointer coercion is handled in the indirect path too.
- **Function-typed locals**: `types_.lower(TypeFunction)` returns `llvm::FunctionType` (not first-class), so allocas and loads for function-typed locals now use `ptr` explicitly.
- **Type checker**: removed the restriction that blocked function-typed params/returns in non-extern functions. Function types are now valid in all positions.
- **Contract**: `CONTRACT_C_ABI_INTEROP.md` updated — indirect calls marked as implemented.

## What this enables

```dao
fn apply(op: fn(i32, i32): i32, a: i32, b: i32): i32
  return op(a, b)

fn skip_while(source: string, pos: i64, pred: fn(i32): bool): i64
  // call pred(ch) through function pointer
```

Higher-order functions, predicate-based loops, strategy patterns — all now work.

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] Typecheck test updated: function-typed param in non-extern fn now accepted
- [x] E2E: `apply(add, 3, 4)` → 7, `apply(mul, 5, 6)` → 30, `transform(double_val, 21)` → 42
- [x] E2E: `skip_while(source, pos, is_alpha)` / `skip_while(source, pos, is_digit)` — higher-order lexer helper works

🤖 Generated with [Claude Code](https://claude.com/claude-code)