### PR TITLE
feat(lang): ✨ add break statement for loops

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -71,6 +71,8 @@ auto lexical_category(TokenKind kind) -> std::string_view {
     return "keyword.return";
   case TokenKind::KwYield:
     return "keyword.yield";
+  case TokenKind::KwBreak:
+    return "keyword.break";
 
   // Keywords — execution / resource constructs
   case TokenKind::KwMode:

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -25,6 +25,7 @@ auto Stmt::kind() const -> NodeKind {
       [](const WhileStatement&) { return NodeKind::WhileStatement; },
       [](const ForStatement&) { return NodeKind::ForStatement; },
       [](const YieldStatement&) { return NodeKind::YieldStatement; },
+      [](const BreakStmtNode&) { return NodeKind::BreakStatement; },
       [](const ModeBlock&) { return NodeKind::ModeBlock; },
       [](const ResourceBlock&) { return NodeKind::ResourceBlock; },
       [](const ReturnStatement&) { return NodeKind::ReturnStatement; },
@@ -96,6 +97,8 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "ForStatement";
   case NodeKind::YieldStatement:
     return "YieldStatement";
+  case NodeKind::BreakStatement:
+    return "BreakStatement";
   case NodeKind::ModeBlock:
     return "ModeBlock";
   case NodeKind::ResourceBlock:

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -61,6 +61,7 @@ enum class NodeKind : std::uint8_t {
   WhileStatement,
   ForStatement,
   YieldStatement,
+  BreakStatement,
   ModeBlock,
   ResourceBlock,
   ReturnStatement,
@@ -308,6 +309,8 @@ struct YieldStatement {
   Expr* value;
 };
 
+struct BreakStmtNode {};
+
 struct ReturnStatement {
   Expr* value; // nullable for bare return
 };
@@ -318,7 +321,7 @@ struct ExpressionStatement {
 
 using StmtPayload = std::variant<
     LetStatement, Assignment, IfStatement, WhileStatement, ForStatement,
-    YieldStatement, ModeBlock, ResourceBlock, ReturnStatement,
+    YieldStatement, BreakStmtNode, ModeBlock, ResourceBlock, ReturnStatement,
     ExpressionStatement, ErrorStmtNode>;
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -314,6 +314,10 @@ private:
           Scope scope(depth_);
           print_expr(*node.value);
         },
+        [&](const BreakStmtNode&) {
+          indent();
+          out_ << "BreakStatement\n";
+        },
         [&](const ReturnStatement& node) {
           indent();
           out_ << "ReturnStatement\n";

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -32,6 +32,8 @@ auto token_kind_name(TokenKind kind) -> const char* {
     return "KwReturn";
   case TokenKind::KwYield:
     return "KwYield";
+  case TokenKind::KwBreak:
+    return "KwBreak";
   case TokenKind::KwMode:
     return "KwMode";
   case TokenKind::KwResource:
@@ -557,6 +559,9 @@ private:
     }
     if (word == "yield") {
       return TokenKind::KwYield;
+    }
+    if (word == "break") {
+      return TokenKind::KwBreak;
     }
     if (word == "mode") {
       return TokenKind::KwMode;

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -26,6 +26,7 @@ enum class TokenKind : std::uint8_t {
   KwIn,
   KwReturn,
   KwYield,
+  KwBreak,
 
   // Keywords — execution / resource constructs
   KwMode,

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -615,6 +615,10 @@ private:
       return parse_return_statement();
     case TokenKind::KwYield:
       return parse_yield_statement();
+    case TokenKind::KwBreak: {
+      const auto& kw = advance();
+      return ctx_.alloc<Stmt>(kw.span, BreakStmtNode{});
+    }
     default:
       break;
     }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -781,6 +781,11 @@ void TypeChecker::check_statement(const Stmt* stmt) {
   case NodeKind::YieldStatement:
     check_yield(stmt);
     break;
+  case NodeKind::BreakStatement:
+    if (ctx_.loop_depth == 0) {
+      error(stmt->span, "'break' is only allowed inside a loop");
+    }
+    break;
   case NodeKind::ModeBlock:
     check_mode_block(stmt);
     break;
@@ -881,7 +886,9 @@ void TypeChecker::check_while(const Stmt* stmt) {
     error(wh.condition->span,
           "condition must be 'bool', got '" + print_type(cond_type) + "'");
   }
+  ctx_.loop_depth++;
   check_body(wh.body);
+  ctx_.loop_depth--;
 }
 
 void TypeChecker::check_for(const Stmt* stmt) {
@@ -907,7 +914,9 @@ void TypeChecker::check_for(const Stmt* stmt) {
     typed_.set_local_type(stmt, elem_type);
   }
 
+  ctx_.loop_depth++;
   check_body(fo.body);
+  ctx_.loop_depth--;
 }
 
 void TypeChecker::check_yield(const Stmt* stmt) {

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -41,6 +41,7 @@ struct CheckContext {
   const Type* return_type = nullptr; // enclosing function return type
   const Type* self_type = nullptr;   // type of `self` in current scope (class/extend)
   std::unordered_set<std::string_view> active_modes; // e.g. "unsafe"
+  uint32_t loop_depth = 0;           // nesting depth for break validation
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/ir/hir/hir.cpp
+++ b/compiler/ir/hir/hir.cpp
@@ -23,6 +23,7 @@ auto HirStmt::kind() const -> HirKind {
       [](const HirFor&) { return HirKind::For; },
       [](const HirReturn&) { return HirKind::Return; },
       [](const HirYield&) { return HirKind::Yield; },
+      [](const HirBreak&) { return HirKind::Break; },
       [](const HirExprStmt&) { return HirKind::ExprStmt; },
       [](const HirMode&) { return HirKind::Mode; },
       [](const HirResource&) { return HirKind::Resource; },
@@ -63,6 +64,7 @@ auto hir_kind_name(HirKind kind) -> const char* {
   case HirKind::For:           return "For";
   case HirKind::Return:        return "Return";
   case HirKind::Yield:         return "Yield";
+  case HirKind::Break:         return "Break";
   case HirKind::ExprStmt:      return "ExprStmt";
   case HirKind::Mode:          return "Mode";
   case HirKind::Resource:      return "Resource";

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -115,9 +115,11 @@ struct HirResource {
   std::vector<HirStmt*> body;
 };
 
+struct HirBreak {};
+
 using HirStmtPayload = std::variant<
     HirLet, HirAssign, HirIf, HirWhile, HirFor,
-    HirReturn, HirYield, HirExprStmt, HirMode, HirResource>;
+    HirReturn, HirYield, HirBreak, HirExprStmt, HirMode, HirResource>;
 
 // ---------------------------------------------------------------------------
 // Expression payloads

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -226,6 +226,9 @@ auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
     return ctx_.alloc<HirStmt>(stmt->span, HirYield{value});
   }
 
+  case NodeKind::BreakStatement:
+    return ctx_.alloc<HirStmt>(stmt->span, HirBreak{});
+
   case NodeKind::ReturnStatement: {
     const auto& ret = stmt->as<ReturnStatement>();
     HirExpr* value = nullptr;

--- a/compiler/ir/hir/hir_kind.h
+++ b/compiler/ir/hir/hir_kind.h
@@ -25,6 +25,7 @@ enum class HirKind : std::uint8_t {
   For,
   Return,
   Yield,
+  Break,
   ExprStmt,
   Mode,
   Resource,

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -204,6 +204,10 @@ private:
           Scope scope(depth_);
           print_expr(*node.value);
         },
+        [&](const HirBreak&) {
+          indent();
+          out_ << "Break\n";
+        },
         [&](const HirExprStmt& node) {
           indent();
           out_ << "ExprStmt\n";

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -291,6 +291,9 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
       },
       [&](const HirBreak&) {
         if (!loop_exit_stack_.empty()) {
+          // Emit region exits (mode/resource cleanup) before branching
+          // out of the loop, same as early return.
+          emit_region_exits(stmt.span);
           emit_terminator(stmt.span, MirBr{loop_exit_stack_.back()});
         }
       },

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -224,9 +224,11 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
                         MirCondBr{cond_val, body_bb->id, exit_bb->id});
 
         switch_to_block(body_bb);
+        loop_exit_stack_.push_back(exit_bb->id);
         for (const auto* s : hir_while.body) {
           lower_stmt(*s);
         }
+        loop_exit_stack_.pop_back();
         if (!block_terminated()) {
           emit_terminator(stmt.span, MirBr{cond_bb->id});
         }
@@ -272,9 +274,11 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         active_regions_.push_back(
             ActiveRegion{MirIterDestroy{iter_val}, stmt.span});
 
+        loop_exit_stack_.push_back(exit_bb->id);
         for (const auto* s : hir_for.body) {
           lower_stmt(*s);
         }
+        loop_exit_stack_.pop_back();
         if (!block_terminated()) {
           emit_terminator(stmt.span, MirBr{cond_bb->id});
         }
@@ -284,6 +288,11 @@ void MirBuilder::lower_stmt(const HirStmt& stmt) {
         switch_to_block(exit_bb);
         // Free the generator frame on the normal loop-exit path.
         emit_effect(stmt.span, MirIterDestroy{iter_val});
+      },
+      [&](const HirBreak&) {
+        if (!loop_exit_stack_.empty()) {
+          emit_terminator(stmt.span, MirBr{loop_exit_stack_.back()});
+        }
       },
       [&](const HirYield& yield) {
         auto val = lower_expr_value(*yield.value);

--- a/compiler/ir/mir/mir_builder.h
+++ b/compiler/ir/mir/mir_builder.h
@@ -46,6 +46,9 @@ private:
   uint32_t next_block_id_ = 0;
   std::unordered_map<const Symbol*, LocalId> symbol_to_local_;
 
+  // Loop exit block stack for break statement lowering.
+  std::vector<BlockId> loop_exit_stack_;
+
   // Active mode/resource region stack for exit-on-return.
   struct ActiveRegion {
     MirPayload exit_payload;


### PR DESCRIPTION
## Summary

Add `break` statement for `while` and `for` loops. Full vertical through all 8 compiler phases. This was the #1 remaining pain point from the bootstrap probe — every scan loop required a `let done: bool = false` + `while ... and done == false` workaround.

## Highlights

- **16 files changed, 58 insertions** — clean vertical feature
- **Lexer**: `break` keyword token
- **Parser**: `break` parsed as a bare statement (no value)
- **Type checker**: `loop_depth` counter validates break is inside a loop; error at depth 0
- **MIR**: break emits `MirBr` to the loop's exit block via `loop_exit_stack_` maintained during while/for lowering. No new MIR instruction needed.
- **LLVM**: no changes — `MirBr` already lowers to `br` correctly

## Test plan

- [x] `ctest` — all 12 tests pass
- [x] E2E: `find_first_digit("hello42world")` → 5 (break in while)
- [x] E2E: `sum_until_negative(10)` → 22 (break in for)
- [x] E2E: nested loops with break — finds first i,j where i+j==6

🤖 Generated with [Claude Code](https://claude.com/claude-code)