### PR TITLE
feat(stdlib): ✨ add low-level memory substrate — Task 17

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -913,6 +913,119 @@ auto LlvmBackend::lower_binary(const MirBinary& p, const MirInst& inst,
 // ---------------------------------------------------------------------------
 // Place resolution — walk projection chains to an LLVM pointer.
 // ---------------------------------------------------------------------------
+// Compiler builtin intrinsic lowering
+// ---------------------------------------------------------------------------
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+auto LlvmBackend::lower_builtin_call(
+    std::string_view name, const MirCall& p, const MirInst& inst,
+    FunctionState& state) -> bool {
+  auto* builder = state.builder;
+  auto& ctx = module_->getContext();
+  const auto& layout = module_->getDataLayout();
+
+  // Extract the return type from the monomorphized function type.
+  const TypeFunction* fn_type = nullptr;
+  if (inst.type != nullptr && inst.type->kind() == TypeKind::Function) {
+    fn_type = static_cast<const TypeFunction*>(inst.type);
+  }
+
+  // size_of$T(): i64 — return sizeof(T) as constant.
+  if (name == "size_of" || name.starts_with("size_of$")) {
+    // T is the first type arg. Extract from the monomorphized function's
+    // generic context: size_of$i32 → T=i32. We need the semantic Type*
+    // for T. Get it from the call's explicit_type_args.
+    if (p.explicit_type_args != nullptr && !p.explicit_type_args->empty()) {
+      auto* elem_type = types_.lower((*p.explicit_type_args)[0]);
+      uint64_t size = layout.getTypeAllocSize(elem_type);
+      state.values[inst.result.id] =
+          llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), size);
+      state.value_types[inst.result.id] =
+          fn_type != nullptr ? fn_type->return_type() : nullptr;
+      return true;
+    }
+    emit_diagnostic(inst.span, "size_of: missing type argument");
+    return false;
+  }
+
+  // align_of$T(): i64 — return alignof(T) as constant.
+  if (name == "align_of" || name.starts_with("align_of$")) {
+    if (p.explicit_type_args != nullptr && !p.explicit_type_args->empty()) {
+      auto* elem_type = types_.lower((*p.explicit_type_args)[0]);
+      uint64_t align = layout.getABITypeAlign(elem_type).value();
+      state.values[inst.result.id] =
+          llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), align);
+      state.value_types[inst.result.id] =
+          fn_type != nullptr ? fn_type->return_type() : nullptr;
+      return true;
+    }
+    emit_diagnostic(inst.span, "align_of: missing type argument");
+    return false;
+  }
+
+  // null_ptr$T(): *T — return typed null pointer.
+  if (name == "null_ptr" || name.starts_with("null_ptr$")) {
+    auto* ptr_type = llvm::PointerType::getUnqual(ctx);
+    state.values[inst.result.id] =
+        llvm::ConstantPointerNull::get(ptr_type);
+    state.value_types[inst.result.id] =
+        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    return true;
+  }
+
+  // ptr_offset$T(ptr: *T, index: i64): *T — GEP with element type T.
+  if (name == "ptr_offset" || name.starts_with("ptr_offset$")) {
+    if (p.args == nullptr || p.args->size() != 2) {
+      emit_diagnostic(inst.span, "ptr_offset: expected 2 arguments");
+      return false;
+    }
+    auto* ptr_val = get_value((*p.args)[0], state);
+    auto* index_val = get_value((*p.args)[1], state);
+
+    // Get element type T from the pointer's semantic type.
+    const Type* pointee_type = nullptr;
+    auto arg_type_it = state.value_types.find((*p.args)[0].id);
+    if (arg_type_it != state.value_types.end() &&
+        arg_type_it->second != nullptr &&
+        arg_type_it->second->kind() == TypeKind::Pointer) {
+      pointee_type =
+          static_cast<const TypePointer*>(arg_type_it->second)->pointee();
+    }
+    if (pointee_type == nullptr && p.explicit_type_args != nullptr &&
+        !p.explicit_type_args->empty()) {
+      pointee_type = (*p.explicit_type_args)[0];
+    }
+    if (pointee_type == nullptr) {
+      emit_diagnostic(inst.span, "ptr_offset: cannot determine element type");
+      return false;
+    }
+    auto* elem_llvm_type = types_.lower(pointee_type);
+    state.values[inst.result.id] =
+        builder->CreateGEP(elem_llvm_type, ptr_val, {index_val}, "ptr.offset");
+    state.value_types[inst.result.id] =
+        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    return true;
+  }
+
+  // ptr_cast$T(ptr: *i8): *T — no-op with opaque pointers.
+  if (name == "ptr_cast" || name.starts_with("ptr_cast$")) {
+    if (p.args == nullptr || p.args->size() != 1) {
+      emit_diagnostic(inst.span, "ptr_cast: expected 1 argument");
+      return false;
+    }
+    // With opaque pointers, this is a semantic no-op — just pass through.
+    state.values[inst.result.id] = get_value((*p.args)[0], state);
+    state.value_types[inst.result.id] =
+        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    return true;
+  }
+
+  emit_diagnostic(inst.span,
+                  "unknown builtin intrinsic: " + std::string(name));
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto LlvmBackend::resolve_place(const MirPlace& place,
@@ -1099,11 +1212,33 @@ auto LlvmBackend::lower_field_access(const MirFieldAccess& p,
 // Function reference and calls
 // ---------------------------------------------------------------------------
 
+// Check if a function name is a compiler builtin intrinsic.
+// Matches both unmangled names (size_of) and mangled (size_of$i32).
+static auto is_builtin_intrinsic(std::string_view name) -> bool {
+  // Check for exact name or mangled variant (name$type).
+  for (auto base : {"size_of", "align_of", "null_ptr",
+                     "ptr_offset", "ptr_cast"}) {
+    if (name == base || name.starts_with(std::string(base) + "$")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 auto LlvmBackend::lower_fn_ref(const MirFnRef& p, const MirInst& inst,
                                  FunctionState& state) -> bool {
   if (p.symbol == nullptr) {
     emit_diagnostic(inst.span, "FnRef with null symbol");
     return false;
+  }
+
+  // Compiler builtin intrinsics don't have LLVM function declarations.
+  // Store a nullptr marker; lower_call will generate inline IR.
+  if (is_builtin_intrinsic(p.symbol->name)) {
+    state.values[inst.result.id] = nullptr;
+    state.value_types[inst.result.id] = inst.type;
+    state.builtin_names[inst.result.id] = p.symbol->name;
+    return true;
   }
 
   auto* fn = module_->getFunction(std::string(p.symbol->name));
@@ -1120,6 +1255,12 @@ auto LlvmBackend::lower_fn_ref(const MirFnRef& p, const MirInst& inst,
 
 auto LlvmBackend::lower_call(const MirCall& p, const MirInst& inst,
                                FunctionState& state) -> bool {
+  // Check for compiler builtin intrinsics (size_of$T, null_ptr$T, etc.).
+  auto builtin_it = state.builtin_names.find(p.callee.id);
+  if (builtin_it != state.builtin_names.end()) {
+    return lower_builtin_call(builtin_it->second, p, inst, state);
+  }
+
   auto* callee_val = get_value(p.callee, state);
   if (callee_val == nullptr) {
     emit_diagnostic(inst.span, "call callee not found");

--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -924,24 +924,18 @@ auto LlvmBackend::lower_builtin_call(
   auto& ctx = module_->getContext();
   const auto& layout = module_->getDataLayout();
 
-  // Extract the return type from the monomorphized function type.
-  const TypeFunction* fn_type = nullptr;
-  if (inst.type != nullptr && inst.type->kind() == TypeKind::Function) {
-    fn_type = static_cast<const TypeFunction*>(inst.type);
-  }
+  // inst.type on a MirCall is the result type of the call, not a
+  // TypeFunction wrapper. Use it directly as the semantic result type.
+  const Type* result_type = inst.type;
 
   // size_of$T(): i64 — return sizeof(T) as constant.
   if (name == "size_of" || name.starts_with("size_of$")) {
-    // T is the first type arg. Extract from the monomorphized function's
-    // generic context: size_of$i32 → T=i32. We need the semantic Type*
-    // for T. Get it from the call's explicit_type_args.
     if (p.explicit_type_args != nullptr && !p.explicit_type_args->empty()) {
       auto* elem_type = types_.lower((*p.explicit_type_args)[0]);
       uint64_t size = layout.getTypeAllocSize(elem_type);
       state.values[inst.result.id] =
           llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), size);
-      state.value_types[inst.result.id] =
-          fn_type != nullptr ? fn_type->return_type() : nullptr;
+      state.value_types[inst.result.id] = result_type;
       return true;
     }
     emit_diagnostic(inst.span, "size_of: missing type argument");
@@ -955,8 +949,7 @@ auto LlvmBackend::lower_builtin_call(
       uint64_t align = layout.getABITypeAlign(elem_type).value();
       state.values[inst.result.id] =
           llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), align);
-      state.value_types[inst.result.id] =
-          fn_type != nullptr ? fn_type->return_type() : nullptr;
+      state.value_types[inst.result.id] = result_type;
       return true;
     }
     emit_diagnostic(inst.span, "align_of: missing type argument");
@@ -968,8 +961,7 @@ auto LlvmBackend::lower_builtin_call(
     auto* ptr_type = llvm::PointerType::getUnqual(ctx);
     state.values[inst.result.id] =
         llvm::ConstantPointerNull::get(ptr_type);
-    state.value_types[inst.result.id] =
-        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    state.value_types[inst.result.id] = result_type;
     return true;
   }
 
@@ -982,14 +974,22 @@ auto LlvmBackend::lower_builtin_call(
     auto* ptr_val = get_value((*p.args)[0], state);
     auto* index_val = get_value((*p.args)[1], state);
 
-    // Get element type T from the pointer's semantic type.
+    // Get element type T: first from the result type (*T), then from
+    // the argument's value type, then from explicit type args.
     const Type* pointee_type = nullptr;
-    auto arg_type_it = state.value_types.find((*p.args)[0].id);
-    if (arg_type_it != state.value_types.end() &&
-        arg_type_it->second != nullptr &&
-        arg_type_it->second->kind() == TypeKind::Pointer) {
+    if (result_type != nullptr &&
+        result_type->kind() == TypeKind::Pointer) {
       pointee_type =
-          static_cast<const TypePointer*>(arg_type_it->second)->pointee();
+          static_cast<const TypePointer*>(result_type)->pointee();
+    }
+    if (pointee_type == nullptr) {
+      auto arg_type_it = state.value_types.find((*p.args)[0].id);
+      if (arg_type_it != state.value_types.end() &&
+          arg_type_it->second != nullptr &&
+          arg_type_it->second->kind() == TypeKind::Pointer) {
+        pointee_type =
+            static_cast<const TypePointer*>(arg_type_it->second)->pointee();
+      }
     }
     if (pointee_type == nullptr && p.explicit_type_args != nullptr &&
         !p.explicit_type_args->empty()) {
@@ -1002,12 +1002,11 @@ auto LlvmBackend::lower_builtin_call(
     auto* elem_llvm_type = types_.lower(pointee_type);
     state.values[inst.result.id] =
         builder->CreateGEP(elem_llvm_type, ptr_val, {index_val}, "ptr.offset");
-    state.value_types[inst.result.id] =
-        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    state.value_types[inst.result.id] = result_type;
     return true;
   }
 
-  // ptr_cast$T(ptr: *i8): *T — no-op with opaque pointers.
+  // ptr_cast$T(ptr: *void): *T — no-op with opaque pointers.
   if (name == "ptr_cast" || name.starts_with("ptr_cast$")) {
     if (p.args == nullptr || p.args->size() != 1) {
       emit_diagnostic(inst.span, "ptr_cast: expected 1 argument");
@@ -1015,8 +1014,7 @@ auto LlvmBackend::lower_builtin_call(
     }
     // With opaque pointers, this is a semantic no-op — just pass through.
     state.values[inst.result.id] = get_value((*p.args)[0], state);
-    state.value_types[inst.result.id] =
-        fn_type != nullptr ? fn_type->return_type() : nullptr;
+    state.value_types[inst.result.id] = result_type;
     return true;
   }
 

--- a/compiler/backend/llvm/llvm_backend.h
+++ b/compiler/backend/llvm/llvm_backend.h
@@ -87,6 +87,9 @@ private:
     // MIR MirValueId → semantic Type* (for signedness decisions)
     std::unordered_map<uint32_t, const Type*> value_types;
 
+    // MIR MirValueId → builtin intrinsic name (for compiler builtins)
+    std::unordered_map<uint32_t, std::string_view> builtin_names;
+
     // MIR BlockId → LLVM BasicBlock*
     std::unordered_map<uint32_t, llvm::BasicBlock*> blocks;
 
@@ -170,6 +173,11 @@ private:
                                llvm::Value* lhs, llvm::Value* rhs,
                                const char* name,
                                FunctionState& state) -> llvm::Value*;
+
+  // Compiler builtin intrinsic lowering.
+  auto lower_builtin_call(std::string_view name, const MirCall& p,
+                          const MirInst& inst,
+                          FunctionState& state) -> bool;
 
   // Place resolution — walk projection chains to an LLVM pointer.
   auto resolve_place(const MirPlace& place,

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -339,9 +339,9 @@ void LlvmRuntimeHooks::declare_alloc_hooks() {
   ensure_declared(runtime_hooks::kMemAlloc,
                   llvm::FunctionType::get(ptr, {i64, i64}, false));
 
-  // __dao_mem_realloc(ptr, new_size: i64, align: i64): ptr
+  // __dao_mem_realloc(ptr, old_size: i64, new_size: i64, align: i64): ptr
   ensure_declared(runtime_hooks::kMemRealloc,
-                  llvm::FunctionType::get(ptr, {ptr, i64, i64}, false));
+                  llvm::FunctionType::get(ptr, {ptr, i64, i64, i64}, false));
 
   // __dao_mem_free(ptr): void
   ensure_declared(runtime_hooks::kMemFree,

--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -24,6 +24,8 @@ void LlvmRuntimeHooks::declare_all() {
   declare_overflow_hooks();
   declare_generator_hooks();
   declare_mem_resource_hooks();
+  declare_alloc_hooks();
+  declare_panic_hooks();
   declare_string_hooks();
 }
 
@@ -321,6 +323,43 @@ void LlvmRuntimeHooks::declare_mem_resource_hooks() {
   // __dao_mem_resource_exit(domain: ptr): void
   ensure_declared(runtime_hooks::kMemResourceExit,
                   llvm::FunctionType::get(void_ty, {ptr}, false));
+}
+
+// ---------------------------------------------------------------------------
+// Allocation hooks
+// ---------------------------------------------------------------------------
+
+void LlvmRuntimeHooks::declare_alloc_hooks() {
+  auto& ctx = module_.getContext();
+  auto* ptr = llvm::PointerType::getUnqual(ctx);
+  auto* i64 = llvm::Type::getInt64Ty(ctx);
+  auto* void_ty = llvm::Type::getVoidTy(ctx);
+
+  // __dao_mem_alloc(size: i64, align: i64): ptr
+  ensure_declared(runtime_hooks::kMemAlloc,
+                  llvm::FunctionType::get(ptr, {i64, i64}, false));
+
+  // __dao_mem_realloc(ptr, new_size: i64, align: i64): ptr
+  ensure_declared(runtime_hooks::kMemRealloc,
+                  llvm::FunctionType::get(ptr, {ptr, i64, i64}, false));
+
+  // __dao_mem_free(ptr): void
+  ensure_declared(runtime_hooks::kMemFree,
+                  llvm::FunctionType::get(void_ty, {ptr}, false));
+}
+
+// ---------------------------------------------------------------------------
+// Panic hooks
+// ---------------------------------------------------------------------------
+
+void LlvmRuntimeHooks::declare_panic_hooks() {
+  auto* void_ty = llvm::Type::getVoidTy(module_.getContext());
+  auto* str_ptr = llvm::PointerType::getUnqual(types_.string_type());
+
+  // __dao_panic(msg: *dao.string): void
+  auto* fn = ensure_declared(runtime_hooks::kPanic,
+                             llvm::FunctionType::get(void_ty, {str_ptr}, false));
+  fn->addFnAttr(llvm::Attribute::NoReturn);
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -135,6 +135,14 @@ inline constexpr std::string_view kGenFree  = "__dao_gen_free";
 inline constexpr std::string_view kMemResourceEnter = "__dao_mem_resource_enter";
 inline constexpr std::string_view kMemResourceExit  = "__dao_mem_resource_exit";
 
+// Allocation domain
+inline constexpr std::string_view kMemAlloc   = "__dao_mem_alloc";
+inline constexpr std::string_view kMemRealloc = "__dao_mem_realloc";
+inline constexpr std::string_view kMemFree    = "__dao_mem_free";
+
+// Panic domain
+inline constexpr std::string_view kPanic = "__dao_panic";
+
 // String domain
 inline constexpr std::string_view kStrConcat     = "__dao_str_concat";
 inline constexpr std::string_view kStrLength     = "__dao_str_length";
@@ -175,6 +183,8 @@ inline constexpr std::string_view kAllHooks[] = {
     kSaturatingAddI64, kSaturatingSubI64, kSaturatingMulI64,
     kGenAlloc, kGenFree,
     kMemResourceEnter, kMemResourceExit,
+    kMemAlloc, kMemRealloc, kMemFree,
+    kPanic,
     kStrConcat, kStrLength,
     kStrCharAt, kStrSubstring, kStrIndexOf,
     kStrStartsWith, kStrEndsWith, kStrCompare,
@@ -208,6 +218,8 @@ private:
   void declare_generator_hooks();
   void declare_mem_resource_hooks();
   void declare_string_hooks();
+  void declare_alloc_hooks();
+  void declare_panic_hooks();
 
   // Helper: get-or-create a function declaration.
   auto ensure_declared(std::string_view name, llvm::FunctionType* fn_type)

--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -25,6 +25,10 @@ auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
 
   case TypeKind::Pointer: {
     const auto* p = static_cast<const TypePointer*>(type);
+    // *void is an opaque pointer — don't try to lower void as a pointee.
+    if (p->pointee()->kind() == TypeKind::Void) {
+      return llvm::PointerType::getUnqual(ctx_);
+    }
     auto* pointee = lower(p->pointee());
     if (pointee == nullptr) {
       return nullptr;

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -342,6 +342,7 @@ struct UnaryExpr {
 struct CallExpr {
   Expr* callee;
   std::vector<Expr*> args;
+  std::vector<TypeNode*> type_args; // Explicit type arguments: f<i32>(x)
 };
 
 struct IndexExpr {

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -443,6 +443,16 @@ private:
             Scope callee_scope(depth_);
             print_expr(*node.callee);
           }
+          if (!node.type_args.empty()) {
+            indent();
+            out_ << "TypeArgs\n";
+            Scope ta_scope(depth_);
+            for (const auto* ta : node.type_args) {
+              indent();
+              print_type_inline(*ta);
+              out_ << "\n";
+            }
+          }
           if (!node.args.empty()) {
             indent();
             out_ << "Args\n";

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -632,8 +632,15 @@ private:
     // Check for assignment: expr = expr
     if (peek_kind() == TokenKind::Eq) {
       // Validate LHS is a legal assignment target.
-      if (expr->kind() != NodeKind::Identifier && expr->kind() != NodeKind::FieldExpr &&
-          expr->kind() != NodeKind::IndexExpr) {
+      bool valid_target = expr->kind() == NodeKind::Identifier ||
+                          expr->kind() == NodeKind::FieldExpr ||
+                          expr->kind() == NodeKind::IndexExpr;
+      // Dereference (*ptr) is a valid assignment target for store-through-pointer.
+      if (!valid_target && expr->kind() == NodeKind::UnaryExpr) {
+        const auto& un = expr->as<UnaryExpr>();
+        valid_target = un.op == UnaryOp::Deref;
+      }
+      if (!valid_target) {
         error("invalid assignment target");
       }
       advance(); // =
@@ -1035,10 +1042,62 @@ private:
   }
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  // Try to speculatively parse <Type, ...> as call-site type arguments.
+  // Returns type args and advances pos_ on success; returns empty and
+  // leaves pos_ unchanged on failure.
+  auto try_parse_call_type_args() -> std::vector<TypeNode*> {
+    auto saved_pos = pos_;
+    auto saved_diag_size = diagnostics_.size();
+    advance(); // consume <
+    std::vector<TypeNode*> type_args;
+    type_args.push_back(parse_type());
+    while (peek_kind() == TokenKind::Comma) {
+      advance();
+      type_args.push_back(parse_type());
+    }
+    if (peek_kind() == TokenKind::Gt) {
+      advance(); // consume >
+      if (peek_kind() == TokenKind::LParen) {
+        // Success: <Types>(  — these are call-site type arguments.
+        return type_args;
+      }
+    }
+    // Failed: restore position and discard any diagnostics added.
+    pos_ = saved_pos;
+    diagnostics_.resize(saved_diag_size);
+    return {};
+  }
+
   auto parse_postfix() -> Expr* {
     auto* expr = parse_primary();
 
     while (true) {
+      if (peek_kind() == TokenKind::Lt &&
+          expr->kind() == NodeKind::Identifier) {
+        // Speculatively try call-site type arguments: ident<Type>(args).
+        auto type_args = try_parse_call_type_args();
+        if (!type_args.empty()) {
+          // Commit: parse the call arguments.
+          advance(); // (
+          std::vector<Expr*> args;
+          if (peek_kind() != TokenKind::RParen) {
+            args.push_back(parse_expression());
+            while (peek_kind() == TokenKind::Comma) {
+              advance();
+              args.push_back(parse_expression());
+            }
+          }
+          const auto& rparen = consume(TokenKind::RParen);
+          Span span = {.offset = expr->span.offset,
+                       .length = (rparen.span.offset + rparen.span.length) - expr->span.offset};
+          expr = ctx_.alloc<Expr>(span, CallExpr{.callee = expr,
+                                                    .args = std::move(args),
+                                                    .type_args = std::move(type_args)});
+          continue;
+        }
+        // Fall through to normal expression parsing (< as comparison).
+        break;
+      }
       if (peek_kind() == TokenKind::LParen) {
         // Call: expr(args)
         advance(); // (

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -53,6 +53,14 @@ constexpr std::string_view kPredeclaredTypes[] = {
     "Generator",
 };
 
+// Compiler builtin functions — generic functions whose bodies are
+// replaced by the LLVM backend with inline IR. These are registered
+// as predeclared function symbols so they're available without import.
+constexpr std::string_view kBuiltinFunctions[] = {
+    "null_ptr",
+    "ptr_cast",
+};
+
 // ---------------------------------------------------------------------------
 // Resolver — two-pass name resolution over the AST
 // ---------------------------------------------------------------------------
@@ -95,6 +103,10 @@ private:
     }
     for (auto name : kPredeclaredTypes) {
       auto* sym = ctx_.make_symbol(SymbolKind::Predeclared, name, Span{}, nullptr);
+      file_scope_->declare(name, sym);
+    }
+    for (auto name : kBuiltinFunctions) {
+      auto* sym = ctx_.make_symbol(SymbolKind::Function, name, Span{}, nullptr);
       file_scope_->declare(name, sym);
     }
   }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -2036,12 +2036,12 @@ auto TypeChecker::resolve_builtin_function_type(std::string_view name)
     auto* ptr_t = types_.pointer_to(generic_t);
     return types_.function_type({}, ptr_t);
   }
-  // ptr_cast<T>(ptr: *i8): *T
+  // ptr_cast<T>(ptr: *void): *T
   if (name == "ptr_cast") {
     auto* generic_t = types_.generic_param(nullptr, "T", 0);
     auto* ptr_t = types_.pointer_to(generic_t);
-    auto* i8_ptr = types_.pointer_to(types_.i8());
-    return types_.function_type({i8_ptr}, ptr_t);
+    auto* void_ptr = types_.pointer_to(types_.void_type());
+    return types_.function_type({void_ptr}, ptr_t);
   }
   return nullptr;
 }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -177,6 +177,8 @@ auto TypeChecker::resolve_symbol_type(const Symbol* sym) -> const Type* {
   case SymbolKind::Function: {
     // Function symbol -> derive TypeFunction from declaration.
     if (sym->decl == nullptr) {
+      // Compiler builtin functions with no AST declaration.
+      result = resolve_builtin_function_type(sym->name);
       break;
     }
     const auto& fn = sym->decl_as_decl()->as<FunctionDecl>();
@@ -1493,6 +1495,42 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
   // type_bindings maps generic param index → concrete type.
   std::unordered_map<uint32_t, const Type*> type_bindings;
 
+  // Populate bindings from explicit type arguments: f<i32, f64>(x).
+  if (!call.type_args.empty() && call.callee->is<IdentifierExpr>()) {
+    auto sym_it = resolve_.uses.find(call.callee->span.offset);
+    if (sym_it != resolve_.uses.end() &&
+        sym_it->second->kind == SymbolKind::Function) {
+      // Determine expected type param count.
+      size_t expected_count = 0;
+      if (sym_it->second->decl != nullptr) {
+        const auto* fn_decl = static_cast<const Decl*>(sym_it->second->decl);
+        if (fn_decl->is<FunctionDecl>()) {
+          expected_count = fn_decl->as<FunctionDecl>().type_params.size();
+        }
+      } else {
+        // Compiler builtin functions (null_ptr, ptr_cast) take 1 type param.
+        expected_count = 1;
+      }
+
+      if (call.type_args.size() != expected_count) {
+        error(expr->span,
+              "expected " + std::to_string(expected_count) +
+                  " type argument(s), got " +
+                  std::to_string(call.type_args.size()));
+      } else {
+        std::vector<const Type*> resolved_type_args;
+        for (size_t i = 0; i < call.type_args.size(); ++i) {
+          const auto* resolved = resolve_type_node(call.type_args[i]);
+          if (resolved != nullptr) {
+            type_bindings[static_cast<uint32_t>(i)] = resolved;
+            resolved_type_args.push_back(resolved);
+          }
+        }
+        typed_.set_call_type_args(expr, std::move(resolved_type_args));
+      }
+    }
+  }
+
   for (size_t i = 0; i < params.size(); ++i) {
     // Reject lambdas in function-pointer positions of extern fn calls.
     // Lambdas cannot cross the C ABI boundary as closures have no
@@ -1984,6 +2022,28 @@ auto TypeChecker::find_generic_param_index(const Symbol* sym) -> uint32_t {
     }
   }
   return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Compiler builtin function types
+// ---------------------------------------------------------------------------
+
+auto TypeChecker::resolve_builtin_function_type(std::string_view name)
+    -> const Type* {
+  // null_ptr<T>(): *T
+  if (name == "null_ptr") {
+    auto* generic_t = types_.generic_param(nullptr, "T", 0);
+    auto* ptr_t = types_.pointer_to(generic_t);
+    return types_.function_type({}, ptr_t);
+  }
+  // ptr_cast<T>(ptr: *i8): *T
+  if (name == "ptr_cast") {
+    auto* generic_t = types_.generic_param(nullptr, "T", 0);
+    auto* ptr_t = types_.pointer_to(generic_t);
+    auto* i8_ptr = types_.pointer_to(types_.i8());
+    return types_.function_type({i8_ptr}, ptr_t);
+  }
+  return nullptr;
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -198,6 +198,7 @@ private:
 
   auto is_lvalue(const Expr* expr) -> bool;
   auto find_generic_param_index(const Symbol* sym) -> uint32_t;
+  auto resolve_builtin_function_type(std::string_view name) -> const Type*;
 };
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -26,6 +26,15 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
     return true;
   }
 
+  // Any pointer *T is assignable to *void (opaque pointer upcast).
+  if (source->kind() == TypeKind::Pointer &&
+      target->kind() == TypeKind::Pointer) {
+    const auto* target_ptr = static_cast<const TypePointer*>(target);
+    if (target_ptr->pointee()->kind() == TypeKind::Void) {
+      return true;
+    }
+  }
+
   // Structural recursion for composite types containing generic params.
   if (source->kind() == target->kind()) {
     switch (target->kind()) {

--- a/compiler/frontend/typecheck/typed_results.h
+++ b/compiler/frontend/typecheck/typed_results.h
@@ -70,11 +70,25 @@ public:
     return it != method_resolutions_.end() ? it->second : nullptr;
   }
 
+  // --- Call-site explicit type arguments ---
+
+  void set_call_type_args(const Expr* call_expr,
+                          std::vector<const Type*> type_args) {
+    call_type_args_[call_expr] = std::move(type_args);
+  }
+
+  [[nodiscard]] auto call_type_args(const Expr* call_expr) const
+      -> const std::vector<const Type*>* {
+    auto it = call_type_args_.find(call_expr);
+    return it != call_type_args_.end() ? &it->second : nullptr;
+  }
+
 private:
   std::unordered_map<const Expr*, const Type*> expr_types_;
   std::unordered_map<const Stmt*, const Type*> local_types_;
   std::unordered_map<const Decl*, const Type*> decl_types_;
   std::unordered_map<const Expr*, const Decl*> method_resolutions_;
+  std::unordered_map<const Expr*, std::vector<const Type*>> call_type_args_;
 };
 
 } // namespace dao

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -145,6 +145,7 @@ struct HirBinary {
 struct HirCall {
   HirExpr* callee;
   std::vector<HirExpr*> args;
+  std::vector<const Type*> explicit_type_args; // From f<i32>(x) syntax
 };
 
 struct HirConstruct {

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -362,8 +362,16 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
     for (const auto* arg : call.args) {
       args.push_back(lower_expr(arg));
     }
+
+    // Propagate explicit type arguments resolved by the type checker.
+    std::vector<const Type*> explicit_type_args;
+    const auto* resolved_ta = typed_.typed.call_type_args(expr);
+    if (resolved_ta != nullptr) {
+      explicit_type_args = *resolved_ta;
+    }
     return ctx_.alloc<HirExpr>(span, type,
-                                HirCall{callee, std::move(args)});
+                                HirCall{callee, std::move(args),
+                                        std::move(explicit_type_args)});
   }
 
   case NodeKind::PipeExpr: {

--- a/compiler/ir/mir/mir.h
+++ b/compiler/ir/mir/mir.h
@@ -91,7 +91,8 @@ struct MirFieldAccess { MirValueId object; std::string_view field; uint32_t fiel
 struct MirIndexAccess { MirValueId object; MirValueId index; };
 
 struct MirFnRef { const Symbol* symbol; };
-struct MirCall  { MirValueId callee; std::vector<MirValueId>* args; };
+struct MirCall  { MirValueId callee; std::vector<MirValueId>* args;
+                  std::vector<const Type*>* explicit_type_args = nullptr; };
 struct MirConstruct { const TypeStruct* struct_type; std::vector<MirValueId>* field_values; };
 
 struct MirIterInit    { MirValueId iter_operand; };

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -410,7 +410,12 @@ auto MirBuilder::lower_expr_value(const HirExpr& expr) -> MirValueId {
         for (const auto* arg : call.args) {
           args->push_back(lower_expr_value(*arg));
         }
-        return emit_value(expr, MirCall{callee_val, args});
+        std::vector<const Type*>* type_args = nullptr;
+        if (!call.explicit_type_args.empty()) {
+          type_args = ctx_.alloc<std::vector<const Type*>>(
+              call.explicit_type_args);
+        }
+        return emit_value(expr, MirCall{callee_val, args, type_args});
       },
       [&](const HirConstruct& ctor) -> MirValueId {
         auto* field_vals = ctx_.alloc<std::vector<MirValueId>>();

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -537,13 +537,36 @@ auto MirBuilder::lower_expr_place(const HirExpr& expr) -> MirPlace {
       },
       [&](const HirUnary& un) -> MirPlace {
         if (un.op == UnaryOp::Deref) {
-          auto base = lower_expr_place(*un.operand);
-          base.projections.push_back(
+          // Try to lower as a place first (e.g., *local_var).
+          // If that fails (e.g., *fn_call()), lower as a value,
+          // store to a temp, and create a place with Deref.
+          bool operand_is_place =
+              std::holds_alternative<HirSymbolRef>(un.operand->payload) ||
+              std::holds_alternative<HirField>(un.operand->payload) ||
+              std::holds_alternative<HirUnary>(un.operand->payload);
+          if (operand_is_place) {
+            auto base = lower_expr_place(*un.operand);
+            base.projections.push_back(
+                {.kind = MirProjectionKind::Deref,
+                 .field_name = {},
+                 .field_index = 0,
+                 .index_value = {}});
+            return base;
+          }
+          // Operand is a value expression (call, etc.) — store to temp.
+          auto val = lower_expr_value(*un.operand);
+          auto tmp_id = declare_local(nullptr, un.operand->type, expr.span);
+          auto* tmp_place = ctx_.alloc<MirPlace>();
+          tmp_place->local = tmp_id;
+          emit_effect(expr.span, MirStore{tmp_place, val});
+          MirPlace result;
+          result.local = tmp_id;
+          result.projections.push_back(
               {.kind = MirProjectionKind::Deref,
                .field_name = {},
                .field_index = 0,
                .index_value = {}});
-          return base;
+          return result;
         }
         error(expr.span, "expression is not a valid place");
         return {};

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -208,6 +208,10 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
           auto* new_args = ctx.alloc<std::vector<MirValueId>>(*call->args);
           call->args = new_args;
         }
+        if (call->explicit_type_args != nullptr) {
+          call->explicit_type_args =
+              ctx.alloc<std::vector<const Type*>>(*call->explicit_type_args);
+        }
       } else if (auto* ctor = std::get_if<MirConstruct>(&dst_inst->payload)) {
         if (ctor->field_values != nullptr) {
           auto* new_fv =
@@ -484,6 +488,16 @@ auto specialize_call_site(
 
   // Infer substitution from argument types.
   auto subst = infer_substitution(git->second, arg_types);
+
+  // If inference failed (e.g. zero-arg builtin), use explicit type args.
+  if (subst.empty() && call_payload->explicit_type_args != nullptr &&
+      !call_payload->explicit_type_args->empty()) {
+    for (size_t i = 0; i < call_payload->explicit_type_args->size(); ++i) {
+      subst[static_cast<uint32_t>(i)] =
+          (*call_payload->explicit_type_args)[i];
+    }
+  }
+
   if (subst.empty()) {
     return false;
   }

--- a/docs/task_specs/TASK_17_LOW_LEVEL_MEMORY_SUBSTRATE.md
+++ b/docs/task_specs/TASK_17_LOW_LEVEL_MEMORY_SUBSTRATE.md
@@ -128,7 +128,7 @@ Add three runtime hooks under the `mem` domain:
 | Hook | Signature | Semantics |
 |------|-----------|-----------|
 | `__dao_mem_alloc` | `(size: i64, align: i64): *void` | Allocate `size` bytes with `align` alignment. Trap on failure. |
-| `__dao_mem_realloc` | `(ptr: *void, new_size: i64, align: i64): *void` | Resize allocation. Trap on failure. `ptr` may be null (acts as alloc). |
+| `__dao_mem_realloc` | `(ptr: *void, old_size: i64, new_size: i64, align: i64): *void` | Resize allocation. Copies `min(old_size, new_size)` bytes. Trap on failure. `ptr` may be null (acts as alloc). |
 | `__dao_mem_free` | `(ptr: *void): void` | Free allocation. Null is a no-op. |
 
 **C implementation:** in `runtime/memory/alloc.c`. The allocation
@@ -160,7 +160,7 @@ Implementation constraints:
 
 ```dao
 extern fn __dao_mem_alloc(size: i64, align: i64): *void
-extern fn __dao_mem_realloc(ptr: *void, new_size: i64, align: i64): *void
+extern fn __dao_mem_realloc(ptr: *void, old_size: i64, new_size: i64, align: i64): *void
 extern fn __dao_mem_free(ptr: *void): void
 ```
 

--- a/examples/raw_memory.dao
+++ b/examples/raw_memory.dao
@@ -1,0 +1,39 @@
+// raw_memory.dao — Low-level memory substrate proof of concept.
+//
+// Demonstrates: alloc, ptr_cast, ptr_offset, store through pointer,
+// deref, size_of, align_of, null_ptr, pointer equality, free.
+
+fn main(): i32
+  // Allocate space for 4 i32 values.
+  let raw = __dao_mem_alloc(size_of<i32>() * 4, align_of<i32>())
+  mode unsafe =>
+    let data = ptr_cast<i32>(raw)
+
+    // Store values via pointer offset.
+    *data = 10
+    *ptr_offset<i32>(data, 1) = 20
+    *ptr_offset<i32>(data, 2) = 30
+    *ptr_offset<i32>(data, 3) = 40
+
+    // Read them back.
+    print(*data)
+    print(*ptr_offset<i32>(data, 1))
+    print(*ptr_offset<i32>(data, 2))
+    print(*ptr_offset<i32>(data, 3))
+
+    // Null pointer check.
+    let np = null_ptr<i32>()
+    if np == null_ptr<i32>():
+      print("null check passed")
+    if data != null_ptr<i32>():
+      print("non-null check passed")
+
+  __dao_mem_free(raw)
+
+  // Size and alignment queries.
+  print(size_of<i32>())
+  print(size_of<f64>())
+  print(align_of<i32>())
+  print(align_of<f64>())
+
+  return 0

--- a/runtime/core/CMakeLists.txt
+++ b/runtime/core/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(dao_runtime STATIC
   generator.c
   resource.c
   string.c
+  panic.c
+  ${CMAKE_SOURCE_DIR}/runtime/memory/alloc.c
 )
 
 # This is C code, not C++.

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -242,9 +242,11 @@ void __dao_mem_resource_exit(void *domain);
 void *__dao_mem_alloc(int64_t size, int64_t align);
 
 // Resize allocation. Traps on failure. ptr may be null (acts as alloc).
+// old_size is the number of bytes to preserve from the old allocation.
 // Preserves alignment for alignments within max_align_t; for stronger
-// alignments, allocates a new aligned block and copies.
-void *__dao_mem_realloc(void *ptr, int64_t new_size, int64_t align);
+// alignments, allocates a new aligned block and copies old_size bytes.
+void *__dao_mem_realloc(void *ptr, int64_t old_size, int64_t new_size,
+                        int64_t align);
 
 // Free allocation. Null is a no-op.
 void __dao_mem_free(void *ptr);

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -232,6 +232,30 @@ void *__dao_mem_resource_enter(void);
 // Exit a scoped resource domain. Takes the handle returned by enter.
 void __dao_mem_resource_exit(void *domain);
 
+// ---------------------------------------------------------------------------
+// Runtime hook declarations — Allocation domain
+// ---------------------------------------------------------------------------
+
+// Allocate size bytes with the given alignment. Traps on failure.
+// aligned_alloc requires size to be a multiple of alignment; the
+// implementation rounds up internally.
+void *__dao_mem_alloc(int64_t size, int64_t align);
+
+// Resize allocation. Traps on failure. ptr may be null (acts as alloc).
+// Preserves alignment for alignments within max_align_t; for stronger
+// alignments, allocates a new aligned block and copies.
+void *__dao_mem_realloc(void *ptr, int64_t new_size, int64_t align);
+
+// Free allocation. Null is a no-op.
+void __dao_mem_free(void *ptr);
+
+// ---------------------------------------------------------------------------
+// Runtime hook declarations — Panic domain
+// ---------------------------------------------------------------------------
+
+// Print message to stderr and abort. Does not return.
+void __dao_panic(const struct dao_string *msg);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/runtime/core/panic.c
+++ b/runtime/core/panic.c
@@ -1,0 +1,21 @@
+// panic.c — Dao runtime panic hook.
+//
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
+
+#include "dao_abi.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __dao_panic(const struct dao_string *msg) {
+  // Flush stdout so any buffered output is visible before the abort.
+  fflush(stdout);
+  if (msg != NULL && msg->ptr != NULL && msg->len > 0) {
+    fprintf(stderr, "dao panic: ");
+    fwrite(msg->ptr, 1, (size_t)msg->len, stderr);
+    fputc('\n', stderr);
+  } else {
+    fprintf(stderr, "dao panic\n");
+  }
+  abort();
+}

--- a/runtime/memory/alloc.c
+++ b/runtime/memory/alloc.c
@@ -1,0 +1,69 @@
+// alloc.c — Dao runtime allocation hooks.
+//
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
+// Placement: runtime/memory/ per docs/ARCH_INDEX.md
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../core/dao_abi.h"
+
+// Round size up to a multiple of alignment.
+static int64_t round_up(int64_t size, int64_t align) {
+  return (size + align - 1) & ~(align - 1);
+}
+
+void *__dao_mem_alloc(int64_t size, int64_t align) {
+  if (size <= 0) {
+    size = align; // Allocate at least one unit.
+  }
+  // aligned_alloc requires size to be a multiple of alignment.
+  int64_t rounded = round_up(size, align);
+  void *ptr = aligned_alloc((size_t)align, (size_t)rounded);
+  if (ptr == NULL) {
+    fprintf(stderr, "dao panic: allocation failed (size=%lld, align=%lld)\n",
+            (long long)size, (long long)align);
+    abort();
+  }
+  return ptr;
+}
+
+void *__dao_mem_realloc(void *ptr, int64_t new_size, int64_t align) {
+  if (ptr == NULL) {
+    return __dao_mem_alloc(new_size, align);
+  }
+  if (new_size <= 0) {
+    free(ptr);
+    return NULL;
+  }
+  // Standard realloc does not preserve alignment beyond max_align_t.
+  // For alignments within max_align_t, plain realloc is sufficient.
+  // For stronger alignments, allocate new + memcpy + free.
+  if (align <= (int64_t)_Alignof(max_align_t)) {
+    void *result = realloc(ptr, (size_t)new_size);
+    if (result == NULL) {
+      fprintf(stderr,
+              "dao panic: reallocation failed (new_size=%lld, align=%lld)\n",
+              (long long)new_size, (long long)align);
+      abort();
+    }
+    return result;
+  }
+  // Strong alignment: allocate fresh aligned block and copy.
+  void *fresh = __dao_mem_alloc(new_size, align);
+  // We must copy min(old_size, new_size) bytes, but we don't know old_size.
+  // The caller must ensure new_size >= the data they need to preserve.
+  // Copy new_size bytes (may read past old allocation if caller misuses,
+  // but this matches the contract where the caller is responsible for
+  // correct sizing).
+  memcpy(fresh, ptr, (size_t)new_size);
+  free(ptr);
+  return fresh;
+}
+
+void __dao_mem_free(void *ptr) {
+  free(ptr);
+}

--- a/runtime/memory/alloc.c
+++ b/runtime/memory/alloc.c
@@ -31,7 +31,8 @@ void *__dao_mem_alloc(int64_t size, int64_t align) {
   return ptr;
 }
 
-void *__dao_mem_realloc(void *ptr, int64_t new_size, int64_t align) {
+void *__dao_mem_realloc(void *ptr, int64_t old_size, int64_t new_size,
+                        int64_t align) {
   if (ptr == NULL) {
     return __dao_mem_alloc(new_size, align);
   }
@@ -54,12 +55,10 @@ void *__dao_mem_realloc(void *ptr, int64_t new_size, int64_t align) {
   }
   // Strong alignment: allocate fresh aligned block and copy.
   void *fresh = __dao_mem_alloc(new_size, align);
-  // We must copy min(old_size, new_size) bytes, but we don't know old_size.
-  // The caller must ensure new_size >= the data they need to preserve.
-  // Copy new_size bytes (may read past old allocation if caller misuses,
-  // but this matches the contract where the caller is responsible for
-  // correct sizing).
-  memcpy(fresh, ptr, (size_t)new_size);
+  int64_t copy_size = old_size < new_size ? old_size : new_size;
+  if (copy_size > 0) {
+    memcpy(fresh, ptr, (size_t)copy_size);
+  }
   free(ptr);
   return fresh;
 }

--- a/stdlib/core/builtins.dao
+++ b/stdlib/core/builtins.dao
@@ -1,0 +1,19 @@
+// builtins.dao — Compiler-recognized builtin functions.
+//
+// These are generic functions whose bodies are replaced by the
+// compiler backend with inline LLVM IR after monomorphization.
+// The expression bodies exist only to satisfy the type checker;
+// the backend replaces them entirely.
+
+// Return the size of type T in bytes.
+fn size_of<T>(): i64
+  let r: i64 = 0
+  return r
+
+// Return the alignment of type T in bytes.
+fn align_of<T>(): i64
+  let r: i64 = 0
+  return r
+
+// Compute a typed pointer offset: ptr + index (in units of T).
+fn ptr_offset<T>(ptr: *T, index: i64): *T -> ptr

--- a/stdlib/core/memory.dao
+++ b/stdlib/core/memory.dao
@@ -1,0 +1,9 @@
+// memory.dao — Low-level allocation hooks.
+//
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
+// These are the raw runtime hooks. Typed allocation wrappers
+// will be added once size_of<T> and ptr_cast<T> are available.
+
+extern fn __dao_mem_alloc(size: i64, align: i64): *i8
+extern fn __dao_mem_realloc(ptr: *i8, new_size: i64, align: i64): *i8
+extern fn __dao_mem_free(ptr: *i8): void

--- a/stdlib/core/memory.dao
+++ b/stdlib/core/memory.dao
@@ -1,9 +1,7 @@
 // memory.dao — Low-level allocation hooks.
 //
 // Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
-// These are the raw runtime hooks. Typed allocation wrappers
-// will be added once size_of<T> and ptr_cast<T> are available.
 
-extern fn __dao_mem_alloc(size: i64, align: i64): *i8
-extern fn __dao_mem_realloc(ptr: *i8, new_size: i64, align: i64): *i8
-extern fn __dao_mem_free(ptr: *i8): void
+extern fn __dao_mem_alloc(size: i64, align: i64): *void
+extern fn __dao_mem_realloc(ptr: *void, old_size: i64, new_size: i64, align: i64): *void
+extern fn __dao_mem_free(ptr: *void): void

--- a/stdlib/core/panic.dao
+++ b/stdlib/core/panic.dao
@@ -1,0 +1,7 @@
+// panic.dao — Program abort primitive.
+//
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md
+
+extern fn __dao_panic(msg: string): void
+
+fn panic(msg: string): void -> __dao_panic(msg)

--- a/testdata/ast/examples_raw_memory.ast
+++ b/testdata/ast/examples_raw_memory.ast
@@ -1,0 +1,209 @@
+File
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement raw
+      CallExpr
+        Callee
+          Identifier __dao_mem_alloc
+        Args
+          BinaryExpr *
+            CallExpr
+              Callee
+                Identifier size_of
+              TypeArgs
+                i32
+            IntLiteral 4
+          CallExpr
+            Callee
+              Identifier align_of
+            TypeArgs
+              i32
+    ModeBlock unsafe
+      LetStatement data
+        CallExpr
+          Callee
+            Identifier ptr_cast
+          TypeArgs
+            i32
+          Args
+            Identifier raw
+      Assignment
+        Target
+          UnaryExpr *
+            Identifier data
+        Value
+          IntLiteral 10
+      Assignment
+        Target
+          UnaryExpr *
+            CallExpr
+              Callee
+                Identifier ptr_offset
+              TypeArgs
+                i32
+              Args
+                Identifier data
+                IntLiteral 1
+        Value
+          IntLiteral 20
+      Assignment
+        Target
+          UnaryExpr *
+            CallExpr
+              Callee
+                Identifier ptr_offset
+              TypeArgs
+                i32
+              Args
+                Identifier data
+                IntLiteral 2
+        Value
+          IntLiteral 30
+      Assignment
+        Target
+          UnaryExpr *
+            CallExpr
+              Callee
+                Identifier ptr_offset
+              TypeArgs
+                i32
+              Args
+                Identifier data
+                IntLiteral 3
+        Value
+          IntLiteral 40
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            UnaryExpr *
+              Identifier data
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                TypeArgs
+                  i32
+                Args
+                  Identifier data
+                  IntLiteral 1
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                TypeArgs
+                  i32
+                Args
+                  Identifier data
+                  IntLiteral 2
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                TypeArgs
+                  i32
+                Args
+                  Identifier data
+                  IntLiteral 3
+      LetStatement np
+        CallExpr
+          Callee
+            Identifier null_ptr
+          TypeArgs
+            i32
+      IfStatement
+        Condition
+          BinaryExpr ==
+            Identifier np
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                i32
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier print
+              Args
+                StringLiteral "null check passed"
+      IfStatement
+        Condition
+          BinaryExpr !=
+            Identifier data
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                i32
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier print
+              Args
+                StringLiteral "non-null check passed"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier __dao_mem_free
+        Args
+          Identifier raw
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier size_of
+            TypeArgs
+              i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier size_of
+            TypeArgs
+              f64
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier align_of
+            TypeArgs
+              i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier align_of
+            TypeArgs
+              f64
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/stdlib_core_builtins.ast
+++ b/testdata/ast/stdlib_core_builtins.ast
@@ -1,0 +1,19 @@
+File
+  FunctionDecl size_of<T>
+    ReturnType: i64
+    LetStatement r: i64
+      IntLiteral 0
+    ReturnStatement
+      Identifier r
+  FunctionDecl align_of<T>
+    ReturnType: i64
+    LetStatement r: i64
+      IntLiteral 0
+    ReturnStatement
+      Identifier r
+  FunctionDecl ptr_offset<T>
+    Param ptr: *T
+    Param index: i64
+    ReturnType: *T
+    ExprBody
+      Identifier ptr

--- a/testdata/ast/stdlib_core_memory.ast
+++ b/testdata/ast/stdlib_core_memory.ast
@@ -2,12 +2,13 @@ File
   ExternFunctionDecl __dao_mem_alloc
     Param size: i64
     Param align: i64
-    ReturnType: *i8
+    ReturnType: *void
   ExternFunctionDecl __dao_mem_realloc
-    Param ptr: *i8
+    Param ptr: *void
+    Param old_size: i64
     Param new_size: i64
     Param align: i64
-    ReturnType: *i8
+    ReturnType: *void
   ExternFunctionDecl __dao_mem_free
-    Param ptr: *i8
+    Param ptr: *void
     ReturnType: void

--- a/testdata/ast/stdlib_core_memory.ast
+++ b/testdata/ast/stdlib_core_memory.ast
@@ -1,0 +1,13 @@
+File
+  ExternFunctionDecl __dao_mem_alloc
+    Param size: i64
+    Param align: i64
+    ReturnType: *i8
+  ExternFunctionDecl __dao_mem_realloc
+    Param ptr: *i8
+    Param new_size: i64
+    Param align: i64
+    ReturnType: *i8
+  ExternFunctionDecl __dao_mem_free
+    Param ptr: *i8
+    ReturnType: void

--- a/testdata/ast/stdlib_core_panic.ast
+++ b/testdata/ast/stdlib_core_panic.ast
@@ -1,0 +1,13 @@
+File
+  ExternFunctionDecl __dao_panic
+    Param msg: string
+    ReturnType: void
+  FunctionDecl panic
+    Param msg: string
+    ReturnType: void
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_panic
+        Args
+          Identifier msg


### PR DESCRIPTION
## Summary

Implements the low-level memory substrate defined in `TASK_17_LOW_LEVEL_MEMORY_SUBSTRATE.md` — the minimum language/runtime primitives needed so that generic heap-backed containers can be implemented as ordinary Dao library code, without compiler-privileged container semantics.

## Highlights

- **Store through pointer** — `*ptr = value` now accepted as an assignment target inside `mode unsafe =>`
- **Compiler intrinsics** — `size_of<T>()`, `align_of<T>()`, `null_ptr<T>()`, `ptr_offset<T>(ptr, i)`, `ptr_cast<T>(ptr)` generate inline LLVM IR (GEP, DataLayout queries, null constants)
- **Call-site explicit type arguments** — parser handles `f<Type>(args)` syntax with speculative `<` disambiguation; type args propagate through AST → type checker → HIR → MIR → monomorphizer → backend
- **Runtime allocation hooks** — `__dao_mem_alloc`, `__dao_mem_realloc`, `__dao_mem_free` in `runtime/memory/alloc.c` with correct aligned allocation and alignment-preserving realloc
- **Panic hook** — `__dao_panic` + `panic()` stdlib wrapper; flushes stdout before abort
- **Pointer equality** — `==` / `!=` on `*T` operands works via existing `is_assignable` + `icmp` codegen
- **Deref-of-value places** — `*ptr_offset(p, i) = val` works by lowering the call result to a temp before deref projection
- **Proof of concept** — `examples/raw_memory.dao` demonstrates the full substrate end-to-end

## Test plan

- [x] All 12 existing tests pass
- [x] `examples/raw_memory.dao` compiles and produces correct output (10, 20, 30, 40, null checks, size/align queries)
- [x] `panic("msg")` prints to stderr and aborts with exit code 134
- [x] `size_of<i32>()` = 4, `size_of<f64>()` = 8, `align_of<i32>()` = 4
- [x] `null_ptr<i32>() == null_ptr<i32>()` is true
- [x] `<` comparison disambiguation works (no regression for `x < 3`)
- [x] Store through pointer: `*ptr = value` in unsafe mode
- [ ] Review: verify substrate is sufficient for `Vector<T>` as library code

🤖 Generated with [Claude Code](https://claude.com/claude-code)