### PR TITLE
feat(stdlib): ✨ add Vector<T> and class body methods

### DIFF
--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -218,6 +218,7 @@ struct ClassDecl {
   Span name_span;
   std::vector<GenericParam> type_params;
   std::vector<FieldSpec*> fields;
+  std::vector<Decl*> methods; // Direct method declarations (FunctionDecl)
   std::vector<ConformanceBlock> conformances;
   std::vector<DenySpec> denials;
 };

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -153,6 +153,9 @@ private:
       print_type_inline(*field->type);
       out_ << "\n";
     }
+    for (const auto* method : node.methods) {
+      print_decl(*method);
+    }
     for (const auto& conf : node.conformances) {
       indent();
       out_ << "Conformance " << conf.concept_name << "\n";

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1056,8 +1056,9 @@ private:
     }
     if (peek_kind() == TokenKind::Gt) {
       advance(); // consume >
-      if (peek_kind() == TokenKind::LParen) {
-        // Success: <Types>(  — these are call-site type arguments.
+      if (peek_kind() == TokenKind::LParen ||
+          peek_kind() == TokenKind::ColonColon) {
+        // Success: <Types>( or <Types>:: — call-site type arguments.
         return type_args;
       }
     }
@@ -1076,6 +1077,39 @@ private:
         // Speculatively try call-site type arguments: ident<Type>(args).
         auto type_args = try_parse_call_type_args();
         if (!type_args.empty()) {
+          // Static method call: Type<Args>::method(args)
+          if (peek_kind() == TokenKind::ColonColon) {
+            advance(); // ::
+            const auto& method_tok = consume(TokenKind::Identifier);
+            // Synthesize a mangled callee: "Type.method"
+            const auto& ident = expr->as<IdentifierExpr>();
+            auto* mangled_str = ctx_.alloc<std::string>(
+                std::string(ident.name) + "." + std::string(method_tok.text));
+            std::string_view mangled(*mangled_str);
+            auto* callee = ctx_.alloc<Expr>(
+                Span{.offset = expr->span.offset,
+                     .length = (method_tok.span.offset + method_tok.span.length) -
+                               expr->span.offset},
+                IdentifierExpr{.name = mangled});
+            consume(TokenKind::LParen);
+            std::vector<Expr*> args;
+            if (peek_kind() != TokenKind::RParen) {
+              args.push_back(parse_expression());
+              while (peek_kind() == TokenKind::Comma) {
+                advance();
+                args.push_back(parse_expression());
+              }
+            }
+            const auto& rparen = consume(TokenKind::RParen);
+            Span span = {.offset = expr->span.offset,
+                         .length = (rparen.span.offset + rparen.span.length) -
+                                   expr->span.offset};
+            expr = ctx_.alloc<Expr>(span,
+                                    CallExpr{.callee = callee,
+                                             .args = std::move(args),
+                                             .type_args = std::move(type_args)});
+            continue;
+          }
           // Commit: parse the call arguments.
           advance(); // (
           std::vector<Expr*> args;

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1131,6 +1131,38 @@ private:
         // Fall through to normal expression parsing (< as comparison).
         break;
       }
+      if (peek_kind() == TokenKind::ColonColon &&
+          expr->kind() == NodeKind::Identifier) {
+        // Static method call on nongeneric type: Type::method(args)
+        advance(); // ::
+        const auto& method_tok = consume(TokenKind::Identifier);
+        const auto& ident = expr->as<IdentifierExpr>();
+        auto* mangled_str = ctx_.alloc<std::string>(
+            std::string(ident.name) + "." + std::string(method_tok.text));
+        std::string_view mangled(*mangled_str);
+        auto* callee = ctx_.alloc<Expr>(
+            Span{.offset = expr->span.offset,
+                 .length = (method_tok.span.offset + method_tok.span.length) -
+                           expr->span.offset},
+            IdentifierExpr{.name = mangled});
+        consume(TokenKind::LParen);
+        std::vector<Expr*> args;
+        if (peek_kind() != TokenKind::RParen) {
+          args.push_back(parse_expression());
+          while (peek_kind() == TokenKind::Comma) {
+            advance();
+            args.push_back(parse_expression());
+          }
+        }
+        const auto& rparen = consume(TokenKind::RParen);
+        Span span = {.offset = expr->span.offset,
+                     .length = (rparen.span.offset + rparen.span.length) -
+                               expr->span.offset};
+        expr = ctx_.alloc<Expr>(span,
+                                CallExpr{.callee = callee,
+                                         .args = std::move(args)});
+        continue;
+      }
       if (peek_kind() == TokenKind::LParen) {
         // Call: expr(args)
         advance(); // (

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1073,7 +1073,9 @@ private:
 
     while (true) {
       if (peek_kind() == TokenKind::Lt &&
-          expr->kind() == NodeKind::Identifier) {
+          (expr->kind() == NodeKind::Identifier ||
+           expr->kind() == NodeKind::FieldExpr ||
+           expr->kind() == NodeKind::QualifiedName)) {
         // Speculatively try call-site type arguments: ident<Type>(args).
         auto type_args = try_parse_call_type_args();
         if (!type_args.empty()) {

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -375,12 +375,14 @@ private:
         span, ClassDecl{.name = name_tok.text, .name_span = name_tok.span,
                         .type_params = std::move(type_params),
                         .fields = std::move(body.fields),
+                        .methods = std::move(body.methods),
                         .conformances = std::move(body.conformances),
                         .denials = std::move(body.denials)});
   }
 
   struct ClassBody {
     std::vector<FieldSpec*> fields;
+    std::vector<Decl*> methods;
     std::vector<ConformanceBlock> conformances;
     std::vector<DenySpec> denials;
   };
@@ -396,10 +398,7 @@ private:
       } else if (peek_kind() == TokenKind::KwDeny) {
         body.denials.push_back(parse_deny_spec());
       } else if (peek_kind() == TokenKind::KwFn) {
-        // Method declaration inside class body (future: §11.5).
-        // For now, skip ahead and emit a diagnostic.
-        error("methods inside class bodies are not yet supported");
-        advance();
+        body.methods.push_back(parse_method_decl());
       } else {
         body.fields.push_back(parse_field_spec());
       }

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -788,6 +788,107 @@ suite<"error_recovery"> error_recovery = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Call-site explicit type arguments
+// ---------------------------------------------------------------------------
+
+suite<"call_type_arg_tests"> call_type_arg_tests = [] {
+  "explicit type arg parsed"_test = [] {
+    auto output = parse_string("fn f(): i32\n    size_of<i32>()\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& call = fn.body[0]->as<ExpressionStatement>().expr->as<CallExpr>();
+    expect(call.type_args.size() == 1_u);
+    expect(call.args.empty());
+  };
+
+  "explicit type arg does not break comparison"_test = [] {
+    auto output = parse_string("fn f(x: i32): i32\n    if x < 3:\n        return 1\n    return 0\n");
+    expect(output.parse_result.diagnostics.empty());
+  };
+
+  "multiple type args parsed"_test = [] {
+    auto output = parse_string("fn f(): i32\n    g<i32, f64>(1)\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& call = fn.body[0]->as<ExpressionStatement>().expr->as<CallExpr>();
+    expect(call.type_args.size() == 2_u);
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Class body methods
+// ---------------------------------------------------------------------------
+
+suite<"class_method_tests"> class_method_tests = [] {
+  "class with method parses"_test = [] {
+    auto output = parse_string(
+        "class Foo:\n"
+        "    x: i32\n"
+        "\n"
+        "    fn get(self): i32 -> self.x\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& cls = output.parse_result.file->declarations[0]->as<ClassDecl>();
+    expect(cls.fields.size() == 1_u);
+    expect(cls.methods.size() == 1_u);
+    expect(cls.methods[0]->as<FunctionDecl>().name == "get");
+  };
+
+  "class with static method parses"_test = [] {
+    auto output = parse_string(
+        "class Foo:\n"
+        "    x: i32\n"
+        "\n"
+        "    fn zero(): Foo\n"
+        "        let z: i32 = 0\n"
+        "        return Foo(z)\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& cls = output.parse_result.file->declarations[0]->as<ClassDecl>();
+    expect(cls.methods.size() == 1_u);
+    expect(cls.methods[0]->as<FunctionDecl>().name == "zero");
+    expect(cls.methods[0]->as<FunctionDecl>().params.empty());
+  };
+
+  "store through pointer parses"_test = [] {
+    auto output = parse_string(
+        "fn f(p: *i32): void\n"
+        "    mode unsafe =>\n"
+        "        *p = 42\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& mode = fn.body[0]->as<ModeBlock>();
+    const auto& assign = mode.body[0]->as<Assignment>();
+    expect(assign.target->kind() == NodeKind::UnaryExpr);
+    expect(assign.target->as<UnaryExpr>().op == UnaryOp::Deref);
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Static method call syntax
+// ---------------------------------------------------------------------------
+
+suite<"static_method_tests"> static_method_tests = [] {
+  "nongeneric static call parses as mangled identifier"_test = [] {
+    auto output = parse_string("fn f(): i32\n    Foo::bar()\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& call = fn.body[0]->as<ExpressionStatement>().expr->as<CallExpr>();
+    // When followed by (, 2-segment QualifiedName stays as QualifiedName
+    // but the resolver mangles it. Parser preserves the QualifiedName.
+    expect(call.callee->kind() == NodeKind::QualifiedName);
+  };
+
+  "generic static call parses with type args"_test = [] {
+    auto output = parse_string("fn f(): i32\n    Foo<i32>::bar()\n");
+    expect(output.parse_result.diagnostics.empty());
+    const auto& fn = output.parse_result.file->declarations[0]->as<FunctionDecl>();
+    const auto& call = fn.body[0]->as<ExpressionStatement>().expr->as<CallExpr>();
+    expect(call.type_args.size() == 1_u);
+    expect(call.callee->kind() == NodeKind::Identifier);
+    expect(call.callee->as<IdentifierExpr>().name == "Foo.bar");
+  };
+};
+
 // NOLINTEND(readability-function-cognitive-complexity,readability-magic-numbers,modernize-use-trailing-return-type)
 
 } // namespace

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -427,6 +427,11 @@ private:
       }
     }
 
+    // Resolve direct class methods.
+    for (const auto* method : st.methods) {
+      resolve_function(*method, struct_scope);
+    }
+
     // Resolve conformance blocks — concept name + method signatures.
     for (const auto& conf : st.conformances) {
       auto* sym = parent->lookup(conf.concept_name);

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -427,9 +427,16 @@ private:
       }
     }
 
-    // Resolve direct class methods.
+    // Resolve direct class methods and create Function symbols with
+    // mangled names (e.g. "Vector.push") so HIR method desugaring
+    // can find them — same pattern as extend method symbols.
     for (const auto* method : st.methods) {
       resolve_function(*method, struct_scope);
+      const auto& fn_decl = method->as<FunctionDecl>();
+      auto mangled_name = ctx_.intern(
+          std::string(st.name) + "." + std::string(fn_decl.name));
+      ctx_.make_symbol(SymbolKind::Function, mangled_name,
+                       fn_decl.name_span, method);
     }
 
     // Resolve conformance blocks — concept name + method signatures.

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -747,6 +747,10 @@ private:
       for (const auto* arg : call.args) {
         resolve_expr(*arg, scope);
       }
+      // Resolve explicit type arguments (e.g., size_of<T>()).
+      for (const auto* ta : call.type_args) {
+        resolve_type(*ta, scope);
+      }
       break;
     }
     case NodeKind::IndexExpr: {

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -718,6 +718,21 @@ private:
         diagnostics_.push_back(Diagnostic::error(
             seg_span,
             "unknown name '" + std::string(first_seg) + "'"));
+      } else if (sym->kind == SymbolKind::Type &&
+                 qn.segments.size() == 2) {
+        // Static method call: Type::method — resolve as the mangled
+        // symbol "Type.method" registered during resolve_class.
+        auto mangled_name = ctx_.intern(
+            std::string(qn.segments[0]) + "." + std::string(qn.segments[1]));
+        auto* method_sym = file_scope_->lookup(mangled_name);
+        if (method_sym != nullptr) {
+          uses_[expr.span.offset] = method_sym;
+        } else {
+          diagnostics_.push_back(Diagnostic::error(
+              expr.span,
+              "'" + std::string(first_seg) + "' has no static method '" +
+                  std::string(qn.segments[1]) + "'"));
+        }
       } else if (sym->kind != SymbolKind::Module) {
         diagnostics_.push_back(Diagnostic::error(
             seg_span,

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -430,13 +430,16 @@ private:
     // Resolve direct class methods and create Function symbols with
     // mangled names (e.g. "Vector.push") so HIR method desugaring
     // can find them — same pattern as extend method symbols.
+    // Also declare in file scope for static method calls (Type::method()).
     for (const auto* method : st.methods) {
       resolve_function(*method, struct_scope);
       const auto& fn_decl = method->as<FunctionDecl>();
       auto mangled_name = ctx_.intern(
           std::string(st.name) + "." + std::string(fn_decl.name));
-      ctx_.make_symbol(SymbolKind::Function, mangled_name,
-                       fn_decl.name_span, method);
+      auto* method_sym = ctx_.make_symbol(SymbolKind::Function,
+                                          mangled_name,
+                                          fn_decl.name_span, method);
+      file_scope_->declare(mangled_name, method_sym);
     }
 
     // Resolve conformance blocks — concept name + method signatures.

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -368,6 +368,33 @@ void TypeChecker::register_declarations(const FileNode& file) {
           types_.make_struct(sym, st.name, std::move(fields));
       symbol_types_[sym] = struct_type;
       typed_.set_decl_type(decl, struct_type);
+
+      // Register class body methods as function declarations so
+      // they get proper TypeFunction entries in the typed results.
+      for (const auto* method : st.methods) {
+        const auto& fn = method->as<FunctionDecl>();
+        auto mdecl_it = decl_symbols_.find(fn.name_span.offset);
+        if (mdecl_it == decl_symbols_.end()) {
+          continue;
+        }
+        const auto* method_sym = mdecl_it->second;
+        std::vector<const Type*> param_types;
+        for (const auto& param : fn.params) {
+          if (param.name == "self") {
+            param_types.push_back(struct_type);
+          } else {
+            const auto* param_type = resolve_type_node(param.type);
+            param_types.push_back(param_type);
+          }
+        }
+        const auto* ret = fn.return_type != nullptr
+                              ? resolve_type_node(fn.return_type)
+                              : types_.void_type();
+        const auto* fn_type =
+            types_.function_type(std::move(param_types), ret);
+        symbol_types_[method_sym] = fn_type;
+        typed_.set_decl_type(method, fn_type);
+      }
       break;
     }
 
@@ -1607,17 +1634,24 @@ auto TypeChecker::check_construct(const Expr* expr,
     return nullptr;
   }
 
+  std::unordered_map<uint32_t, const Type*> type_bindings;
   for (size_t i = 0; i < fields.size(); ++i) {
     const auto* arg_type = check_expr(call.args[i]);
-    if (arg_type != nullptr && fields[i].type != nullptr &&
-        !is_assignable(arg_type, fields[i].type)) {
-      error(call.args[i]->span,
-            "field '" + std::string(fields[i].name) + "' expects type '" +
-                print_type(fields[i].type) + "', got '" +
-                print_type(arg_type) + "'");
+    if (arg_type != nullptr && fields[i].type != nullptr) {
+      if (!is_assignable(arg_type, fields[i].type)) {
+        error(call.args[i]->span,
+              "field '" + std::string(fields[i].name) + "' expects type '" +
+                  print_type(fields[i].type) + "', got '" +
+                  print_type(arg_type) + "'");
+      }
+      infer_type_bindings(fields[i].type, arg_type, type_bindings,
+                          call.args[i]->span);
     }
   }
 
+  if (!type_bindings.empty()) {
+    return substitute_generics(struct_type, type_bindings);
+  }
   return struct_type;
 }
 

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1359,7 +1359,7 @@ void TypeChecker::infer_type_bindings(
     auto it = bindings.find(gp->index());
     if (it != bindings.end()) {
       // Already bound — check consistency.
-      if (it->second != concrete) {
+      if (it->second != concrete && !is_assignable(it->second, concrete)) {
         error(error_span,
               "conflicting types for generic parameter '" +
                   std::string(gp->name()) + "': '" +
@@ -1396,6 +1396,18 @@ void TypeChecker::infer_type_bindings(
       }
       infer_type_bindings(fp->return_type(), fc->return_type(),
                           bindings, error_span);
+    }
+  } else if (pattern->kind() == TypeKind::Struct &&
+             concrete->kind() == TypeKind::Struct) {
+    const auto* sp = static_cast<const TypeStruct*>(pattern);
+    const auto* sc = static_cast<const TypeStruct*>(concrete);
+    // Only infer bindings between instances of the same class.
+    if (sp->decl_id() == sc->decl_id() &&
+        sp->fields().size() == sc->fields().size()) {
+      for (size_t j = 0; j < sp->fields().size(); ++j) {
+        infer_type_bindings(sp->fields()[j].type, sc->fields()[j].type,
+                            bindings, error_span);
+      }
     }
   }
 }
@@ -1760,13 +1772,24 @@ auto TypeChecker::check_field(const Expr* expr) -> const Type* {
   }
 
   // Try method lookup on any type (struct conformances + extend decls).
+  // Skip static methods (no self parameter) — those are only callable
+  // via Type::method(), not through an instance.
   const Decl* method_decl = nullptr;
   const auto* method_type = lookup_method(obj_type, field.field, &method_decl);
   if (method_type != nullptr) {
+    // Check if this is a static method (no self) — reject for instance calls.
+    bool is_static = false;
     if (method_decl != nullptr) {
-      typed_.set_method_resolution(expr, method_decl);
+      const auto& fn = method_decl->as<FunctionDecl>();
+      is_static = fn.params.empty() || fn.params[0].name != "self";
     }
-    return method_type;
+    if (!is_static) {
+      if (method_decl != nullptr) {
+        typed_.set_method_resolution(expr, method_decl);
+      }
+      return method_type;
+    }
+    // Static method — fall through to field-not-found error.
   }
 
   if (obj_type->kind() == TypeKind::Struct) {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -739,6 +739,15 @@ void TypeChecker::check_class(const Decl* decl) {
     }
   }
 
+  // Validate and check direct class methods.
+  for (const auto* method : cls.methods) {
+    validate_receiver(method, cls.name_span);
+    const auto& fn = method->as<FunctionDecl>();
+    if (!fn.body.empty() || fn.expr_body != nullptr) {
+      check_function(method);
+    }
+  }
+
   // Validate and check conformance-block methods.
   for (const auto& conf : cls.conformances) {
     for (const auto* method : conf.methods) {
@@ -1384,6 +1393,21 @@ auto TypeChecker::substitute_generics(
     if (ret != fn->return_type()) changed = true;
     return changed ? types_.function_type(std::move(params), ret) : type;
   }
+  case TypeKind::Struct: {
+    const auto* st = static_cast<const TypeStruct*>(type);
+    bool changed = false;
+    std::vector<StructField> new_fields;
+    new_fields.reserve(st->fields().size());
+    for (const auto& field : st->fields()) {
+      const auto* sub = substitute_generics(field.type, bindings);
+      if (sub != field.type) changed = true;
+      new_fields.push_back({field.name, sub});
+    }
+    return changed
+               ? types_.make_struct(st->decl_id(), st->name(),
+                                    std::move(new_fields))
+               : type;
+  }
   default:
     return type;
   }
@@ -1738,6 +1762,16 @@ void TypeChecker::build_method_table(const FileNode& file) {
     if (struct_type == nullptr || struct_type->kind() != TypeKind::Struct) {
       continue;
     }
+    // Direct class methods.
+    for (const auto* method_decl : cls.methods) {
+      const auto& method = method_decl->as<FunctionDecl>();
+      MethodKey key{struct_type, method.name};
+      if (method_table_.find(key) == method_table_.end()) {
+        const auto* fn_type = build_method_fn_type(method);
+        method_table_.insert({key, {fn_type, method_decl}});
+      }
+    }
+    // Conformance block methods.
     for (const auto& conf : cls.conformances) {
       for (const auto* method_decl : conf.methods) {
         const auto& method = method_decl->as<FunctionDecl>();

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1858,6 +1858,41 @@ auto TypeChecker::lookup_method(const Type* obj_type,
     return it->second.fn_type;
   }
 
+  // For concrete struct instantiations (e.g., Vector<i32>), fall back to
+  // the generic struct type (Vector<T>) which is how class methods are
+  // registered. Build type bindings from the concrete field types to
+  // substitute into the method's return/param types.
+  if (obj_type->kind() == TypeKind::Struct) {
+    const auto* concrete_st = static_cast<const TypeStruct*>(obj_type);
+    // Look up the class declaration's generic struct type.
+    for (const auto& [key, entry] : method_table_) {
+      if (key.name != name || key.type == nullptr ||
+          key.type->kind() != TypeKind::Struct) {
+        continue;
+      }
+      const auto* generic_st = static_cast<const TypeStruct*>(key.type);
+      if (generic_st->decl_id() != concrete_st->decl_id()) {
+        continue;
+      }
+      // Found matching class. Build substitution from generic → concrete
+      // field types.
+      std::unordered_map<uint32_t, const Type*> bindings;
+      for (size_t i = 0; i < generic_st->fields().size() &&
+                          i < concrete_st->fields().size(); ++i) {
+        infer_type_bindings(generic_st->fields()[i].type,
+                            concrete_st->fields()[i].type,
+                            bindings, Span{});
+      }
+      if (resolved_decl != nullptr) {
+        *resolved_decl = entry.method_decl;
+      }
+      if (bindings.empty()) {
+        return entry.fn_type;
+      }
+      return substitute_generics(entry.fn_type, bindings);
+    }
+  }
+
   // Generic type parameter constraint search — this can't be pre-built
   // because it's parameterized on the receiver type variable.
   if (obj_type->kind() == TypeKind::GenericParam) {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1090,6 +1090,11 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
   case NodeKind::ListLiteral:
     result = check_list_literal(expr);
     break;
+  case NodeKind::QualifiedName:
+    // Static method call: Type::method resolved by the resolver
+    // to a mangled function symbol. Treat like an identifier.
+    result = check_identifier(expr);
+    break;
   case NodeKind::ErrorExpr:
     // Recovery placeholder — skip silently.
     break;
@@ -1110,16 +1115,26 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
 // ---------------------------------------------------------------------------
 
 auto TypeChecker::check_identifier(const Expr* expr) -> const Type* {
-  const auto& id = expr->as<IdentifierExpr>();
+  // Works for both IdentifierExpr and QualifiedName (static method calls).
   auto it = resolve_.uses.find(expr->span.offset);
   if (it == resolve_.uses.end()) {
-    error(expr->span, "unresolved identifier '" + std::string(id.name) + "'");
+    std::string name_str;
+    if (expr->is<IdentifierExpr>()) {
+      name_str = expr->as<IdentifierExpr>().name;
+    } else if (expr->is<QualifiedName>()) {
+      const auto& qn = expr->as<QualifiedName>();
+      for (size_t i = 0; i < qn.segments.size(); ++i) {
+        if (i > 0) name_str += "::";
+        name_str += qn.segments[i];
+      }
+    }
+    error(expr->span, "unresolved identifier '" + name_str + "'");
     return nullptr;
   }
   const auto* result = resolve_symbol_type(it->second);
   if (result == nullptr && it->second->kind == SymbolKind::Param) {
     error(expr->span,
-          "'" + std::string(id.name) + "' has no known type in this context");
+          "'" + std::string(it->second->name) + "' has no known type in this context");
   }
   return result;
 }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -767,9 +767,12 @@ void TypeChecker::check_class(const Decl* decl) {
   }
 
   // Validate and check direct class methods.
+  // Static methods (no self parameter) are allowed in class bodies.
   for (const auto* method : cls.methods) {
-    validate_receiver(method, cls.name_span);
     const auto& fn = method->as<FunctionDecl>();
+    if (!fn.params.empty() && fn.params[0].name == "self") {
+      validate_receiver(method, cls.name_span);
+    }
     if (!fn.body.empty() || fn.expr_body != nullptr) {
       check_function(method);
     }
@@ -1557,6 +1560,20 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
         const auto* fn_decl = static_cast<const Decl*>(sym_it->second->decl);
         if (fn_decl->is<FunctionDecl>()) {
           expected_count = fn_decl->as<FunctionDecl>().type_params.size();
+          // For class methods (no own type params), use the enclosing
+          // class's type params when invoked via Type<Args>::method().
+          if (expected_count == 0 && sym_it->second->name.find('.') != std::string_view::npos) {
+            // Find the enclosing ClassDecl by checking file declarations.
+            auto class_name = sym_it->second->name.substr(
+                0, sym_it->second->name.find('.'));
+            for (const auto* file_decl : file_->declarations) {
+              if (file_decl->kind() == NodeKind::ClassDecl &&
+                  file_decl->as<ClassDecl>().name == class_name) {
+                expected_count = file_decl->as<ClassDecl>().type_params.size();
+                break;
+              }
+            }
+          }
         }
       } else {
         // Compiler builtin functions (null_ptr, ptr_cast) take 1 type param.

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -62,7 +62,9 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
     case TypeKind::Struct: {
       const auto* ss = static_cast<const TypeStruct*>(source);
       const auto* ts = static_cast<const TypeStruct*>(target);
-      // Same class: match by decl_id and structural field compatibility.
+      // Same class: match by decl_id and exact field type equality.
+      // NOT assignability — that would allow unsound covariance
+      // (e.g., Vector<*i32> -> Vector<*void>).
       if (ss->decl_id() != ts->decl_id() || ss->name() != ts->name()) {
         return false;
       }
@@ -70,9 +72,27 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
         return false;
       }
       for (size_t i = 0; i < ss->fields().size(); ++i) {
-        if (!is_assignable(ss->fields()[i].type, ts->fields()[i].type)) {
-          return false;
+        const auto* sf = ss->fields()[i].type;
+        const auto* tf = ts->fields()[i].type;
+        if (sf == tf) {
+          continue; // Interned identity — always matches.
         }
+        // Allow generic param matching (needed during type checking
+        // when the same T appears in differently-instantiated structs).
+        if (sf->kind() == TypeKind::GenericParam ||
+            tf->kind() == TypeKind::GenericParam) {
+          continue;
+        }
+        // Recurse for nested structs (same decl_id check applies
+        // recursively), but NOT for pointer covariance.
+        if (sf->kind() == tf->kind() && sf->kind() == TypeKind::Struct) {
+          if (!is_assignable(sf, tf)) {
+            return false;
+          }
+          continue;
+        }
+        // All other field types: exact match only.
+        return false;
       }
       return true;
     }

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -59,6 +59,23 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
       }
       return is_assignable(sf->return_type(), tf->return_type());
     }
+    case TypeKind::Struct: {
+      const auto* ss = static_cast<const TypeStruct*>(source);
+      const auto* ts = static_cast<const TypeStruct*>(target);
+      // Same class: match by decl_id and structural field compatibility.
+      if (ss->decl_id() != ts->decl_id() || ss->name() != ts->name()) {
+        return false;
+      }
+      if (ss->fields().size() != ts->fields().size()) {
+        return false;
+      }
+      for (size_t i = 0; i < ss->fields().size(); ++i) {
+        if (!is_assignable(ss->fields()[i].type, ts->fields()[i].type)) {
+          return false;
+        }
+      }
+      return true;
+    }
     default:
       break;
     }

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -1567,6 +1567,144 @@ suite<"typecheck_generator"> typecheck_generator = [] {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Pointer operations
+// ---------------------------------------------------------------------------
+
+suite<"pointer_ops"> pointer_ops = [] {
+  "store through pointer requires unsafe"_test = [] {
+    auto result = check_source(
+        "fn f(p: *i32): void\n"
+        "    *p = 42\n");
+    expect(!result.diagnostics.empty());
+    bool found = false;
+    for (const auto& d : result.diagnostics) {
+      if (d.message.find("unsafe") != std::string::npos) found = true;
+    }
+    expect(found) << "should require mode unsafe";
+  };
+
+  "store through pointer in unsafe accepted"_test = [] {
+    auto result = check_source(
+        "fn f(p: *i32): void\n"
+        "    mode unsafe =>\n"
+        "        *p = 42\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "pointer equality accepted"_test = [] {
+    auto result = check_source(
+        "fn f(a: *i32, b: *i32): bool\n"
+        "    return a == b\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "void pointer assignability"_test = [] {
+    auto result = check_source(
+        "fn f(p: *i32): *void\n"
+        "    return p\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "void pointer not assignable to typed pointer"_test = [] {
+    auto result = check_source(
+        "fn f(p: *void): *i32\n"
+        "    return p\n");
+    expect(!result.diagnostics.empty());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Class body methods and static calls
+// ---------------------------------------------------------------------------
+
+suite<"class_methods"> class_methods = [] {
+  "class with instance method typechecks"_test = [] {
+    auto result = check_source(
+        "class Box:\n"
+        "    x: i32\n"
+        "\n"
+        "    fn get(self): i32 -> self.x\n"
+        "\n"
+        "fn main(): i32\n"
+        "    let b = Box(42)\n"
+        "    return b.get()\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "class with static method typechecks"_test = [] {
+    auto result = check_source(
+        "class Box:\n"
+        "    x: i32\n"
+        "\n"
+        "    fn zero(): Box\n"
+        "        let z: i32 = 0\n"
+        "        return Box(z)\n"
+        "\n"
+        "fn main(): i32\n"
+        "    let b = Box::zero()\n"
+        "    return b.x\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "generic constructor infers type"_test = [] {
+    auto result = check_source(
+        "class Box<T>:\n"
+        "    value: T\n"
+        "\n"
+        "fn main(): i32\n"
+        "    let b = Box(42)\n"
+        "    return b.value\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "struct field assignability is exact not covariant"_test = [] {
+    // Two non-generic structs with mismatched fields are rejected.
+    auto result = check_source(
+        "class A:\n"
+        "    x: i32\n"
+        "\n"
+        "class B:\n"
+        "    x: i32\n"
+        "\n"
+        "fn f(a: A): i32 -> a.x\n"
+        "\n"
+        "fn main(): i32\n"
+        "    let b = B(42)\n"
+        "    return f(b)\n");
+    expect(!result.diagnostics.empty()) << "A and B are different nominal types";
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Explicit type arguments
+// ---------------------------------------------------------------------------
+
+suite<"explicit_type_args"> explicit_type_args = [] {
+  "call with explicit type arg typechecks"_test = [] {
+    auto result = check_source(
+        "fn identity<T>(x: T): T -> x\n"
+        "\n"
+        "fn main(): i32\n"
+        "    return identity<i32>(42)\n");
+    expect(result.diagnostics.empty());
+  };
+
+  "wrong type arg count rejected"_test = [] {
+    auto result = check_source(
+        "fn identity<T>(x: T): T -> x\n"
+        "\n"
+        "fn main(): i32\n"
+        "    return identity<i32, f64>(42)\n");
+    expect(!result.diagnostics.empty());
+    bool found = false;
+    for (const auto& d : result.diagnostics) {
+      if (d.message.find("type argument") != std::string::npos) found = true;
+    }
+    expect(found) << "should mention type argument count";
+  };
+};
+
 // NOLINTEND(readability-magic-numbers)
 
 auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -1658,6 +1658,22 @@ suite<"class_methods"> class_methods = [] {
     expect(result.diagnostics.empty());
   };
 
+  "static method not callable through instance"_test = [] {
+    auto result = check_source(
+        "class Box:\n"
+        "    x: i32\n"
+        "\n"
+        "    fn zero(): Box\n"
+        "        let z: i32 = 0\n"
+        "        return Box(z)\n"
+        "\n"
+        "fn main(): i32\n"
+        "    let b = Box(1)\n"
+        "    let z = b.zero()\n"
+        "    return z.x\n");
+    expect(!result.diagnostics.empty()) << "static method should not be callable on instance";
+  };
+
   "struct field assignability is exact not covariant"_test = [] {
     // Two non-generic structs with mismatched fields are rejected.
     auto result = check_source(

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -305,7 +305,10 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
     return ctx_.alloc<HirExpr>(span, type, HirBoolLiteral{lit.value});
   }
 
-  case NodeKind::Identifier: {
+  case NodeKind::Identifier:
+  case NodeKind::QualifiedName: {
+    // QualifiedName for static method calls (Type::method) is resolved
+    // by the resolver to a function symbol, same as an identifier.
     const auto* sym = find_symbol_at_use(expr->span.offset);
     return ctx_.alloc<HirExpr>(span, type, HirSymbolRef{sym});
   }

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -136,6 +136,24 @@ auto HirBuilder::lower_class(const Decl* decl) -> HirDecl* {
     struct_type = static_cast<const TypeStruct*>(decl_type);
   }
 
+  // Lower direct class methods as standalone functions.
+  for (const auto* method : st.methods) {
+    auto* hir_fn = lower_function(method);
+    if (hir_fn != nullptr) {
+      extend_decls_.push_back(hir_fn);
+    }
+  }
+
+  // Lower conformance-block methods as standalone functions.
+  for (const auto& conf : st.conformances) {
+    for (const auto* method : conf.methods) {
+      auto* hir_fn = lower_function(method);
+      if (hir_fn != nullptr) {
+        extend_decls_.push_back(hir_fn);
+      }
+    }
+  }
+
   return ctx_.alloc<HirDecl>(decl->span, HirClassDecl{sym, struct_type});
 }
 

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -75,6 +75,25 @@ auto substitute_type(const Type* type, const TypeSubst& subst,
     return types.generator_type(sub);
   }
 
+  case TypeKind::Struct: {
+    const auto* st = static_cast<const TypeStruct*>(type);
+    bool changed = false;
+    std::vector<StructField> new_fields;
+    new_fields.reserve(st->fields().size());
+    for (const auto& field : st->fields()) {
+      auto* sub = substitute_type(field.type, subst, types);
+      if (sub != field.type) {
+        changed = true;
+      }
+      new_fields.push_back({field.name, sub});
+    }
+    if (!changed) {
+      return type;
+    }
+    return types.make_struct(st->decl_id(), st->name(),
+                             std::move(new_fields));
+  }
+
   default:
     return type;
   }
@@ -107,6 +126,15 @@ auto type_has_generic(const Type* type) -> bool {
   case TypeKind::Generator:
     return type_has_generic(
         static_cast<const TypeGenerator*>(type)->yield_type());
+  case TypeKind::Struct: {
+    const auto* st = static_cast<const TypeStruct*>(type);
+    for (const auto& field : st->fields()) {
+      if (type_has_generic(field.type)) {
+        return true;
+      }
+    }
+    return false;
+  }
   default:
     return false;
   }

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -417,6 +417,16 @@ void infer_bindings_recursive(const Type* pattern, const Type* concrete,
       }
       infer_bindings_recursive(fp->return_type(), fc->return_type(), subst);
     }
+  } else if (pattern->kind() == TypeKind::Struct &&
+             concrete->kind() == TypeKind::Struct) {
+    const auto* sp = static_cast<const TypeStruct*>(pattern);
+    const auto* sc = static_cast<const TypeStruct*>(concrete);
+    if (sp->fields().size() == sc->fields().size()) {
+      for (size_t i = 0; i < sp->fields().size(); ++i) {
+        infer_bindings_recursive(sp->fields()[i].type,
+                                 sc->fields()[i].type, subst);
+      }
+    }
   }
 }
 

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -237,8 +237,12 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
           call->args = new_args;
         }
         if (call->explicit_type_args != nullptr) {
-          call->explicit_type_args =
-              ctx.alloc<std::vector<const Type*>>(*call->explicit_type_args);
+          auto* new_ta = ctx.alloc<std::vector<const Type*>>();
+          new_ta->reserve(call->explicit_type_args->size());
+          for (const auto* ta : *call->explicit_type_args) {
+            new_ta->push_back(substitute_type(ta, subst, types));
+          }
+          call->explicit_type_args = new_ta;
         }
       } else if (auto* ctor = std::get_if<MirConstruct>(&dst_inst->payload)) {
         if (ctor->field_values != nullptr) {

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -92,15 +92,28 @@ Rules:
 class Point:
     x: f64
     y: f64
+
+    fn magnitude(self): f64
+        return sqrt(self.x * self.x + self.y * self.y)
 ```
 
 Rules:
 - `class <name> :` introduces a class declaration
-- the body is an indented block of field specifiers
+- the body is an indented block of field specifiers and method
+  declarations
 - each field specifier is `name: type` on its own line
 - field specifiers are not statements; `let` is not used inside class bodies
 - the body must contain at least one field
 - field names must be unique within a class
+- method declarations use `fn` and follow the same syntax as
+  top-level function declarations
+- methods must appear after all field specifiers
+- methods with a bare `self` parameter receive the enclosing class
+  type as the receiver; `self` has no special meaning outside a
+  class or extend body
+- methods defined inside the class body are equivalent to methods
+  defined in an `extend` block — they are ordinary functions
+  attached to the type
 
 ## Concepts
 

--- a/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
+++ b/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
@@ -158,10 +158,16 @@ type metadata or vtable pointers at runtime. Dynamic dispatch, if
 needed, is expressed through concept objects or explicit indirection,
 not through the class mechanism itself.
 
-### 8.5 Field access
+### 8.5 Field access and methods
 
 Fields are accessed via `.` (dot notation). There are no synthesized
 getters, setters, or property wrappers at the class level.
+
+Methods may be declared inside the class body after all field
+specifiers. A method with a bare `self` parameter receives the
+enclosing class type as the receiver. Methods defined inside the
+class body are semantically equivalent to methods attached via
+`extend` blocks — they are ordinary functions with static dispatch.
 
 ### 8.6 Why "class"
 

--- a/examples/vectors.dao
+++ b/examples/vectors.dao
@@ -5,7 +5,7 @@
 
 fn main(): i32
   // Create and populate a vector.
-  let v = vec_new<i32>()
+  let v = Vector<i32>::new()
   v = v.push(10)
   v = v.push(20)
   v = v.push(30)

--- a/examples/vectors.dao
+++ b/examples/vectors.dao
@@ -1,0 +1,25 @@
+// vectors.dao — Vector<T> as an ordinary library type.
+//
+// Demonstrates push, get, set, and length on a generic dynamic array
+// built entirely from the low-level memory substrate.
+
+fn main(): i32
+  // Create and populate a vector.
+  let v = vec_new<i32>()
+  v = v.push(10)
+  v = v.push(20)
+  v = v.push(30)
+  v = v.push(40)
+
+  // Length and element access.
+  print(v.length())
+  print(v.get(0))
+  print(v.get(1))
+  print(v.get(2))
+  print(v.get(3))
+
+  // Mutation via set.
+  v = v.set(1, 99)
+  print(v.get(1))
+
+  return 0

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -1,0 +1,54 @@
+// vector.dao — Generic dynamic array.
+//
+// Vector<T> is an ordinary library type built on the low-level memory
+// substrate. No compiler-privileged container semantics.
+
+class Vector<T>:
+  data: *T
+  len: i64
+  cap: i64
+
+  fn push(self, elem: T): Vector<T>
+    let new_len = self.len + 1
+    if new_len > self.cap:
+      let new_cap: i64 = self.cap * 2
+      if self.cap == 0:
+        new_cap = 8
+      let new_data_raw = __dao_mem_alloc(
+        size_of<T>() * new_cap, align_of<T>())
+      mode unsafe =>
+        let new_data = ptr_cast<T>(new_data_raw)
+        let i: i64 = 0
+        while i < self.len:
+          *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
+          i = i + 1
+        *ptr_offset(new_data, self.len) = elem
+        if self.cap > 0:
+          __dao_mem_free(self.data)
+        return Vector(new_data, new_len, new_cap)
+    mode unsafe =>
+      *ptr_offset(self.data, self.len) = elem
+    return Vector(self.data, new_len, self.cap)
+
+  fn get(self, index: i64): T
+    if index < 0:
+      panic("Vector.get: index out of bounds")
+    if index >= self.len:
+      panic("Vector.get: index out of bounds")
+    mode unsafe =>
+      return *ptr_offset(self.data, index)
+    panic("unreachable")
+
+  fn set(self, index: i64, elem: T): Vector<T>
+    if index < 0:
+      panic("Vector.set: index out of bounds")
+    if index >= self.len:
+      panic("Vector.set: index out of bounds")
+    mode unsafe =>
+      *ptr_offset(self.data, index) = elem
+    return Vector(self.data, self.len, self.cap)
+
+  fn length(self): i64 -> self.len
+
+fn vec_new<T>(): Vector<T>
+  return Vector(null_ptr<T>(), 0, 0)

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -2,6 +2,10 @@
 //
 // Vector<T> is an ordinary library type built on the low-level memory
 // substrate. No compiler-privileged container semantics.
+//
+// Value semantics: every mutation returns a freshly allocated copy.
+// No aliased Vector values share mutable storage. This is correct
+// but expensive; future COW or ownership tracking can optimize.
 
 class Vector<T>:
   data: *T
@@ -9,26 +13,25 @@ class Vector<T>:
   cap: i64
 
   fn push(self, elem: T): Vector<T>
-    let new_len = self.len + 1
-    if new_len > self.cap:
-      let new_cap: i64 = self.cap * 2
+    let new_cap: i64 = self.cap
+    if self.len + 1 > self.cap:
+      new_cap = self.cap * 2
       if self.cap == 0:
         new_cap = 8
-      let new_data_raw = __dao_mem_alloc(
-        size_of<T>() * new_cap, align_of<T>())
-      mode unsafe =>
-        let new_data = ptr_cast<T>(new_data_raw)
-        let i: i64 = 0
-        while i < self.len:
-          *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
-          i = i + 1
-        *ptr_offset(new_data, self.len) = elem
-        if self.cap > 0:
-          __dao_mem_free(self.data)
-        return Vector(new_data, new_len, new_cap)
+    // Always allocate a fresh buffer for the returned vector.
+    let new_data_raw = __dao_mem_alloc(
+      size_of<T>() * new_cap, align_of<T>())
     mode unsafe =>
-      *ptr_offset(self.data, self.len) = elem
-    return Vector(self.data, new_len, self.cap)
+      let new_data = ptr_cast<T>(new_data_raw)
+      // Copy existing elements.
+      let i: i64 = 0
+      while i < self.len:
+        *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
+        i = i + 1
+      // Append the new element.
+      *ptr_offset(new_data, self.len) = elem
+      return Vector(new_data, self.len + 1, new_cap)
+    panic("unreachable")
 
   fn get(self, index: i64): T
     if index < 0:
@@ -44,9 +47,18 @@ class Vector<T>:
       panic("Vector.set: index out of bounds")
     if index >= self.len:
       panic("Vector.set: index out of bounds")
+    // Allocate a fresh copy — do not mutate self.data in place.
+    let new_data_raw = __dao_mem_alloc(
+      size_of<T>() * self.cap, align_of<T>())
     mode unsafe =>
-      *ptr_offset(self.data, index) = elem
-    return Vector(self.data, self.len, self.cap)
+      let new_data = ptr_cast<T>(new_data_raw)
+      let i: i64 = 0
+      while i < self.len:
+        *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
+        i = i + 1
+      *ptr_offset(new_data, index) = elem
+      return Vector(new_data, self.len, self.cap)
+    panic("unreachable")
 
   fn length(self): i64 -> self.len
 

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -51,4 +51,5 @@ class Vector<T>:
   fn length(self): i64 -> self.len
 
 fn vec_new<T>(): Vector<T>
-  return Vector(null_ptr<T>(), 0, 0)
+  let zero: i64 = 0
+  return Vector(null_ptr<T>(), zero, zero)

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -50,6 +50,6 @@ class Vector<T>:
 
   fn length(self): i64 -> self.len
 
-fn vec_new<T>(): Vector<T>
-  let zero: i64 = 0
-  return Vector(null_ptr<T>(), zero, zero)
+  fn new(): Vector<T>
+    let zero: i64 = 0
+    return Vector(null_ptr<T>(), zero, zero)

--- a/testdata/ast/examples_vectors.ast
+++ b/testdata/ast/examples_vectors.ast
@@ -4,7 +4,7 @@ File
     LetStatement v
       CallExpr
         Callee
-          Identifier vec_new
+          Identifier Vector.new
         TypeArgs
           i32
     Assignment

--- a/testdata/ast/examples_vectors.ast
+++ b/testdata/ast/examples_vectors.ast
@@ -1,0 +1,126 @@
+File
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement v
+      CallExpr
+        Callee
+          Identifier vec_new
+        TypeArgs
+          i32
+    Assignment
+      Target
+        Identifier v
+      Value
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier v
+          Args
+            IntLiteral 10
+    Assignment
+      Target
+        Identifier v
+      Value
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier v
+          Args
+            IntLiteral 20
+    Assignment
+      Target
+        Identifier v
+      Value
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier v
+          Args
+            IntLiteral 30
+    Assignment
+      Target
+        Identifier v
+      Value
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier v
+          Args
+            IntLiteral 40
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .length
+                Identifier v
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier v
+            Args
+              IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier v
+            Args
+              IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier v
+            Args
+              IntLiteral 2
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier v
+            Args
+              IntLiteral 3
+    Assignment
+      Target
+        Identifier v
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier v
+          Args
+            IntLiteral 1
+            IntLiteral 99
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier v
+            Args
+              IntLiteral 1
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -1,0 +1,274 @@
+File
+  ClassDecl Vector<T>
+    Field data: *T
+    Field len: i64
+    Field cap: i64
+    FunctionDecl push
+      Param self
+      Param elem: T
+      ReturnType: Vector<T>
+      LetStatement new_len
+        BinaryExpr +
+          FieldExpr .len
+            Identifier self
+          IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr >
+            Identifier new_len
+            FieldExpr .cap
+              Identifier self
+        Then
+          LetStatement new_cap: i64
+            BinaryExpr *
+              FieldExpr .cap
+                Identifier self
+              IntLiteral 2
+          IfStatement
+            Condition
+              BinaryExpr ==
+                FieldExpr .cap
+                  Identifier self
+                IntLiteral 0
+            Then
+              Assignment
+                Target
+                  Identifier new_cap
+                Value
+                  IntLiteral 8
+          LetStatement new_data_raw
+            CallExpr
+              Callee
+                Identifier __dao_mem_alloc
+              Args
+                BinaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier size_of
+                    TypeArgs
+                      T
+                  Identifier new_cap
+                CallExpr
+                  Callee
+                    Identifier align_of
+                  TypeArgs
+                    T
+          ModeBlock unsafe
+            LetStatement new_data
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  T
+                Args
+                  Identifier new_data_raw
+            LetStatement i: i64
+              IntLiteral 0
+            WhileStatement
+              Condition
+                BinaryExpr <
+                  Identifier i
+                  FieldExpr .len
+                    Identifier self
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        Identifier new_data
+                        Identifier i
+                Value
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        FieldExpr .data
+                          Identifier self
+                        Identifier i
+              Assignment
+                Target
+                  Identifier i
+                Value
+                  BinaryExpr +
+                    Identifier i
+                    IntLiteral 1
+            Assignment
+              Target
+                UnaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier ptr_offset
+                    Args
+                      Identifier new_data
+                      FieldExpr .len
+                        Identifier self
+              Value
+                Identifier elem
+            IfStatement
+              Condition
+                BinaryExpr >
+                  FieldExpr .cap
+                    Identifier self
+                  IntLiteral 0
+              Then
+                ExpressionStatement
+                  CallExpr
+                    Callee
+                      Identifier __dao_mem_free
+                    Args
+                      FieldExpr .data
+                        Identifier self
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier Vector
+                Args
+                  Identifier new_data
+                  Identifier new_len
+                  Identifier new_cap
+      ModeBlock unsafe
+        Assignment
+          Target
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .data
+                    Identifier self
+                  FieldExpr .len
+                    Identifier self
+          Value
+            Identifier elem
+      ReturnStatement
+        CallExpr
+          Callee
+            Identifier Vector
+          Args
+            FieldExpr .data
+              Identifier self
+            Identifier new_len
+            FieldExpr .cap
+              Identifier self
+    FunctionDecl get
+      Param self
+      Param index: i64
+      ReturnType: T
+      IfStatement
+        Condition
+          BinaryExpr <
+            Identifier index
+            IntLiteral 0
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "Vector.get: index out of bounds"
+      IfStatement
+        Condition
+          BinaryExpr >=
+            Identifier index
+            FieldExpr .len
+              Identifier self
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "Vector.get: index out of bounds"
+      ModeBlock unsafe
+        ReturnStatement
+          UnaryExpr *
+            CallExpr
+              Callee
+                Identifier ptr_offset
+              Args
+                FieldExpr .data
+                  Identifier self
+                Identifier index
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier panic
+          Args
+            StringLiteral "unreachable"
+    FunctionDecl set
+      Param self
+      Param index: i64
+      Param elem: T
+      ReturnType: Vector<T>
+      IfStatement
+        Condition
+          BinaryExpr <
+            Identifier index
+            IntLiteral 0
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "Vector.set: index out of bounds"
+      IfStatement
+        Condition
+          BinaryExpr >=
+            Identifier index
+            FieldExpr .len
+              Identifier self
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "Vector.set: index out of bounds"
+      ModeBlock unsafe
+        Assignment
+          Target
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .data
+                    Identifier self
+                  Identifier index
+          Value
+            Identifier elem
+      ReturnStatement
+        CallExpr
+          Callee
+            Identifier Vector
+          Args
+            FieldExpr .data
+              Identifier self
+            FieldExpr .len
+              Identifier self
+            FieldExpr .cap
+              Identifier self
+    FunctionDecl length
+      Param self
+      ReturnType: i64
+      ExprBody
+        FieldExpr .len
+          Identifier self
+  FunctionDecl vec_new<T>
+    ReturnType: Vector<T>
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Vector
+        Args
+          CallExpr
+            Callee
+              Identifier null_ptr
+            TypeArgs
+              T
+          IntLiteral 0
+          IntLiteral 0

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -260,6 +260,8 @@ File
           Identifier self
   FunctionDecl vec_new<T>
     ReturnType: Vector<T>
+    LetStatement zero: i64
+      IntLiteral 0
     ReturnStatement
       CallExpr
         Callee
@@ -270,5 +272,5 @@ File
               Identifier null_ptr
             TypeArgs
               T
-          IntLiteral 0
-          IntLiteral 0
+          Identifier zero
+          Identifier zero

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -7,23 +7,27 @@ File
       Param self
       Param elem: T
       ReturnType: Vector<T>
-      LetStatement new_len
-        BinaryExpr +
-          FieldExpr .len
-            Identifier self
-          IntLiteral 1
+      LetStatement new_cap: i64
+        FieldExpr .cap
+          Identifier self
       IfStatement
         Condition
           BinaryExpr >
-            Identifier new_len
+            BinaryExpr +
+              FieldExpr .len
+                Identifier self
+              IntLiteral 1
             FieldExpr .cap
               Identifier self
         Then
-          LetStatement new_cap: i64
-            BinaryExpr *
-              FieldExpr .cap
-                Identifier self
-              IntLiteral 2
+          Assignment
+            Target
+              Identifier new_cap
+            Value
+              BinaryExpr *
+                FieldExpr .cap
+                  Identifier self
+                IntLiteral 2
           IfStatement
             Condition
               BinaryExpr ==
@@ -36,100 +40,65 @@ File
                   Identifier new_cap
                 Value
                   IntLiteral 8
-          LetStatement new_data_raw
-            CallExpr
-              Callee
-                Identifier __dao_mem_alloc
-              Args
-                BinaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier size_of
-                    TypeArgs
-                      T
-                  Identifier new_cap
-                CallExpr
-                  Callee
-                    Identifier align_of
-                  TypeArgs
-                    T
-          ModeBlock unsafe
-            LetStatement new_data
+      LetStatement new_data_raw
+        CallExpr
+          Callee
+            Identifier __dao_mem_alloc
+          Args
+            BinaryExpr *
               CallExpr
                 Callee
-                  Identifier ptr_cast
+                  Identifier size_of
                 TypeArgs
                   T
-                Args
-                  Identifier new_data_raw
-            LetStatement i: i64
-              IntLiteral 0
-            WhileStatement
-              Condition
-                BinaryExpr <
-                  Identifier i
-                  FieldExpr .len
-                    Identifier self
-              Assignment
-                Target
-                  UnaryExpr *
-                    CallExpr
-                      Callee
-                        Identifier ptr_offset
-                      Args
-                        Identifier new_data
-                        Identifier i
-                Value
-                  UnaryExpr *
-                    CallExpr
-                      Callee
-                        Identifier ptr_offset
-                      Args
-                        FieldExpr .data
-                          Identifier self
-                        Identifier i
-              Assignment
-                Target
-                  Identifier i
-                Value
-                  BinaryExpr +
-                    Identifier i
-                    IntLiteral 1
-            Assignment
-              Target
-                UnaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier ptr_offset
-                    Args
-                      Identifier new_data
-                      FieldExpr .len
-                        Identifier self
-              Value
-                Identifier elem
-            IfStatement
-              Condition
-                BinaryExpr >
-                  FieldExpr .cap
-                    Identifier self
-                  IntLiteral 0
-              Then
-                ExpressionStatement
-                  CallExpr
-                    Callee
-                      Identifier __dao_mem_free
-                    Args
-                      FieldExpr .data
-                        Identifier self
-            ReturnStatement
-              CallExpr
-                Callee
-                  Identifier Vector
-                Args
-                  Identifier new_data
-                  Identifier new_len
-                  Identifier new_cap
+              Identifier new_cap
+            CallExpr
+              Callee
+                Identifier align_of
+              TypeArgs
+                T
       ModeBlock unsafe
+        LetStatement new_data
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              T
+            Args
+              Identifier new_data_raw
+        LetStatement i: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier i
+              FieldExpr .len
+                Identifier self
+          Assignment
+            Target
+              UnaryExpr *
+                CallExpr
+                  Callee
+                    Identifier ptr_offset
+                  Args
+                    Identifier new_data
+                    Identifier i
+            Value
+              UnaryExpr *
+                CallExpr
+                  Callee
+                    Identifier ptr_offset
+                  Args
+                    FieldExpr .data
+                      Identifier self
+                    Identifier i
+          Assignment
+            Target
+              Identifier i
+            Value
+              BinaryExpr +
+                Identifier i
+                IntLiteral 1
         Assignment
           Target
             UnaryExpr *
@@ -137,22 +106,28 @@ File
                 Callee
                   Identifier ptr_offset
                 Args
-                  FieldExpr .data
-                    Identifier self
+                  Identifier new_data
                   FieldExpr .len
                     Identifier self
           Value
             Identifier elem
-      ReturnStatement
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier Vector
+            Args
+              Identifier new_data
+              BinaryExpr +
+                FieldExpr .len
+                  Identifier self
+                IntLiteral 1
+              Identifier new_cap
+      ExpressionStatement
         CallExpr
           Callee
-            Identifier Vector
+            Identifier panic
           Args
-            FieldExpr .data
-              Identifier self
-            Identifier new_len
-            FieldExpr .cap
-              Identifier self
+            StringLiteral "unreachable"
     FunctionDecl get
       Param self
       Param index: i64
@@ -228,7 +203,66 @@ File
                 Identifier panic
               Args
                 StringLiteral "Vector.set: index out of bounds"
+      LetStatement new_data_raw
+        CallExpr
+          Callee
+            Identifier __dao_mem_alloc
+          Args
+            BinaryExpr *
+              CallExpr
+                Callee
+                  Identifier size_of
+                TypeArgs
+                  T
+              FieldExpr .cap
+                Identifier self
+            CallExpr
+              Callee
+                Identifier align_of
+              TypeArgs
+                T
       ModeBlock unsafe
+        LetStatement new_data
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              T
+            Args
+              Identifier new_data_raw
+        LetStatement i: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier i
+              FieldExpr .len
+                Identifier self
+          Assignment
+            Target
+              UnaryExpr *
+                CallExpr
+                  Callee
+                    Identifier ptr_offset
+                  Args
+                    Identifier new_data
+                    Identifier i
+            Value
+              UnaryExpr *
+                CallExpr
+                  Callee
+                    Identifier ptr_offset
+                  Args
+                    FieldExpr .data
+                      Identifier self
+                    Identifier i
+          Assignment
+            Target
+              Identifier i
+            Value
+              BinaryExpr +
+                Identifier i
+                IntLiteral 1
         Assignment
           Target
             UnaryExpr *
@@ -236,22 +270,26 @@ File
                 Callee
                   Identifier ptr_offset
                 Args
-                  FieldExpr .data
-                    Identifier self
+                  Identifier new_data
                   Identifier index
           Value
             Identifier elem
-      ReturnStatement
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier Vector
+            Args
+              Identifier new_data
+              FieldExpr .len
+                Identifier self
+              FieldExpr .cap
+                Identifier self
+      ExpressionStatement
         CallExpr
           Callee
-            Identifier Vector
+            Identifier panic
           Args
-            FieldExpr .data
-              Identifier self
-            FieldExpr .len
-              Identifier self
-            FieldExpr .cap
-              Identifier self
+            StringLiteral "unreachable"
     FunctionDecl length
       Param self
       ReturnType: i64

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -258,19 +258,19 @@ File
       ExprBody
         FieldExpr .len
           Identifier self
-  FunctionDecl vec_new<T>
-    ReturnType: Vector<T>
-    LetStatement zero: i64
-      IntLiteral 0
-    ReturnStatement
-      CallExpr
-        Callee
-          Identifier Vector
-        Args
-          CallExpr
-            Callee
-              Identifier null_ptr
-            TypeArgs
-              T
-          Identifier zero
-          Identifier zero
+    FunctionDecl new
+      ReturnType: Vector<T>
+      LetStatement zero: i64
+        IntLiteral 0
+      ReturnStatement
+        CallExpr
+          Callee
+            Identifier Vector
+          Args
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                T
+            Identifier zero
+            Identifier zero


### PR DESCRIPTION
## Summary

Implements `Vector<T>` as a genuine library type with no compiler privilege, and adds class body method declarations to the language. Vector is built entirely on the low-level memory substrate from Task 17.

## Highlights

- **Class body methods** — `fn` declarations inside `class` bodies, parsed, resolved, type-checked, and monomorphized as ordinary functions with `self` receiver
- **Generic struct monomorphization** — `substitute_type`, `type_has_generic`, `infer_bindings_recursive` all handle `TypeStruct` with generic param fields
- **Structural struct assignability** — concrete struct instantiations (`Box<i32>`) match across different `TypeStruct` instances by `decl_id` + field types
- **Constructor type inference** — `Box(42)` returns `Box<i32>`, not `Box<T>`; field types drive generic binding inference
- **Method lookup on concrete types** — falls back from exact type match to generic class methods with automatic type binding substitution
- **Call-site type arg resolution** — resolver now resolves explicit type args in `CallExpr` (was missing, broke `size_of<T>()` in method bodies)
- **Monomorphizer explicit_type_args substitution** — cloned methods correctly substitute `TypeGenericParam` in builtin call type args
- **`Vector<T>`** — `push`, `get`, `set`, `length` using alloc/ptr_cast/ptr_offset/size_of/align_of/panic
- **Contract updates** — `CONTRACT_SYNTAX_SURFACE.md` and `CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md` updated for class body methods

## Test plan

- [x] All 12 existing tests pass
- [x] `examples/vectors.dao` compiles and runs: push 4 elements, get all, set one, verify
- [x] `Box<T>.get()` works end-to-end (simple generic class method)
- [x] `Vector<T>.push()` works with allocation, pointer arithmetic, and type builtins
- [x] `v.length()` returns correct count after pushes
- [x] `v.set(1, 99)` followed by `v.get(1)` returns 99
- [x] Normal `<` comparison not regressed by call-site type arg parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)