### PR TITLE
feat(stdlib): ✨ add Vector<T> iteration

### DIFF
--- a/examples/vectors.dao
+++ b/examples/vectors.dao
@@ -1,7 +1,7 @@
 // vectors.dao — Vector<T> as an ordinary library type.
 //
-// Demonstrates push, get, set, and length on a generic dynamic array
-// built entirely from the low-level memory substrate.
+// Demonstrates push, get, set, length, and iteration on a generic
+// dynamic array built entirely from the low-level memory substrate.
 
 fn main(): i32
   // Create and populate a vector.
@@ -21,5 +21,10 @@ fn main(): i32
   // Mutation via set.
   v = v.set(1, 99)
   print(v.get(1))
+
+  // Iteration.
+  print("iterating:")
+  for x in v.iter():
+    print(x)
 
   return 0

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -62,6 +62,13 @@ class Vector<T>:
 
   fn length(self): i64 -> self.len
 
+  fn iter(self): Generator<T>
+    let i: i64 = 0
+    while i < self.len:
+      mode unsafe =>
+        yield *ptr_offset(self.data, i)
+      i = i + 1
+
   fn new(): Vector<T>
     let zero: i64 = 0
     return Vector(null_ptr<T>(), zero, zero)

--- a/testdata/ast/examples_vectors.ast
+++ b/testdata/ast/examples_vectors.ast
@@ -122,5 +122,23 @@ File
                 Identifier v
             Args
               IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "iterating:"
+    ForStatement x
+      Iterable
+        CallExpr
+          Callee
+            FieldExpr .iter
+              Identifier v
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier print
+          Args
+            Identifier x
     ReturnStatement
       IntLiteral 0

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -296,6 +296,34 @@ File
       ExprBody
         FieldExpr .len
           Identifier self
+    FunctionDecl iter
+      Param self
+      ReturnType: Generator<T>
+      LetStatement i: i64
+        IntLiteral 0
+      WhileStatement
+        Condition
+          BinaryExpr <
+            Identifier i
+            FieldExpr .len
+              Identifier self
+        ModeBlock unsafe
+          YieldStatement
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .data
+                    Identifier self
+                  Identifier i
+        Assignment
+          Target
+            Identifier i
+          Value
+            BinaryExpr +
+              Identifier i
+              IntLiteral 1
     FunctionDecl new
       ReturnType: Vector<T>
       LetStatement zero: i64


### PR DESCRIPTION
## Summary

Adds `iter()` method to `Vector<T>` returning `Generator<T>` via `yield`, enabling `for...in` loops over vectors. Zero compiler changes — uses the existing generator/coroutine infrastructure.

## Highlights

- `Vector<T>.iter()` yields elements in order using pointer offset reads
- Works with the existing `for x in expr:` loop desugaring
- No new compiler infrastructure — pure stdlib addition

## Test plan

- [x] All 12 tests pass
- [x] `examples/vectors.dao` demonstrates iteration with correct output
- [x] Iteration over mutated vector shows correct values (10, 99, 30, 40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)