### PR TITLE
feat(bootstrap): ✨ add expression parser probe — lex → parse → eval pipeline

### DIFF
--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -598,7 +598,7 @@ auto monomorphize(MirModule& module, MirContext& ctx,
   // Phase 1: identify generic functions by symbol.
   std::unordered_map<const Symbol*, MirFunction*> generic_fns;
   for (auto* fn : module.functions) {
-    if (is_generic_function(fn)) {
+    if (fn->symbol != nullptr && is_generic_function(fn)) {
       generic_fns[fn->symbol] = fn;
     }
   }
@@ -611,13 +611,17 @@ auto monomorphize(MirModule& module, MirContext& ctx,
   std::unordered_map<SpecKey, MirFunction*, SpecKeyHash> spec_cache;
 
   // Phase 2+3+4: iterate until no new specializations are produced.
+  // Use index-based iteration because specialize_call_site() may
+  // push_back new functions, invalidating range-for iterators.
   bool changed = true;
   while (changed) {
     changed = false;
 
-    for (auto* fn : module.functions) {
+    const size_t fn_count = module.functions.size();
+    for (size_t fn_idx = 0; fn_idx < fn_count; ++fn_idx) {
+      auto* fn = module.functions[fn_idx];
       // Skip generic functions themselves — they'll be removed later.
-      if (generic_fns.count(fn->symbol) != 0) {
+      if (fn->symbol != nullptr && generic_fns.count(fn->symbol) != 0) {
         continue;
       }
 
@@ -645,7 +649,7 @@ auto monomorphize(MirModule& module, MirContext& ctx,
 
   // Phase 5: remove generic originals.
   std::erase_if(module.functions, [&](const MirFunction* fn) {
-    return generic_fns.count(fn->symbol) != 0;
+    return fn->symbol != nullptr && generic_fns.count(fn->symbol) != 0;
   });
 
   return result;

--- a/examples/bootstrap_probe/expr_parser.dao
+++ b/examples/bootstrap_probe/expr_parser.dao
@@ -1,0 +1,409 @@
+// expr_parser.dao — Bootstrap probe 4: recursive-descent expression parser.
+//
+// Consumes Vector<Token> from a simple arithmetic lexer, produces a
+// flat Vector<ExprNode> arena with index-based references, then
+// evaluates the tree by walking the arena.
+//
+// Tests: parser-shaped control flow over collected token data,
+// arena-indexed structured output, recursive descent with
+// precedence, peek/advance/expect helpers, multi-phase pipeline
+// (lex → parse → eval), and composite return types containing
+// Vector<T> fields.
+//
+// Scope: integer literals, + - * /, unary minus, parentheses,
+// precedence and associativity. Nothing more.
+
+// ---------------------------------------------------------------
+// Token representation (minimal arithmetic subset)
+// ---------------------------------------------------------------
+
+fn TK_INT(): i32    -> 1
+fn TK_PLUS(): i32   -> 2
+fn TK_MINUS(): i32  -> 3
+fn TK_STAR(): i32   -> 4
+fn TK_SLASH(): i32  -> 5
+fn TK_LPAREN(): i32 -> 6
+fn TK_RPAREN(): i32 -> 7
+fn TK_EOF(): i32    -> 8
+fn TK_ERROR(): i32  -> 9
+
+class Token:
+  kind: i32
+  offset: i64
+  len: i64
+
+fn make_token(k: i32, off: i64, l: i64): Token
+  return Token(k, off, l)
+
+// ---------------------------------------------------------------
+// Lexer (arithmetic subset only)
+// ---------------------------------------------------------------
+
+fn is_digit(ch: i32): bool
+  return ch >= 48 and ch <= 57
+
+fn is_whitespace(ch: i32): bool
+  return ch == 32 or ch == 9 or ch == 10 or ch == 13
+
+fn lex(source: string): Vector<Token>
+  let tokens = Vector<Token>::new()
+  let pos: i64 = 0
+  let slen: i64 = length(source)
+  while pos < slen:
+    let ch: i32 = char_at(source, pos)
+    if is_whitespace(ch):
+      pos = pos + 1
+    else:
+      if is_digit(ch):
+        let end: i64 = pos + 1
+        while end < slen:
+          if is_digit(char_at(source, end)):
+            end = end + 1
+          else:
+            break
+        tokens = tokens.push(make_token(TK_INT(), pos, end - pos))
+        pos = end
+      else:
+        if ch == 43:
+          tokens = tokens.push(make_token(TK_PLUS(), pos, to_i64(1)))
+          pos = pos + 1
+        else:
+          if ch == 45:
+            tokens = tokens.push(make_token(TK_MINUS(), pos, to_i64(1)))
+            pos = pos + 1
+          else:
+            if ch == 42:
+              tokens = tokens.push(make_token(TK_STAR(), pos, to_i64(1)))
+              pos = pos + 1
+            else:
+              if ch == 47:
+                tokens = tokens.push(make_token(TK_SLASH(), pos, to_i64(1)))
+                pos = pos + 1
+              else:
+                if ch == 40:
+                  tokens = tokens.push(make_token(TK_LPAREN(), pos, to_i64(1)))
+                  pos = pos + 1
+                else:
+                  if ch == 41:
+                    tokens = tokens.push(make_token(TK_RPAREN(), pos, to_i64(1)))
+                    pos = pos + 1
+                  else:
+                    tokens = tokens.push(make_token(TK_ERROR(), pos, to_i64(1)))
+                    pos = pos + 1
+  // Append EOF sentinel.
+  tokens = tokens.push(make_token(TK_EOF(), slen, to_i64(0)))
+  return tokens
+
+// ---------------------------------------------------------------
+// AST arena node
+// ---------------------------------------------------------------
+
+fn NK_INT_LIT(): i32  -> 1
+fn NK_BINARY(): i32   -> 2
+fn NK_UNARY(): i32    -> 3
+
+class ExprNode:
+  kind: i32
+  value: i64     // int literal value, or operator token kind
+  left: i64      // arena index (-1 = none)
+  right: i64     // arena index (-1 = none)
+
+fn make_node(k: i32, v: i64, l: i64, r: i64): ExprNode
+  return ExprNode(k, v, l, r)
+
+fn no_child(): i64 -> to_i64(-1)
+
+// ---------------------------------------------------------------
+// Parse result — bundles arena + node index + cursor position
+// ---------------------------------------------------------------
+
+class ParseResult:
+  arena: Vector<ExprNode>
+  node: i64
+  pos: i64
+
+// Error sentinel: node index -1 signals parse failure.
+fn parse_error(arena: Vector<ExprNode>, pos: i64): ParseResult
+  return ParseResult(arena, to_i64(-1), pos)
+
+fn is_parse_ok(r: ParseResult): bool
+  return r.node >= to_i64(0)
+
+// ---------------------------------------------------------------
+// Parser helpers
+// ---------------------------------------------------------------
+
+fn peek(tokens: Vector<Token>, pos: i64): i32
+  if pos >= tokens.length():
+    return TK_EOF()
+  let tok: Token = tokens.get(pos)
+  return tok.kind
+
+fn token_text_to_i64(source: string, tok: Token): i64
+  // Parse integer literal from source span.
+  let result: i64 = 0
+  let i: i64 = 0
+  while i < tok.len:
+    let ch: i32 = char_at(source, tok.offset + i)
+    result = result * to_i64(10) + to_i64(ch - 48)
+    i = i + 1
+  return result
+
+// ---------------------------------------------------------------
+// Recursive descent parser
+//
+// Grammar:
+//   expr     → additive
+//   additive → multiplicative (('+' | '-') multiplicative)*
+//   multiplicative → unary (('*' | '/') unary)*
+//   unary    → '-' unary | primary
+//   primary  → INT | '(' expr ')'
+// ---------------------------------------------------------------
+
+fn parse_primary(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
+  let kind: i32 = peek(tokens, pos)
+
+  // Integer literal.
+  if kind == TK_INT():
+    let tok: Token = tokens.get(pos)
+    let val: i64 = token_text_to_i64(source, tok)
+    let idx: i64 = arena.length()
+    let new_arena: Vector<ExprNode> = arena.push(make_node(NK_INT_LIT(), val, no_child(), no_child()))
+    return ParseResult(new_arena, idx, pos + 1)
+
+  // Parenthesized expression.
+  if kind == TK_LPAREN():
+    let inner: ParseResult = parse_expr(tokens, source, arena, pos + 1)
+    if is_parse_ok(inner) == false:
+      return inner
+    // Expect closing paren.
+    if peek(tokens, inner.pos) != TK_RPAREN():
+      print("error: expected ')'")
+      return parse_error(inner.arena, inner.pos)
+    return ParseResult(inner.arena, inner.node, inner.pos + 1)
+
+  print("error: expected integer or '('")
+  return parse_error(arena, pos)
+
+fn parse_unary(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
+  // Unary minus.
+  if peek(tokens, pos) == TK_MINUS():
+    let operand: ParseResult = parse_unary(tokens, source, arena, pos + 1)
+    if is_parse_ok(operand) == false:
+      return operand
+    let idx: i64 = operand.arena.length()
+    let new_arena: Vector<ExprNode> = operand.arena.push(
+      make_node(NK_UNARY(), to_i64(TK_MINUS()), operand.node, no_child()))
+    return ParseResult(new_arena, idx, operand.pos)
+
+  return parse_primary(tokens, source, arena, pos)
+
+fn parse_multiplicative(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
+  let left: ParseResult = parse_unary(tokens, source, arena, pos)
+  if is_parse_ok(left) == false:
+    return left
+  let result: ParseResult = left
+  let done: bool = false
+  while done == false:
+    let op: i32 = peek(tokens, result.pos)
+    if op == TK_STAR() or op == TK_SLASH():
+      let right: ParseResult = parse_unary(tokens, source, result.arena, result.pos + 1)
+      if is_parse_ok(right) == false:
+        return right
+      let idx: i64 = right.arena.length()
+      let new_arena: Vector<ExprNode> = right.arena.push(
+        make_node(NK_BINARY(), to_i64(op), result.node, right.node))
+      result = ParseResult(new_arena, idx, right.pos)
+    else:
+      done = true
+  return result
+
+fn parse_additive(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
+  let left: ParseResult = parse_multiplicative(tokens, source, arena, pos)
+  if is_parse_ok(left) == false:
+    return left
+  let result: ParseResult = left
+  let done: bool = false
+  while done == false:
+    let op: i32 = peek(tokens, result.pos)
+    if op == TK_PLUS() or op == TK_MINUS():
+      let right: ParseResult = parse_multiplicative(tokens, source, result.arena, result.pos + 1)
+      if is_parse_ok(right) == false:
+        return right
+      let idx: i64 = right.arena.length()
+      let new_arena: Vector<ExprNode> = right.arena.push(
+        make_node(NK_BINARY(), to_i64(op), result.node, right.node))
+      result = ParseResult(new_arena, idx, right.pos)
+    else:
+      done = true
+  return result
+
+fn parse_expr(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
+  return parse_additive(tokens, source, arena, pos)
+
+fn parse(tokens: Vector<Token>, source: string): ParseResult
+  let arena = Vector<ExprNode>::new()
+  let result: ParseResult = parse_expr(tokens, source, arena, to_i64(0))
+  if is_parse_ok(result):
+    // Verify we consumed all tokens (except EOF).
+    if peek(tokens, result.pos) != TK_EOF():
+      print("error: unexpected token after expression")
+      return parse_error(result.arena, result.pos)
+  return result
+
+// ---------------------------------------------------------------
+// Evaluator — walks the arena by index
+// ---------------------------------------------------------------
+
+fn eval_node(arena: Vector<ExprNode>, idx: i64): i64
+  let node: ExprNode = arena.get(idx)
+  if node.kind == NK_INT_LIT():
+    return node.value
+  if node.kind == NK_UNARY():
+    let operand: i64 = eval_node(arena, node.left)
+    return to_i64(0) - operand
+  if node.kind == NK_BINARY():
+    let lval: i64 = eval_node(arena, node.left)
+    let rval: i64 = eval_node(arena, node.right)
+    let op: i32 = i64_to_i32(node.value)
+    if op == TK_PLUS():
+      return lval + rval
+    if op == TK_MINUS():
+      return lval - rval
+    if op == TK_STAR():
+      return lval * rval
+    if op == TK_SLASH():
+      if rval != to_i64(0):
+        return lval / rval
+      print("error: division by zero")
+      return to_i64(0)
+  print("error: unknown node kind")
+  return to_i64(0)
+
+// ---------------------------------------------------------------
+// Arena printer — dump structure for debugging
+// ---------------------------------------------------------------
+
+fn op_name(op: i32): string
+  if op == TK_PLUS():
+    return "+"
+  if op == TK_MINUS():
+    return "-"
+  if op == TK_STAR():
+    return "*"
+  if op == TK_SLASH():
+    return "/"
+  return "?"
+
+fn print_node(arena: Vector<ExprNode>, idx: i64, depth: i32): i32
+  let node: ExprNode = arena.get(idx)
+  let indent: string = ""
+  let d: i32 = 0
+  while d < depth:
+    indent = indent + "  "
+    d = d + 1
+  if node.kind == NK_INT_LIT():
+    print(indent + "INT " + i64_to_string(node.value))
+  if node.kind == NK_UNARY():
+    print(indent + "NEG")
+    let unused: i32 = print_node(arena, node.left, depth + 1)
+  if node.kind == NK_BINARY():
+    print(indent + "BIN " + op_name(i64_to_i32(node.value)))
+    let unused1: i32 = print_node(arena, node.left, depth + 1)
+    let unused2: i32 = print_node(arena, node.right, depth + 1)
+  return 0
+
+// ---------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------
+
+fn test_expr(label: string, source: string, expected: i64): bool
+  let tokens: Vector<Token> = lex(source)
+  let result: ParseResult = parse(tokens, source)
+  if is_parse_ok(result) == false:
+    print("FAIL " + label + ": parse error")
+    return false
+  let actual: i64 = eval_node(result.arena, result.node)
+  if actual == expected:
+    print("PASS " + label + " = " + i64_to_string(actual))
+    return true
+  else:
+    print("FAIL " + label + ": expected " + i64_to_string(expected) + ", got " + i64_to_string(actual))
+    return false
+
+// ---------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------
+
+fn main(): i32
+  print("=== expr_parser: lex -> parse -> eval ===")
+  print("")
+
+  // --- Basic cases ---
+  let pass_count: i32 = 0
+
+  if test_expr("literal", "42", to_i64(42)):
+    pass_count = pass_count + 1
+  if test_expr("add", "1 + 2", to_i64(3)):
+    pass_count = pass_count + 1
+  if test_expr("sub", "10 - 3", to_i64(7)):
+    pass_count = pass_count + 1
+  if test_expr("mul", "4 * 5", to_i64(20)):
+    pass_count = pass_count + 1
+  if test_expr("div", "20 / 4", to_i64(5)):
+    pass_count = pass_count + 1
+
+  // --- Precedence ---
+  if test_expr("prec1", "2 + 3 * 4", to_i64(14)):
+    pass_count = pass_count + 1
+  if test_expr("prec2", "2 * 3 + 4", to_i64(10)):
+    pass_count = pass_count + 1
+  if test_expr("prec3", "10 - 2 * 3", to_i64(4)):
+    pass_count = pass_count + 1
+
+  // --- Associativity ---
+  if test_expr("assoc_sub", "10 - 3 - 2", to_i64(5)):
+    pass_count = pass_count + 1
+  if test_expr("assoc_div", "24 / 4 / 2", to_i64(3)):
+    pass_count = pass_count + 1
+
+  // --- Parentheses ---
+  if test_expr("parens1", "(2 + 3) * 4", to_i64(20)):
+    pass_count = pass_count + 1
+  if test_expr("parens2", "2 * (3 + 4)", to_i64(14)):
+    pass_count = pass_count + 1
+  if test_expr("nested_parens", "((2 + 3))", to_i64(5)):
+    pass_count = pass_count + 1
+
+  // --- Unary minus ---
+  if test_expr("neg", "-5", to_i64(-5)):
+    pass_count = pass_count + 1
+  if test_expr("neg_expr", "-(3 + 4)", to_i64(-7)):
+    pass_count = pass_count + 1
+  if test_expr("double_neg", "--5", to_i64(5)):
+    pass_count = pass_count + 1
+
+  // --- Combined ---
+  if test_expr("complex1", "2 + 3 * 4 - 1", to_i64(13)):
+    pass_count = pass_count + 1
+  if test_expr("complex2", "(1 + 2) * (3 + 4)", to_i64(21)):
+    pass_count = pass_count + 1
+  if test_expr("complex3", "-2 * (3 + -4) * -5", to_i64(-10)):
+    pass_count = pass_count + 1
+
+  let total: i32 = 19
+  print("")
+  print("--- results ---")
+  print(i32_to_string(pass_count) + " / " + i32_to_string(total) + " passed")
+
+  // --- Show arena structure for one expression ---
+  print("")
+  print("--- arena dump: (2 + 3) * 4 ---")
+  let demo_source: string = "(2 + 3) * 4"
+  let demo_tokens: Vector<Token> = lex(demo_source)
+  let demo_result: ParseResult = parse(demo_tokens, demo_source)
+  if is_parse_ok(demo_result):
+    print("arena size: " + i64_to_string(demo_result.arena.length()) + " nodes")
+    let unused: i32 = print_node(demo_result.arena, demo_result.node, 0)
+
+  return 0


### PR DESCRIPTION
## Summary

Add bootstrap probe 4: a recursive-descent arithmetic parser that exercises the full lex → parse → eval pipeline over collected data structures. Fix two latent monomorphizer bugs that surfaced under the probe's heavier generic instantiation load.

## Highlights

- **Monomorphizer iterator-invalidation fix**: range-for over `module.functions` was invalidated by `push_back()` during specialization — switch to index-based iteration with pre-snapshot size
- **Monomorphizer null-symbol guard**: synthesized specializations have null `symbol` pointers; three hash lookups now guard against null before calling `.count()`
- **Expression parser probe** (`expr_parser.dao`): recursive-descent parser consuming `Vector<Token>`, producing flat `Vector<ExprNode>` arena with index-based node references, plus a tree-walking evaluator
- **19/19 test cases**: literals, `+ - * /` with correct precedence and left-associativity, parenthesized grouping, unary minus, double negation, compound expressions
- **ParseResult bundles `Vector<ExprNode>` + cursor**: first Dao program to pass composite return types containing generic containers through recursive function calls
- **Arena dump**: prints tree structure to verify correct parse output (`BIN * / BIN + / INT 2 / INT 3 / INT 4`)

## Test plan

- [x] All 12 compiler tests pass (`ctest`)
- [x] Existing examples compile and run unchanged (vectors, dao_lexer, vector_tokenizer)
- [x] `expr_parser.dao` compiles and passes 19/19 evaluation tests
- [x] Arena dump shows correct tree structure for `(2 + 3) * 4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)