### PR TITLE
feat(lang): ✨ add payload-free enum types — full pipeline

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -53,6 +53,8 @@ auto lexical_category(TokenKind kind) -> std::string_view {
     return "keyword.fn";
   case TokenKind::KwClass:
     return "keyword.type";
+  case TokenKind::KwEnum:
+    return "keyword.type";
   case TokenKind::KwType:
     return "keyword.type";
   case TokenKind::KwLet:
@@ -249,6 +251,9 @@ private:
     case NodeKind::ClassDecl:
       visit_class(decl);
       break;
+    case NodeKind::EnumDecl:
+      visit_enum(decl);
+      break;
     case NodeKind::AliasDecl:
       visit_alias(decl);
       break;
@@ -292,6 +297,14 @@ private:
       if (field->type != nullptr) {
         visit_type(*field->type);
       }
+    }
+  }
+
+  void visit_enum(const Decl& decl) {
+    const auto& en = decl.as<EnumDeclNode>();
+    classify(en.name_span, "decl.type");
+    for (const auto& variant : en.variants) {
+      classify(variant.name_span, "decl.field");
     }
   }
 

--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -72,11 +72,9 @@ auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
     return nullptr;
   }
 
-  case TypeKind::Enum: {
-    const auto* e = static_cast<const TypeEnum*>(type);
-    error_ = "enum lowering not yet implemented: " + std::string(e->name());
-    return nullptr;
-  }
+  case TypeKind::Enum:
+    // Payload-free enums lower to i32 discriminant tag.
+    return llvm::Type::getInt32Ty(ctx_);
 
   case TypeKind::Generator:
     // Generator<T> is a fat pair: { ptr frame, ptr resume_fn }.

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -10,6 +10,7 @@ auto Decl::kind() const -> NodeKind {
   return std::visit(overloaded{
       [](const FunctionDecl&) { return NodeKind::FunctionDecl; },
       [](const ClassDecl&) { return NodeKind::ClassDecl; },
+      [](const EnumDeclNode&) { return NodeKind::EnumDecl; },
       [](const AliasDecl&) { return NodeKind::AliasDecl; },
       [](const ConceptDecl&) { return NodeKind::ConceptDecl; },
       [](const ExtendDecl&) { return NodeKind::ExtendDecl; },
@@ -77,6 +78,8 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "FunctionDecl";
   case NodeKind::ClassDecl:
     return "ClassDecl";
+  case NodeKind::EnumDecl:
+    return "EnumDecl";
   case NodeKind::AliasDecl:
     return "AliasDecl";
   case NodeKind::ConceptDecl:

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -47,6 +47,7 @@ enum class NodeKind : std::uint8_t {
   // Declarations
   FunctionDecl,
   ClassDecl,
+  EnumDecl,
   AliasDecl,
   ConceptDecl,
   ExtendDecl,
@@ -223,6 +224,17 @@ struct ClassDecl {
   std::vector<DenySpec> denials;
 };
 
+struct EnumVariantSpec {
+  std::string_view name;
+  Span name_span;
+};
+
+struct EnumDeclNode {
+  std::string_view name;
+  Span name_span;
+  std::vector<EnumVariantSpec> variants;
+};
+
 struct AliasDecl {
   std::string_view name;
   Span name_span;
@@ -251,8 +263,8 @@ struct ErrorStmtNode {};
 struct ErrorExprNode {};
 
 using DeclPayload =
-    std::variant<FunctionDecl, ClassDecl, AliasDecl, ConceptDecl, ExtendDecl,
-                 ErrorDeclNode>;
+    std::variant<FunctionDecl, ClassDecl, EnumDeclNode, AliasDecl, ConceptDecl,
+                 ExtendDecl, ErrorDeclNode>;
 
 // ---------------------------------------------------------------------------
 // Statement payloads

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -68,6 +68,7 @@ private:
     std::visit(overloaded{
         [&](const FunctionDecl& fn) { print_function_decl(fn); },
         [&](const ClassDecl& cls) { print_class_decl(cls); },
+        [&](const EnumDeclNode& en) { print_enum_decl(en); },
         [&](const AliasDecl& alias) { print_alias_decl(alias); },
         [&](const ConceptDecl& concept_) { print_concept_decl(concept_); },
         [&](const ExtendDecl& ext) { print_extend_decl(ext); },
@@ -167,6 +168,16 @@ private:
     for (const auto& deny : node.denials) {
       indent();
       out_ << "Deny " << deny.concept_name << "\n";
+    }
+  }
+
+  void print_enum_decl(const EnumDeclNode& node) {
+    indent();
+    out_ << "EnumDecl " << node.name << "\n";
+    Scope scope(depth_);
+    for (const auto& variant : node.variants) {
+      indent();
+      out_ << "Variant " << variant.name << "\n";
     }
   }
 

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -14,6 +14,8 @@ auto token_kind_name(TokenKind kind) -> const char* {
     return "KwFn";
   case TokenKind::KwClass:
     return "KwClass";
+  case TokenKind::KwEnum:
+    return "KwEnum";
   case TokenKind::KwType:
     return "KwType";
   case TokenKind::KwLet:
@@ -532,6 +534,9 @@ private:
     }
     if (word == "class") {
       return TokenKind::KwClass;
+    }
+    if (word == "enum") {
+      return TokenKind::KwEnum;
     }
     if (word == "type") {
       return TokenKind::KwType;

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -17,6 +17,7 @@ enum class TokenKind : std::uint8_t {
   KwExtern,
   KwFn,
   KwClass,
+  KwEnum,
   KwType,
   KwLet,
   KwIf,

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -208,6 +208,8 @@ private:
       return parse_function_decl(/*is_extern=*/false);
     case TokenKind::KwClass:
       return parse_class_decl();
+    case TokenKind::KwEnum:
+      return parse_enum_decl();
     case TokenKind::KwType:
       return parse_alias_decl();
     case TokenKind::KwConcept:
@@ -231,7 +233,7 @@ private:
                             .type_params = {}, .fields = std::move(fields),
                             .conformances = {}, .denials = {}});
       }
-      error("expected declaration (fn, extern, class, concept, extend, or type)");
+      error("expected declaration (fn, extern, class, enum, concept, extend, or type)");
       advance(); // skip problematic token
       return nullptr;
     }
@@ -408,6 +410,39 @@ private:
       error("class body must contain at least one field");
     }
     return body;
+  }
+
+  auto parse_enum_decl() -> Decl* {
+    const auto& kw = consume(TokenKind::KwEnum);
+    const auto& name_tok = consume(TokenKind::Identifier);
+    consume(TokenKind::Colon);
+    consume(TokenKind::Newline);
+    consume(TokenKind::Indent);
+    std::vector<EnumVariantSpec> variants;
+    while (peek_kind() != TokenKind::Dedent && peek_kind() != TokenKind::Eof) {
+      skip_newlines();
+      if (peek_kind() == TokenKind::Dedent || peek_kind() == TokenKind::Eof) {
+        break;
+      }
+      if (peek_kind() != TokenKind::Identifier) {
+        error("expected variant name in enum body");
+        advance();
+        continue;
+      }
+      const auto& variant_tok = consume(TokenKind::Identifier);
+      variants.push_back({.name = variant_tok.text, .name_span = variant_tok.span});
+      if (peek_kind() == TokenKind::Newline) {
+        advance();
+      }
+    }
+    consume(TokenKind::Dedent);
+    if (variants.empty()) {
+      error("enum must contain at least one variant");
+    }
+    Span span = span_from(kw.span);
+    return ctx_.alloc<Decl>(
+        span, EnumDeclNode{.name = name_tok.text, .name_span = name_tok.span,
+                           .variants = std::move(variants)});
   }
 
   auto parse_conformance_block() -> ConformanceBlock {

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -172,6 +172,13 @@ private:
       kind = SymbolKind::Type;
       break;
     }
+    case NodeKind::EnumDecl: {
+      const auto& en = decl.as<EnumDeclNode>();
+      name = en.name;
+      name_span = en.name_span;
+      kind = SymbolKind::Type;
+      break;
+    }
     case NodeKind::AliasDecl: {
       const auto& alias = decl.as<AliasDecl>();
       name = alias.name;
@@ -325,6 +332,10 @@ private:
       break;
     case NodeKind::ClassDecl:
       resolve_class(decl, scope);
+      break;
+    case NodeKind::EnumDecl:
+      // Enum variants are resolved through qualified access (Enum.Variant),
+      // not through body resolution. Nothing to resolve here.
       break;
     case NodeKind::AliasDecl:
       resolve_alias(decl, scope);

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -453,6 +453,26 @@ void TypeChecker::register_declarations(const FileNode& file) {
       break;
     }
 
+    case NodeKind::EnumDecl: {
+      const auto& en = decl->as<EnumDeclNode>();
+      auto decl_it = decl_symbols_.find(en.name_span.offset);
+      if (decl_it == decl_symbols_.end()) {
+        break;
+      }
+      const auto* sym = decl_it->second;
+
+      // Build enum type from variant specifiers.
+      std::vector<EnumVariant> variants;
+      for (const auto& variant : en.variants) {
+        variants.push_back({variant.name, {}});
+      }
+      const auto* enum_type =
+          types_.make_enum(sym, en.name, std::move(variants));
+      symbol_types_[sym] = enum_type;
+      typed_.set_decl_type(decl, enum_type);
+      break;
+    }
+
     case NodeKind::ExtendDecl: {
       // Register extend methods as typed functions so HIR lowering
       // can find their type info via decl_type().
@@ -1824,6 +1844,20 @@ auto TypeChecker::check_field(const Expr* expr) -> const Type* {
         return f.type;
       }
     }
+  }
+
+  // Enum variant access: EnumName.VariantName → the enum type.
+  if (obj_type->kind() == TypeKind::Enum) {
+    const auto* en = static_cast<const TypeEnum*>(obj_type);
+    for (const auto& variant : en->variants()) {
+      if (variant.name == field.field) {
+        return obj_type;
+      }
+    }
+    error(field.field_span,
+          "'" + std::string(field.field) + "' is not a variant of '" +
+              std::string(en->name()) + "'");
+    return nullptr;
   }
 
   // Try method lookup on any type (struct conformances + extend decls).

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -96,6 +96,12 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
       }
       return true;
     }
+    case TypeKind::Enum: {
+      // Same enum type: match by decl_id.
+      const auto* se = static_cast<const TypeEnum*>(source);
+      const auto* te = static_cast<const TypeEnum*>(target);
+      return se->decl_id() == te->decl_id();
+    }
     default:
       break;
     }

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -404,6 +404,16 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
 
   case NodeKind::FieldExpr: {
     const auto& field = expr->as<FieldExpr>();
+    // Enum variant access: lower to integer constant with enum type.
+    if (type != nullptr && type->kind() == TypeKind::Enum) {
+      const auto* enum_type = static_cast<const TypeEnum*>(type);
+      for (size_t i = 0; i < enum_type->variants().size(); ++i) {
+        if (enum_type->variants()[i].name == field.field) {
+          return ctx_.alloc<HirExpr>(span, type,
+                                      HirIntLiteral{static_cast<int64_t>(i)});
+        }
+      }
+    }
     auto* object = lower_expr(field.object);
     return ctx_.alloc<HirExpr>(span, type,
                                 HirField{object, field.field});

--- a/examples/enums.dao
+++ b/examples/enums.dao
@@ -1,0 +1,43 @@
+// enums.dao — Payload-free enum types.
+//
+// Demonstrates enum declaration, qualified variant access,
+// equality comparison, and enum as function parameter/return.
+
+enum Direction:
+  North
+  South
+  East
+  West
+
+fn opposite(d: Direction): Direction
+  if d == Direction.North:
+    return Direction.South
+  if d == Direction.South:
+    return Direction.North
+  if d == Direction.East:
+    return Direction.West
+  return Direction.East
+
+fn direction_name(d: Direction): string
+  if d == Direction.North:
+    return "North"
+  if d == Direction.South:
+    return "South"
+  if d == Direction.East:
+    return "East"
+  if d == Direction.West:
+    return "West"
+  return "?"
+
+fn main(): i32
+  let d: Direction = Direction.East
+  print("direction: " + direction_name(d))
+  print("opposite:  " + direction_name(opposite(d)))
+
+  // Equality.
+  if d == Direction.East:
+    print("heading east")
+  if d != Direction.North:
+    print("not heading north")
+
+  return 0

--- a/testdata/ast/examples_enums.ast
+++ b/testdata/ast/examples_enums.ast
@@ -1,0 +1,144 @@
+File
+  EnumDecl Direction
+    Variant North
+    Variant South
+    Variant East
+    Variant West
+  FunctionDecl opposite
+    Param d: Direction
+    ReturnType: Direction
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .North
+            Identifier Direction
+      Then
+        ReturnStatement
+          FieldExpr .South
+            Identifier Direction
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .South
+            Identifier Direction
+      Then
+        ReturnStatement
+          FieldExpr .North
+            Identifier Direction
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .East
+            Identifier Direction
+      Then
+        ReturnStatement
+          FieldExpr .West
+            Identifier Direction
+    ReturnStatement
+      FieldExpr .East
+        Identifier Direction
+  FunctionDecl direction_name
+    Param d: Direction
+    ReturnType: string
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .North
+            Identifier Direction
+      Then
+        ReturnStatement
+          StringLiteral "North"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .South
+            Identifier Direction
+      Then
+        ReturnStatement
+          StringLiteral "South"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .East
+            Identifier Direction
+      Then
+        ReturnStatement
+          StringLiteral "East"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .West
+            Identifier Direction
+      Then
+        ReturnStatement
+          StringLiteral "West"
+    ReturnStatement
+      StringLiteral "?"
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement d: Direction
+      FieldExpr .East
+        Identifier Direction
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "direction: "
+            CallExpr
+              Callee
+                Identifier direction_name
+              Args
+                Identifier d
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "opposite:  "
+            CallExpr
+              Callee
+                Identifier direction_name
+              Args
+                CallExpr
+                  Callee
+                    Identifier opposite
+                  Args
+                    Identifier d
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier d
+          FieldExpr .East
+            Identifier Direction
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "heading east"
+    IfStatement
+      Condition
+        BinaryExpr !=
+          Identifier d
+          FieldExpr .North
+            Identifier Direction
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "not heading north"
+    ReturnStatement
+      IntLiteral 0


### PR DESCRIPTION
## Summary

Add enum declarations as a first-class language feature, wired through every compiler phase from lexer to LLVM backend. This is the direct response to the bootstrap probe's demonstrated pain point: magic-number kind tagging in parser-shaped code.

## Highlights

- **Full pipeline**: `KwEnum` token → `EnumDeclNode` AST → resolver registration → `TypeEnum` creation → variant lookup via `EnumName.Variant` → HIR integer constant lowering → i32 LLVM tag
- **Qualified variant access**: `Color.Red`, `TokenKind.Plus` — variant names are scoped to the enum, accessed via dot notation
- **Equality/inequality**: `==` and `!=` work between same-enum values via `is_assignable` with `TypeKind::Enum` case
- **Function parameter/return**: enums work as function types — `fn opposite(d: Direction): Direction`
- **Semantic tokens**: `enum` keyword classified as `keyword.type`, enum name as `decl.type`, variants as `decl.field`
- **12 files changed, ~150 lines added** — minimal cross-cutting change touching lexer, parser, AST, resolver, typechecker, type_conversion, HIR builder, LLVM type lowering, semantic tokens, AST printer

## Reserved syntax (not implemented yet)

```dao
enum TokenKind:       // ✅ implemented — auto-incrementing from 0
  Int
  Plus

enum HttpMethod(string):  // reserved — explicit backing type
  Get = "GET"             // reserved — explicit values
```

## Test plan

- [x] All 12 existing tests pass (`ctest`)
- [x] All existing examples compile and run unchanged
- [x] New `examples/enums.dao` — Direction enum with opposite(), equality, dispatch
- [x] Enum as function parameter and return type
- [x] Variant equality (`==`) and inequality (`!=`)
- [x] Distinct variants produce distinct values (Plus != Minus)
- [x] 8-variant enum (TokenKind) with exhaustive if-chain dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)