### PR TITLE
feat(lang): ✨ add else-if chains and match statements

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -75,6 +75,8 @@ auto lexical_category(TokenKind kind) -> std::string_view {
     return "keyword.yield";
   case TokenKind::KwBreak:
     return "keyword.break";
+  case TokenKind::KwMatch:
+    return "keyword.match";
 
   // Keywords — execution / resource constructs
   case TokenKind::KwMode:

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -27,6 +27,7 @@ auto Stmt::kind() const -> NodeKind {
       [](const ForStatement&) { return NodeKind::ForStatement; },
       [](const YieldStatement&) { return NodeKind::YieldStatement; },
       [](const BreakStmtNode&) { return NodeKind::BreakStatement; },
+      [](const MatchStmt&) { return NodeKind::MatchStatement; },
       [](const ModeBlock&) { return NodeKind::ModeBlock; },
       [](const ResourceBlock&) { return NodeKind::ResourceBlock; },
       [](const ReturnStatement&) { return NodeKind::ReturnStatement; },
@@ -102,6 +103,8 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "YieldStatement";
   case NodeKind::BreakStatement:
     return "BreakStatement";
+  case NodeKind::MatchStatement:
+    return "MatchStatement";
   case NodeKind::ModeBlock:
     return "ModeBlock";
   case NodeKind::ResourceBlock:

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -63,6 +63,7 @@ enum class NodeKind : std::uint8_t {
   ForStatement,
   YieldStatement,
   BreakStatement,
+  MatchStatement,
   ModeBlock,
   ResourceBlock,
   ReturnStatement,
@@ -324,6 +325,16 @@ struct YieldStatement {
 
 struct BreakStmtNode {};
 
+struct MatchArm {
+  Expr* pattern;             // constant or qualified enum variant
+  std::vector<Stmt*> body;
+};
+
+struct MatchStmt {
+  Expr* scrutinee;
+  std::vector<MatchArm> arms;
+};
+
 struct ReturnStatement {
   Expr* value; // nullable for bare return
 };
@@ -334,8 +345,8 @@ struct ExpressionStatement {
 
 using StmtPayload = std::variant<
     LetStatement, Assignment, IfStatement, WhileStatement, ForStatement,
-    YieldStatement, BreakStmtNode, ModeBlock, ResourceBlock, ReturnStatement,
-    ExpressionStatement, ErrorStmtNode>;
+    YieldStatement, BreakStmtNode, MatchStmt, ModeBlock, ResourceBlock,
+    ReturnStatement, ExpressionStatement, ErrorStmtNode>;
 
 // ---------------------------------------------------------------------------
 // Expression payloads

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -332,6 +332,35 @@ private:
           indent();
           out_ << "BreakStatement\n";
         },
+        [&](const MatchStmt& node) {
+          indent();
+          out_ << "MatchStatement\n";
+          {
+            Scope scope(depth_);
+            indent();
+            out_ << "Scrutinee\n";
+            {
+              Scope inner(depth_);
+              print_expr(*node.scrutinee);
+            }
+            for (const auto& arm : node.arms) {
+              indent();
+              out_ << "Arm\n";
+              {
+                Scope arm_scope(depth_);
+                indent();
+                out_ << "Pattern\n";
+                {
+                  Scope pat(depth_);
+                  print_expr(*arm.pattern);
+                }
+                for (const auto* s : arm.body) {
+                  print_stmt(*s);
+                }
+              }
+            }
+          }
+        },
         [&](const ReturnStatement& node) {
           indent();
           out_ << "ReturnStatement\n";

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -36,6 +36,8 @@ auto token_kind_name(TokenKind kind) -> const char* {
     return "KwYield";
   case TokenKind::KwBreak:
     return "KwBreak";
+  case TokenKind::KwMatch:
+    return "KwMatch";
   case TokenKind::KwMode:
     return "KwMode";
   case TokenKind::KwResource:
@@ -564,6 +566,9 @@ private:
     }
     if (word == "yield") {
       return TokenKind::KwYield;
+    }
+    if (word == "match") {
+      return TokenKind::KwMatch;
     }
     if (word == "break") {
       return TokenKind::KwBreak;

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -28,6 +28,7 @@ enum class TokenKind : std::uint8_t {
   KwReturn,
   KwYield,
   KwBreak,
+  KwMatch,
 
   // Keywords — execution / resource constructs
   KwMode,

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -641,6 +641,8 @@ private:
       return parse_while_statement();
     case TokenKind::KwFor:
       return parse_for_statement();
+    case TokenKind::KwMatch:
+      return parse_match_statement();
     case TokenKind::KwMode:
       return parse_mode_block();
     case TokenKind::KwResource:
@@ -746,8 +748,13 @@ private:
     std::vector<Stmt*> else_body;
     if (peek_kind() == TokenKind::KwElse) {
       advance(); // else
-      consume(TokenKind::Colon);
-      else_body = parse_suite();
+      if (peek_kind() == TokenKind::KwIf) {
+        // else if — parse as a nested if-statement in the else body.
+        else_body.push_back(parse_if_statement());
+      } else {
+        consume(TokenKind::Colon);
+        else_body = parse_suite();
+      }
     }
 
     Span span = span_from(kw.span);
@@ -755,6 +762,39 @@ private:
         span, IfStatement{.condition = condition,
                           .then_body = std::move(then_body),
                           .else_body = std::move(else_body)});
+  }
+
+  auto parse_match_statement() -> Stmt* {
+    const auto& kw = consume(TokenKind::KwMatch);
+    auto* scrutinee = parse_expression();
+    if (is_error_expr(scrutinee)) {
+      synchronize_to_statement();
+      return make_error_stmt(span_from(kw.span));
+    }
+    consume(TokenKind::Colon);
+    consume(TokenKind::Newline);
+    consume(TokenKind::Indent);
+
+    std::vector<MatchArm> arms;
+    while (peek_kind() != TokenKind::Dedent && peek_kind() != TokenKind::Eof) {
+      skip_newlines();
+      if (peek_kind() == TokenKind::Dedent || peek_kind() == TokenKind::Eof) {
+        break;
+      }
+      // Parse arm pattern (expression — constant, enum variant, etc.).
+      auto* pattern = parse_expression();
+      consume(TokenKind::Colon);
+      auto body = parse_suite();
+      arms.push_back({.pattern = pattern, .body = std::move(body)});
+    }
+    consume(TokenKind::Dedent);
+    if (arms.empty()) {
+      error("match must contain at least one arm");
+    }
+    Span span = span_from(kw.span);
+    return ctx_.alloc<Stmt>(
+        span, MatchStmt{.scrutinee = scrutinee,
+                        .arms = std::move(arms)});
   }
 
   auto parse_while_statement() -> Stmt* {

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -686,6 +686,18 @@ private:
       }
       break;
     }
+    case NodeKind::MatchStatement: {
+      const auto& match = stmt.as<MatchStmt>();
+      resolve_expr(*match.scrutinee, scope);
+      for (const auto& arm : match.arms) {
+        resolve_expr(*arm.pattern, scope);
+        auto* arm_scope = ctx_.make_scope(ScopeKind::Block, scope);
+        for (const auto* body_stmt : arm.body) {
+          resolve_stmt(*body_stmt, arm_scope);
+        }
+      }
+      break;
+    }
     case NodeKind::ExpressionStatement: {
       const auto& expr_stmt = stmt.as<ExpressionStatement>();
       resolve_expr(*expr_stmt.expr, scope);

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -902,6 +902,9 @@ void TypeChecker::check_statement(const Stmt* stmt) {
       error(stmt->span, "'break' is only allowed inside a loop");
     }
     break;
+  case NodeKind::MatchStatement:
+    check_match(stmt);
+    break;
   case NodeKind::ModeBlock:
     check_mode_block(stmt);
     break;
@@ -1057,6 +1060,24 @@ void TypeChecker::check_yield(const Stmt* stmt) {
   }
 
   typed_.set_local_type(stmt, value_type);
+}
+
+void TypeChecker::check_match(const Stmt* stmt) {
+  const auto& match = stmt->as<MatchStmt>();
+  const auto* scrutinee_type = check_expr(match.scrutinee);
+
+  for (const auto& arm : match.arms) {
+    const auto* pattern_type = check_expr(arm.pattern);
+    if (scrutinee_type != nullptr && pattern_type != nullptr) {
+      if (!is_assignable(pattern_type, scrutinee_type)) {
+        error(arm.pattern->span,
+              "match arm type '" + print_type(pattern_type) +
+                  "' does not match scrutinee type '" +
+                  print_type(scrutinee_type) + "'");
+      }
+    }
+    check_body(arm.body);
+  }
 }
 
 void TypeChecker::check_mode_block(const Stmt* stmt) {

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -149,6 +149,7 @@ private:
   void check_while(const Stmt* stmt);
   void check_for(const Stmt* stmt);
   void check_yield(const Stmt* stmt);
+  void check_match(const Stmt* stmt);
   void check_mode_block(const Stmt* stmt);
   void check_resource_block(const Stmt* stmt);
   void check_return(const Stmt* stmt);

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -244,6 +244,31 @@ auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
     return ctx_.alloc<HirStmt>(stmt->span, HirYield{value});
   }
 
+  case NodeKind::MatchStatement: {
+    // Lower match to a chain of if/else comparisons.
+    const auto& match = stmt->as<MatchStmt>();
+    auto* scrutinee = lower_expr(match.scrutinee);
+
+    // Build the chain from last arm to first (innermost else first).
+    HirStmt* result = nullptr;
+    for (auto it = match.arms.rbegin(); it != match.arms.rend(); ++it) {
+      auto* pattern = lower_expr(it->pattern);
+      auto arm_body = lower_body(it->body);
+      // scrutinee == pattern
+      auto* cond = ctx_.alloc<HirExpr>(
+          stmt->span, nullptr,
+          HirBinary{BinaryOp::EqEq, scrutinee, pattern});
+      std::vector<HirStmt*> else_body;
+      if (result != nullptr) {
+        else_body.push_back(result);
+      }
+      result = ctx_.alloc<HirStmt>(
+          stmt->span,
+          HirIf{cond, std::move(arm_body), std::move(else_body)});
+    }
+    return result;
+  }
+
   case NodeKind::BreakStatement:
     return ctx_.alloc<HirStmt>(stmt->span, HirBreak{});
 

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -165,9 +165,13 @@ auto HirBuilder::lower_body(const std::vector<Stmt*>& body)
     -> std::vector<HirStmt*> {
   std::vector<HirStmt*> result;
   for (const auto* stmt : body) {
-    auto* hir = lower_stmt(stmt);
-    if (hir != nullptr) {
-      result.push_back(hir);
+    if (stmt->kind() == NodeKind::MatchStatement) {
+      lower_match_into(stmt, result);
+    } else {
+      auto* hir = lower_stmt(stmt);
+      if (hir != nullptr) {
+        result.push_back(hir);
+      }
     }
   }
   return result;
@@ -245,28 +249,14 @@ auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
   }
 
   case NodeKind::MatchStatement: {
-    // Lower match to a chain of if/else comparisons.
-    const auto& match = stmt->as<MatchStmt>();
-    auto* scrutinee = lower_expr(match.scrutinee);
-
-    // Build the chain from last arm to first (innermost else first).
-    HirStmt* result = nullptr;
-    for (auto it = match.arms.rbegin(); it != match.arms.rend(); ++it) {
-      auto* pattern = lower_expr(it->pattern);
-      auto arm_body = lower_body(it->body);
-      // scrutinee == pattern
-      auto* cond = ctx_.alloc<HirExpr>(
-          stmt->span, nullptr,
-          HirBinary{BinaryOp::EqEq, scrutinee, pattern});
-      std::vector<HirStmt*> else_body;
-      if (result != nullptr) {
-        else_body.push_back(result);
-      }
-      result = ctx_.alloc<HirStmt>(
-          stmt->span,
-          HirIf{cond, std::move(arm_body), std::move(else_body)});
-    }
-    return result;
+    // Match is lowered by lower_match_into() which emits multiple
+    // statements (let binding + if/else chain). When reached here
+    // from a context that expects a single statement (e.g. match
+    // inside if-else), wrap in a single-element body.
+    std::vector<HirStmt*> stmts;
+    lower_match_into(stmt, stmts);
+    // Return the last statement (the if/else chain).
+    return stmts.empty() ? nullptr : stmts.back();
   }
 
   case NodeKind::BreakStatement:
@@ -295,6 +285,54 @@ auto HirBuilder::lower_stmt(const Stmt* stmt) -> HirStmt* {
 // ---------------------------------------------------------------------------
 // Expression lowering
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Match lowering — emits a let binding for the scrutinee followed by
+// a chain of if/else comparisons referencing the bound variable.
+// ---------------------------------------------------------------------------
+
+void HirBuilder::lower_match_into(const Stmt* stmt,
+                                  std::vector<HirStmt*>& out) {
+  const auto& match = stmt->as<MatchStmt>();
+  auto* scrutinee_expr = lower_expr(match.scrutinee);
+  const auto* scrutinee_type = expr_type(match.scrutinee);
+
+  // Create a synthetic symbol for the scrutinee temporary.
+  auto* scrutinee_sym = ctx_.alloc<Symbol>(Symbol{
+      .kind = SymbolKind::Local,
+      .name = "__match_scrutinee",
+      .decl_span = stmt->span,
+      .decl = nullptr});
+
+  // Emit: let __match_scrutinee = <scrutinee>
+  out.push_back(ctx_.alloc<HirStmt>(
+      stmt->span,
+      HirLet{scrutinee_sym, scrutinee_type, scrutinee_expr}));
+
+  // Build a reference expression for the bound scrutinee.
+  auto* scrutinee_ref = ctx_.alloc<HirExpr>(
+      stmt->span, scrutinee_type, HirSymbolRef{scrutinee_sym});
+
+  // Build the if/else chain from last arm to first.
+  HirStmt* chain = nullptr;
+  for (auto it = match.arms.rbegin(); it != match.arms.rend(); ++it) {
+    auto* pattern = lower_expr(it->pattern);
+    auto arm_body = lower_body(it->body);
+    auto* cond = ctx_.alloc<HirExpr>(
+        stmt->span, nullptr,
+        HirBinary{BinaryOp::EqEq, scrutinee_ref, pattern});
+    std::vector<HirStmt*> else_body;
+    if (chain != nullptr) {
+      else_body.push_back(chain);
+    }
+    chain = ctx_.alloc<HirStmt>(
+        stmt->span,
+        HirIf{cond, std::move(arm_body), std::move(else_body)});
+  }
+  if (chain != nullptr) {
+    out.push_back(chain);
+  }
+}
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {

--- a/compiler/ir/hir/hir_builder.h
+++ b/compiler/ir/hir/hir_builder.h
@@ -57,6 +57,7 @@ private:
 
   auto lower_stmt(const Stmt* stmt) -> HirStmt*;
   auto lower_body(const std::vector<Stmt*>& body) -> std::vector<HirStmt*>;
+  void lower_match_into(const Stmt* stmt, std::vector<HirStmt*>& out);
 
   // --- Expression lowering ---
 

--- a/examples/match.dao
+++ b/examples/match.dao
@@ -1,0 +1,61 @@
+// match.dao — Match statements and else-if chains.
+//
+// Demonstrates match over enum variants and else-if as
+// flat alternatives to deeply nested if/else.
+
+enum Season:
+  Spring
+  Summer
+  Autumn
+  Winter
+
+fn season_name(s: Season): string
+  match s:
+    Season.Spring:
+      return "Spring"
+    Season.Summer:
+      return "Summer"
+    Season.Autumn:
+      return "Autumn"
+    Season.Winter:
+      return "Winter"
+  return "?"
+
+fn is_warm(s: Season): bool
+  match s:
+    Season.Summer:
+      return true
+    Season.Spring:
+      return true
+  return false
+
+fn classify(x: i32): string
+  if x < 0:
+    return "negative"
+  else if x == 0:
+    return "zero"
+  else if x < 10:
+    return "small"
+  else if x < 100:
+    return "medium"
+  else:
+    return "large"
+
+fn main(): i32
+  // Match over enum.
+  print(season_name(Season.Spring))
+  print(season_name(Season.Winter))
+
+  if is_warm(Season.Summer):
+    print("summer is warm")
+  if is_warm(Season.Winter) == false:
+    print("winter is not warm")
+
+  // Else-if chains.
+  print(classify(-5))
+  print(classify(0))
+  print(classify(7))
+  print(classify(42))
+  print(classify(999))
+
+  return 0

--- a/testdata/ast/examples_match.ast
+++ b/testdata/ast/examples_match.ast
@@ -1,0 +1,208 @@
+File
+  EnumDecl Season
+    Variant Spring
+    Variant Summer
+    Variant Autumn
+    Variant Winter
+  FunctionDecl season_name
+    Param s: Season
+    ReturnType: string
+    MatchStatement
+      Scrutinee
+        Identifier s
+      Arm
+        Pattern
+          FieldExpr .Spring
+            Identifier Season
+        ReturnStatement
+          StringLiteral "Spring"
+      Arm
+        Pattern
+          FieldExpr .Summer
+            Identifier Season
+        ReturnStatement
+          StringLiteral "Summer"
+      Arm
+        Pattern
+          FieldExpr .Autumn
+            Identifier Season
+        ReturnStatement
+          StringLiteral "Autumn"
+      Arm
+        Pattern
+          FieldExpr .Winter
+            Identifier Season
+        ReturnStatement
+          StringLiteral "Winter"
+    ReturnStatement
+      StringLiteral "?"
+  FunctionDecl is_warm
+    Param s: Season
+    ReturnType: bool
+    MatchStatement
+      Scrutinee
+        Identifier s
+      Arm
+        Pattern
+          FieldExpr .Summer
+            Identifier Season
+        ReturnStatement
+          BoolLiteral true
+      Arm
+        Pattern
+          FieldExpr .Spring
+            Identifier Season
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BoolLiteral false
+  FunctionDecl classify
+    Param x: i32
+    ReturnType: string
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier x
+          IntLiteral 0
+      Then
+        ReturnStatement
+          StringLiteral "negative"
+      Else
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier x
+              IntLiteral 0
+          Then
+            ReturnStatement
+              StringLiteral "zero"
+          Else
+            IfStatement
+              Condition
+                BinaryExpr <
+                  Identifier x
+                  IntLiteral 10
+              Then
+                ReturnStatement
+                  StringLiteral "small"
+              Else
+                IfStatement
+                  Condition
+                    BinaryExpr <
+                      Identifier x
+                      IntLiteral 100
+                  Then
+                    ReturnStatement
+                      StringLiteral "medium"
+                  Else
+                    ReturnStatement
+                      StringLiteral "large"
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier season_name
+            Args
+              FieldExpr .Spring
+                Identifier Season
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier season_name
+            Args
+              FieldExpr .Winter
+                Identifier Season
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_warm
+          Args
+            FieldExpr .Summer
+              Identifier Season
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "summer is warm"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier is_warm
+            Args
+              FieldExpr .Winter
+                Identifier Season
+          BoolLiteral false
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "winter is not warm"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier classify
+            Args
+              UnaryExpr -
+                IntLiteral 5
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier classify
+            Args
+              IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier classify
+            Args
+              IntLiteral 7
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier classify
+            Args
+              IntLiteral 42
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          CallExpr
+            Callee
+              Identifier classify
+            Args
+              IntLiteral 999
+    ReturnStatement
+      IntLiteral 0


### PR DESCRIPTION
## Summary

Add `else if` chains and `match` statements — the two branching features identified by the bootstrap probes as the next ergonomic blockers after enums. Both directly eliminate the deeply nested if/else cascades that made parser-shaped code unreadable.

## Highlights

- **`else if`**: parser-only change — `else` followed by `if` parses as a nested if-statement in the else body, no colon or indent required after `else`
- **`match`**: full pipeline (`KwMatch` token → `MatchStmt`/`MatchArm` AST → resolver → typechecker → HIR lowering as chained `==` comparisons)
- **Type-safe arms**: arm pattern types are checked against the scrutinee type — mismatched enum types are rejected
- **HIR lowering**: match desugars to nested if/else with `EqEq` comparisons, reusing all existing MIR and LLVM infrastructure with zero new backend code
- **AST golden file** for `examples/match.dao` included

## Test plan

- [x] All 12 existing tests pass (`ctest`) including AST golden files
- [x] All existing examples compile and run unchanged (enums, vectors, bootstrap probes)
- [x] `else if` chains work with enum, integer, and mixed comparisons
- [x] `match` over enum variants dispatches correctly for all arms
- [x] `match` and `else if` coexist in the same program

🤖 Generated with [Claude Code](https://claude.com/claude-code)