### PR TITLE
feat(bootstrap): ♻️ rewrite expr_parser probe with enums and match

### DIFF
--- a/examples/bootstrap_probe/expr_parser.dao
+++ b/examples/bootstrap_probe/expr_parser.dao
@@ -4,35 +4,36 @@
 // flat Vector<ExprNode> arena with index-based references, then
 // evaluates the tree by walking the arena.
 //
-// Tests: parser-shaped control flow over collected token data,
-// arena-indexed structured output, recursive descent with
-// precedence, peek/advance/expect helpers, multi-phase pipeline
-// (lex → parse → eval), and composite return types containing
-// Vector<T> fields.
+// Tests: enum-based kind tagging, match dispatch, else-if chains,
+// parser-shaped control flow over collected token data, arena-indexed
+// structured output, recursive descent with precedence, multi-phase
+// pipeline (lex → parse → eval), and composite return types
+// containing Vector<T> fields.
 //
 // Scope: integer literals, + - * /, unary minus, parentheses,
 // precedence and associativity. Nothing more.
 
 // ---------------------------------------------------------------
-// Token representation (minimal arithmetic subset)
+// Token representation
 // ---------------------------------------------------------------
 
-fn TK_INT(): i32    -> 1
-fn TK_PLUS(): i32   -> 2
-fn TK_MINUS(): i32  -> 3
-fn TK_STAR(): i32   -> 4
-fn TK_SLASH(): i32  -> 5
-fn TK_LPAREN(): i32 -> 6
-fn TK_RPAREN(): i32 -> 7
-fn TK_EOF(): i32    -> 8
-fn TK_ERROR(): i32  -> 9
+enum TK:
+  Int
+  Plus
+  Minus
+  Star
+  Slash
+  LParen
+  RParen
+  Eof
+  Error
 
 class Token:
-  kind: i32
+  kind: TK
   offset: i64
   len: i64
 
-fn make_token(k: i32, off: i64, l: i64): Token
+fn make_token(k: TK, off: i64, l: i64): Token
   return Token(k, off, l)
 
 // ---------------------------------------------------------------
@@ -53,65 +54,64 @@ fn lex(source: string): Vector<Token>
     let ch: i32 = char_at(source, pos)
     if is_whitespace(ch):
       pos = pos + 1
-    else:
-      if is_digit(ch):
-        let end: i64 = pos + 1
-        while end < slen:
-          if is_digit(char_at(source, end)):
-            end = end + 1
-          else:
-            break
-        tokens = tokens.push(make_token(TK_INT(), pos, end - pos))
-        pos = end
-      else:
-        if ch == 43:
-          tokens = tokens.push(make_token(TK_PLUS(), pos, to_i64(1)))
-          pos = pos + 1
+    else if is_digit(ch):
+      let end: i64 = pos + 1
+      while end < slen:
+        if is_digit(char_at(source, end)):
+          end = end + 1
         else:
-          if ch == 45:
-            tokens = tokens.push(make_token(TK_MINUS(), pos, to_i64(1)))
-            pos = pos + 1
-          else:
-            if ch == 42:
-              tokens = tokens.push(make_token(TK_STAR(), pos, to_i64(1)))
-              pos = pos + 1
-            else:
-              if ch == 47:
-                tokens = tokens.push(make_token(TK_SLASH(), pos, to_i64(1)))
-                pos = pos + 1
-              else:
-                if ch == 40:
-                  tokens = tokens.push(make_token(TK_LPAREN(), pos, to_i64(1)))
-                  pos = pos + 1
-                else:
-                  if ch == 41:
-                    tokens = tokens.push(make_token(TK_RPAREN(), pos, to_i64(1)))
-                    pos = pos + 1
-                  else:
-                    tokens = tokens.push(make_token(TK_ERROR(), pos, to_i64(1)))
-                    pos = pos + 1
+          break
+      tokens = tokens.push(make_token(TK.Int, pos, end - pos))
+      pos = end
+    else if ch == 43:
+      tokens = tokens.push(make_token(TK.Plus, pos, to_i64(1)))
+      pos = pos + 1
+    else if ch == 45:
+      tokens = tokens.push(make_token(TK.Minus, pos, to_i64(1)))
+      pos = pos + 1
+    else if ch == 42:
+      tokens = tokens.push(make_token(TK.Star, pos, to_i64(1)))
+      pos = pos + 1
+    else if ch == 47:
+      tokens = tokens.push(make_token(TK.Slash, pos, to_i64(1)))
+      pos = pos + 1
+    else if ch == 40:
+      tokens = tokens.push(make_token(TK.LParen, pos, to_i64(1)))
+      pos = pos + 1
+    else if ch == 41:
+      tokens = tokens.push(make_token(TK.RParen, pos, to_i64(1)))
+      pos = pos + 1
+    else:
+      tokens = tokens.push(make_token(TK.Error, pos, to_i64(1)))
+      pos = pos + 1
   // Append EOF sentinel.
-  tokens = tokens.push(make_token(TK_EOF(), slen, to_i64(0)))
+  tokens = tokens.push(make_token(TK.Eof, slen, to_i64(0)))
   return tokens
 
 // ---------------------------------------------------------------
 // AST arena node
 // ---------------------------------------------------------------
 
-fn NK_INT_LIT(): i32  -> 1
-fn NK_BINARY(): i32   -> 2
-fn NK_UNARY(): i32    -> 3
+enum NK:
+  IntLit
+  Binary
+  Unary
 
 class ExprNode:
-  kind: i32
-  value: i64     // int literal value, or operator token kind
-  left: i64      // arena index (-1 = none)
-  right: i64     // arena index (-1 = none)
+  kind: NK
+  op: TK       // operator kind for binary/unary; TK.Eof for literals
+  value: i64   // integer literal value; unused for binary/unary
+  left: i64    // arena index (-1 = none)
+  right: i64   // arena index (-1 = none)
 
-fn make_node(k: i32, v: i64, l: i64, r: i64): ExprNode
-  return ExprNode(k, v, l, r)
+fn int_node(val: i64): ExprNode
+  return ExprNode(NK.IntLit, TK.Eof, val, to_i64(-1), to_i64(-1))
 
-fn no_child(): i64 -> to_i64(-1)
+fn binary_node(op: TK, left: i64, right: i64): ExprNode
+  return ExprNode(NK.Binary, op, to_i64(0), left, right)
+
+fn unary_node(op: TK, operand: i64): ExprNode
+  return ExprNode(NK.Unary, op, to_i64(0), operand, to_i64(-1))
 
 // ---------------------------------------------------------------
 // Parse result — bundles arena + node index + cursor position
@@ -133,14 +133,13 @@ fn is_parse_ok(r: ParseResult): bool
 // Parser helpers
 // ---------------------------------------------------------------
 
-fn peek(tokens: Vector<Token>, pos: i64): i32
+fn peek(tokens: Vector<Token>, pos: i64): TK
   if pos >= tokens.length():
-    return TK_EOF()
+    return TK.Eof
   let tok: Token = tokens.get(pos)
   return tok.kind
 
 fn token_text_to_i64(source: string, tok: Token): i64
-  // Parse integer literal from source span.
   let result: i64 = 0
   let i: i64 = 0
   while i < tok.len:
@@ -161,23 +160,22 @@ fn token_text_to_i64(source: string, tok: Token): i64
 // ---------------------------------------------------------------
 
 fn parse_primary(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
-  let kind: i32 = peek(tokens, pos)
+  let kind: TK = peek(tokens, pos)
 
   // Integer literal.
-  if kind == TK_INT():
+  if kind == TK.Int:
     let tok: Token = tokens.get(pos)
     let val: i64 = token_text_to_i64(source, tok)
     let idx: i64 = arena.length()
-    let new_arena: Vector<ExprNode> = arena.push(make_node(NK_INT_LIT(), val, no_child(), no_child()))
+    let new_arena: Vector<ExprNode> = arena.push(int_node(val))
     return ParseResult(new_arena, idx, pos + 1)
 
   // Parenthesized expression.
-  if kind == TK_LPAREN():
+  if kind == TK.LParen:
     let inner: ParseResult = parse_expr(tokens, source, arena, pos + 1)
     if is_parse_ok(inner) == false:
       return inner
-    // Expect closing paren.
-    if peek(tokens, inner.pos) != TK_RPAREN():
+    if peek(tokens, inner.pos) != TK.RParen:
       print("error: expected ')'")
       return parse_error(inner.arena, inner.pos)
     return ParseResult(inner.arena, inner.node, inner.pos + 1)
@@ -186,14 +184,13 @@ fn parse_primary(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>,
   return parse_error(arena, pos)
 
 fn parse_unary(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>, pos: i64): ParseResult
-  // Unary minus.
-  if peek(tokens, pos) == TK_MINUS():
+  if peek(tokens, pos) == TK.Minus:
     let operand: ParseResult = parse_unary(tokens, source, arena, pos + 1)
     if is_parse_ok(operand) == false:
       return operand
     let idx: i64 = operand.arena.length()
     let new_arena: Vector<ExprNode> = operand.arena.push(
-      make_node(NK_UNARY(), to_i64(TK_MINUS()), operand.node, no_child()))
+      unary_node(TK.Minus, operand.node))
     return ParseResult(new_arena, idx, operand.pos)
 
   return parse_primary(tokens, source, arena, pos)
@@ -205,14 +202,14 @@ fn parse_multiplicative(tokens: Vector<Token>, source: string, arena: Vector<Exp
   let result: ParseResult = left
   let done: bool = false
   while done == false:
-    let op: i32 = peek(tokens, result.pos)
-    if op == TK_STAR() or op == TK_SLASH():
+    let op: TK = peek(tokens, result.pos)
+    if op == TK.Star or op == TK.Slash:
       let right: ParseResult = parse_unary(tokens, source, result.arena, result.pos + 1)
       if is_parse_ok(right) == false:
         return right
       let idx: i64 = right.arena.length()
       let new_arena: Vector<ExprNode> = right.arena.push(
-        make_node(NK_BINARY(), to_i64(op), result.node, right.node))
+        binary_node(op, result.node, right.node))
       result = ParseResult(new_arena, idx, right.pos)
     else:
       done = true
@@ -225,14 +222,14 @@ fn parse_additive(tokens: Vector<Token>, source: string, arena: Vector<ExprNode>
   let result: ParseResult = left
   let done: bool = false
   while done == false:
-    let op: i32 = peek(tokens, result.pos)
-    if op == TK_PLUS() or op == TK_MINUS():
+    let op: TK = peek(tokens, result.pos)
+    if op == TK.Plus or op == TK.Minus:
       let right: ParseResult = parse_multiplicative(tokens, source, result.arena, result.pos + 1)
       if is_parse_ok(right) == false:
         return right
       let idx: i64 = right.arena.length()
       let new_arena: Vector<ExprNode> = right.arena.push(
-        make_node(NK_BINARY(), to_i64(op), result.node, right.node))
+        binary_node(op, result.node, right.node))
       result = ParseResult(new_arena, idx, right.pos)
     else:
       done = true
@@ -245,8 +242,7 @@ fn parse(tokens: Vector<Token>, source: string): ParseResult
   let arena = Vector<ExprNode>::new()
   let result: ParseResult = parse_expr(tokens, source, arena, to_i64(0))
   if is_parse_ok(result):
-    // Verify we consumed all tokens (except EOF).
-    if peek(tokens, result.pos) != TK_EOF():
+    if peek(tokens, result.pos) != TK.Eof:
       print("error: unexpected token after expression")
       return parse_error(result.arena, result.pos)
   return result
@@ -257,26 +253,27 @@ fn parse(tokens: Vector<Token>, source: string): ParseResult
 
 fn eval_node(arena: Vector<ExprNode>, idx: i64): i64
   let node: ExprNode = arena.get(idx)
-  if node.kind == NK_INT_LIT():
-    return node.value
-  if node.kind == NK_UNARY():
-    let operand: i64 = eval_node(arena, node.left)
-    return to_i64(0) - operand
-  if node.kind == NK_BINARY():
-    let lval: i64 = eval_node(arena, node.left)
-    let rval: i64 = eval_node(arena, node.right)
-    let op: i32 = i64_to_i32(node.value)
-    if op == TK_PLUS():
-      return lval + rval
-    if op == TK_MINUS():
-      return lval - rval
-    if op == TK_STAR():
-      return lval * rval
-    if op == TK_SLASH():
-      if rval != to_i64(0):
-        return lval / rval
-      print("error: division by zero")
-      return to_i64(0)
+  match node.kind:
+    NK.IntLit:
+      return node.value
+    NK.Unary:
+      let operand: i64 = eval_node(arena, node.left)
+      return to_i64(0) - operand
+    NK.Binary:
+      let lval: i64 = eval_node(arena, node.left)
+      let rval: i64 = eval_node(arena, node.right)
+      match node.op:
+        TK.Plus:
+          return lval + rval
+        TK.Minus:
+          return lval - rval
+        TK.Star:
+          return lval * rval
+        TK.Slash:
+          if rval != to_i64(0):
+            return lval / rval
+          print("error: division by zero")
+          return to_i64(0)
   print("error: unknown node kind")
   return to_i64(0)
 
@@ -284,15 +281,16 @@ fn eval_node(arena: Vector<ExprNode>, idx: i64): i64
 // Arena printer — dump structure for debugging
 // ---------------------------------------------------------------
 
-fn op_name(op: i32): string
-  if op == TK_PLUS():
-    return "+"
-  if op == TK_MINUS():
-    return "-"
-  if op == TK_STAR():
-    return "*"
-  if op == TK_SLASH():
-    return "/"
+fn op_name(op: TK): string
+  match op:
+    TK.Plus:
+      return "+"
+    TK.Minus:
+      return "-"
+    TK.Star:
+      return "*"
+    TK.Slash:
+      return "/"
   return "?"
 
 fn print_node(arena: Vector<ExprNode>, idx: i64, depth: i32): i32
@@ -302,15 +300,16 @@ fn print_node(arena: Vector<ExprNode>, idx: i64, depth: i32): i32
   while d < depth:
     indent = indent + "  "
     d = d + 1
-  if node.kind == NK_INT_LIT():
-    print(indent + "INT " + i64_to_string(node.value))
-  if node.kind == NK_UNARY():
-    print(indent + "NEG")
-    let unused: i32 = print_node(arena, node.left, depth + 1)
-  if node.kind == NK_BINARY():
-    print(indent + "BIN " + op_name(i64_to_i32(node.value)))
-    let unused1: i32 = print_node(arena, node.left, depth + 1)
-    let unused2: i32 = print_node(arena, node.right, depth + 1)
+  match node.kind:
+    NK.IntLit:
+      print(indent + "INT " + i64_to_string(node.value))
+    NK.Unary:
+      print(indent + "NEG")
+      let unused: i32 = print_node(arena, node.left, depth + 1)
+    NK.Binary:
+      print(indent + "BIN " + op_name(node.op))
+      let unused1: i32 = print_node(arena, node.left, depth + 1)
+      let unused2: i32 = print_node(arena, node.right, depth + 1)
   return 0
 
 // ---------------------------------------------------------------
@@ -339,9 +338,9 @@ fn main(): i32
   print("=== expr_parser: lex -> parse -> eval ===")
   print("")
 
-  // --- Basic cases ---
   let pass_count: i32 = 0
 
+  // --- Basic cases ---
   if test_expr("literal", "42", to_i64(42)):
     pass_count = pass_count + 1
   if test_expr("add", "1 + 2", to_i64(3)):

--- a/testdata/ast/examples_bootstrap_probe_expr_parser.ast
+++ b/testdata/ast/examples_bootstrap_probe_expr_parser.ast
@@ -1,0 +1,2069 @@
+File
+  EnumDecl TK
+    Variant Int
+    Variant Plus
+    Variant Minus
+    Variant Star
+    Variant Slash
+    Variant LParen
+    Variant RParen
+    Variant Eof
+    Variant Error
+  ClassDecl Token
+    Field kind: TK
+    Field offset: i64
+    Field len: i64
+  FunctionDecl make_token
+    Param k: TK
+    Param off: i64
+    Param l: i64
+    ReturnType: Token
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Token
+        Args
+          Identifier k
+          Identifier off
+          Identifier l
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr or
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 32
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 9
+          BinaryExpr ==
+            Identifier ch
+            IntLiteral 10
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 13
+  FunctionDecl lex
+    Param source: string
+    ReturnType: Vector<Token>
+    LetStatement tokens
+      CallExpr
+        Callee
+          Identifier Vector.new
+        TypeArgs
+          Token
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier pos
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_whitespace
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier pos
+            Value
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        Else
+          IfStatement
+            Condition
+              CallExpr
+                Callee
+                  Identifier is_digit
+                Args
+                  Identifier ch
+            Then
+              LetStatement end: i64
+                BinaryExpr +
+                  Identifier pos
+                  IntLiteral 1
+              WhileStatement
+                Condition
+                  BinaryExpr <
+                    Identifier end
+                    Identifier slen
+                IfStatement
+                  Condition
+                    CallExpr
+                      Callee
+                        Identifier is_digit
+                      Args
+                        CallExpr
+                          Callee
+                            Identifier char_at
+                          Args
+                            Identifier source
+                            Identifier end
+                  Then
+                    Assignment
+                      Target
+                        Identifier end
+                      Value
+                        BinaryExpr +
+                          Identifier end
+                          IntLiteral 1
+                  Else
+                    BreakStatement
+              Assignment
+                Target
+                  Identifier tokens
+                Value
+                  CallExpr
+                    Callee
+                      FieldExpr .push
+                        Identifier tokens
+                    Args
+                      CallExpr
+                        Callee
+                          Identifier make_token
+                        Args
+                          FieldExpr .Int
+                            Identifier TK
+                          Identifier pos
+                          BinaryExpr -
+                            Identifier end
+                            Identifier pos
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  Identifier end
+            Else
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    Identifier ch
+                    IntLiteral 43
+                Then
+                  Assignment
+                    Target
+                      Identifier tokens
+                    Value
+                      CallExpr
+                        Callee
+                          FieldExpr .push
+                            Identifier tokens
+                        Args
+                          CallExpr
+                            Callee
+                              Identifier make_token
+                            Args
+                              FieldExpr .Plus
+                                Identifier TK
+                              Identifier pos
+                              CallExpr
+                                Callee
+                                  Identifier to_i64
+                                Args
+                                  IntLiteral 1
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      BinaryExpr +
+                        Identifier pos
+                        IntLiteral 1
+                Else
+                  IfStatement
+                    Condition
+                      BinaryExpr ==
+                        Identifier ch
+                        IntLiteral 45
+                    Then
+                      Assignment
+                        Target
+                          Identifier tokens
+                        Value
+                          CallExpr
+                            Callee
+                              FieldExpr .push
+                                Identifier tokens
+                            Args
+                              CallExpr
+                                Callee
+                                  Identifier make_token
+                                Args
+                                  FieldExpr .Minus
+                                    Identifier TK
+                                  Identifier pos
+                                  CallExpr
+                                    Callee
+                                      Identifier to_i64
+                                    Args
+                                      IntLiteral 1
+                      Assignment
+                        Target
+                          Identifier pos
+                        Value
+                          BinaryExpr +
+                            Identifier pos
+                            IntLiteral 1
+                    Else
+                      IfStatement
+                        Condition
+                          BinaryExpr ==
+                            Identifier ch
+                            IntLiteral 42
+                        Then
+                          Assignment
+                            Target
+                              Identifier tokens
+                            Value
+                              CallExpr
+                                Callee
+                                  FieldExpr .push
+                                    Identifier tokens
+                                Args
+                                  CallExpr
+                                    Callee
+                                      Identifier make_token
+                                    Args
+                                      FieldExpr .Star
+                                        Identifier TK
+                                      Identifier pos
+                                      CallExpr
+                                        Callee
+                                          Identifier to_i64
+                                        Args
+                                          IntLiteral 1
+                          Assignment
+                            Target
+                              Identifier pos
+                            Value
+                              BinaryExpr +
+                                Identifier pos
+                                IntLiteral 1
+                        Else
+                          IfStatement
+                            Condition
+                              BinaryExpr ==
+                                Identifier ch
+                                IntLiteral 47
+                            Then
+                              Assignment
+                                Target
+                                  Identifier tokens
+                                Value
+                                  CallExpr
+                                    Callee
+                                      FieldExpr .push
+                                        Identifier tokens
+                                    Args
+                                      CallExpr
+                                        Callee
+                                          Identifier make_token
+                                        Args
+                                          FieldExpr .Slash
+                                            Identifier TK
+                                          Identifier pos
+                                          CallExpr
+                                            Callee
+                                              Identifier to_i64
+                                            Args
+                                              IntLiteral 1
+                              Assignment
+                                Target
+                                  Identifier pos
+                                Value
+                                  BinaryExpr +
+                                    Identifier pos
+                                    IntLiteral 1
+                            Else
+                              IfStatement
+                                Condition
+                                  BinaryExpr ==
+                                    Identifier ch
+                                    IntLiteral 40
+                                Then
+                                  Assignment
+                                    Target
+                                      Identifier tokens
+                                    Value
+                                      CallExpr
+                                        Callee
+                                          FieldExpr .push
+                                            Identifier tokens
+                                        Args
+                                          CallExpr
+                                            Callee
+                                              Identifier make_token
+                                            Args
+                                              FieldExpr .LParen
+                                                Identifier TK
+                                              Identifier pos
+                                              CallExpr
+                                                Callee
+                                                  Identifier to_i64
+                                                Args
+                                                  IntLiteral 1
+                                  Assignment
+                                    Target
+                                      Identifier pos
+                                    Value
+                                      BinaryExpr +
+                                        Identifier pos
+                                        IntLiteral 1
+                                Else
+                                  IfStatement
+                                    Condition
+                                      BinaryExpr ==
+                                        Identifier ch
+                                        IntLiteral 41
+                                    Then
+                                      Assignment
+                                        Target
+                                          Identifier tokens
+                                        Value
+                                          CallExpr
+                                            Callee
+                                              FieldExpr .push
+                                                Identifier tokens
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier make_token
+                                                Args
+                                                  FieldExpr .RParen
+                                                    Identifier TK
+                                                  Identifier pos
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier to_i64
+                                                    Args
+                                                      IntLiteral 1
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 1
+                                    Else
+                                      Assignment
+                                        Target
+                                          Identifier tokens
+                                        Value
+                                          CallExpr
+                                            Callee
+                                              FieldExpr .push
+                                                Identifier tokens
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier make_token
+                                                Args
+                                                  FieldExpr .Error
+                                                    Identifier TK
+                                                  Identifier pos
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier to_i64
+                                                    Args
+                                                      IntLiteral 1
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 1
+    Assignment
+      Target
+        Identifier tokens
+      Value
+        CallExpr
+          Callee
+            FieldExpr .push
+              Identifier tokens
+          Args
+            CallExpr
+              Callee
+                Identifier make_token
+              Args
+                FieldExpr .Eof
+                  Identifier TK
+                Identifier slen
+                CallExpr
+                  Callee
+                    Identifier to_i64
+                  Args
+                    IntLiteral 0
+    ReturnStatement
+      Identifier tokens
+  EnumDecl NK
+    Variant IntLit
+    Variant Binary
+    Variant Unary
+  ClassDecl ExprNode
+    Field kind: NK
+    Field op: TK
+    Field value: i64
+    Field left: i64
+    Field right: i64
+  FunctionDecl int_node
+    Param val: i64
+    ReturnType: ExprNode
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier ExprNode
+        Args
+          FieldExpr .IntLit
+            Identifier NK
+          FieldExpr .Eof
+            Identifier TK
+          Identifier val
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+  FunctionDecl binary_node
+    Param op: TK
+    Param left: i64
+    Param right: i64
+    ReturnType: ExprNode
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier ExprNode
+        Args
+          FieldExpr .Binary
+            Identifier NK
+          Identifier op
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+          Identifier left
+          Identifier right
+  FunctionDecl unary_node
+    Param op: TK
+    Param operand: i64
+    ReturnType: ExprNode
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier ExprNode
+        Args
+          FieldExpr .Unary
+            Identifier NK
+          Identifier op
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+          Identifier operand
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+  ClassDecl ParseResult
+    Field arena: Vector<ExprNode>
+    Field node: i64
+    Field pos: i64
+  FunctionDecl parse_error
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier ParseResult
+        Args
+          Identifier arena
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+          Identifier pos
+  FunctionDecl is_parse_ok
+    Param r: ParseResult
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr >=
+        FieldExpr .node
+          Identifier r
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            IntLiteral 0
+  FunctionDecl peek
+    Param tokens: Vector<Token>
+    Param pos: i64
+    ReturnType: TK
+    IfStatement
+      Condition
+        BinaryExpr >=
+          Identifier pos
+          CallExpr
+            Callee
+              FieldExpr .length
+                Identifier tokens
+      Then
+        ReturnStatement
+          FieldExpr .Eof
+            Identifier TK
+    LetStatement tok: Token
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier tokens
+        Args
+          Identifier pos
+    ReturnStatement
+      FieldExpr .kind
+        Identifier tok
+  FunctionDecl token_text_to_i64
+    Param source: string
+    Param tok: Token
+    ReturnType: i64
+    LetStatement result: i64
+      IntLiteral 0
+    LetStatement i: i64
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier i
+          FieldExpr .len
+            Identifier tok
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            BinaryExpr +
+              FieldExpr .offset
+                Identifier tok
+              Identifier i
+      Assignment
+        Target
+          Identifier result
+        Value
+          BinaryExpr +
+            BinaryExpr *
+              Identifier result
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 10
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                BinaryExpr -
+                  Identifier ch
+                  IntLiteral 48
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+    ReturnStatement
+      Identifier result
+  FunctionDecl parse_primary
+    Param tokens: Vector<Token>
+    Param source: string
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    LetStatement kind: TK
+      CallExpr
+        Callee
+          Identifier peek
+        Args
+          Identifier tokens
+          Identifier pos
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier kind
+          FieldExpr .Int
+            Identifier TK
+      Then
+        LetStatement tok: Token
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier tokens
+            Args
+              Identifier pos
+        LetStatement val: i64
+          CallExpr
+            Callee
+              Identifier token_text_to_i64
+            Args
+              Identifier source
+              Identifier tok
+        LetStatement idx: i64
+          CallExpr
+            Callee
+              FieldExpr .length
+                Identifier arena
+        LetStatement new_arena: Vector<ExprNode>
+          CallExpr
+            Callee
+              FieldExpr .push
+                Identifier arena
+            Args
+              CallExpr
+                Callee
+                  Identifier int_node
+                Args
+                  Identifier val
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier ParseResult
+            Args
+              Identifier new_arena
+              Identifier idx
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier kind
+          FieldExpr .LParen
+            Identifier TK
+      Then
+        LetStatement inner: ParseResult
+          CallExpr
+            Callee
+              Identifier parse_expr
+            Args
+              Identifier tokens
+              Identifier source
+              Identifier arena
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        IfStatement
+          Condition
+            BinaryExpr ==
+              CallExpr
+                Callee
+                  Identifier is_parse_ok
+                Args
+                  Identifier inner
+              BoolLiteral false
+          Then
+            ReturnStatement
+              Identifier inner
+        IfStatement
+          Condition
+            BinaryExpr !=
+              CallExpr
+                Callee
+                  Identifier peek
+                Args
+                  Identifier tokens
+                  FieldExpr .pos
+                    Identifier inner
+              FieldExpr .RParen
+                Identifier TK
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  StringLiteral "error: expected ')'"
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier parse_error
+                Args
+                  FieldExpr .arena
+                    Identifier inner
+                  FieldExpr .pos
+                    Identifier inner
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier ParseResult
+            Args
+              FieldExpr .arena
+                Identifier inner
+              FieldExpr .node
+                Identifier inner
+              BinaryExpr +
+                FieldExpr .pos
+                  Identifier inner
+                IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "error: expected integer or '('"
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier parse_error
+        Args
+          Identifier arena
+          Identifier pos
+  FunctionDecl parse_unary
+    Param tokens: Vector<Token>
+    Param source: string
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier peek
+            Args
+              Identifier tokens
+              Identifier pos
+          FieldExpr .Minus
+            Identifier TK
+      Then
+        LetStatement operand: ParseResult
+          CallExpr
+            Callee
+              Identifier parse_unary
+            Args
+              Identifier tokens
+              Identifier source
+              Identifier arena
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        IfStatement
+          Condition
+            BinaryExpr ==
+              CallExpr
+                Callee
+                  Identifier is_parse_ok
+                Args
+                  Identifier operand
+              BoolLiteral false
+          Then
+            ReturnStatement
+              Identifier operand
+        LetStatement idx: i64
+          CallExpr
+            Callee
+              FieldExpr .length
+                FieldExpr .arena
+                  Identifier operand
+        LetStatement new_arena: Vector<ExprNode>
+          CallExpr
+            Callee
+              FieldExpr .push
+                FieldExpr .arena
+                  Identifier operand
+            Args
+              CallExpr
+                Callee
+                  Identifier unary_node
+                Args
+                  FieldExpr .Minus
+                    Identifier TK
+                  FieldExpr .node
+                    Identifier operand
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier ParseResult
+            Args
+              Identifier new_arena
+              Identifier idx
+              FieldExpr .pos
+                Identifier operand
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier parse_primary
+        Args
+          Identifier tokens
+          Identifier source
+          Identifier arena
+          Identifier pos
+  FunctionDecl parse_multiplicative
+    Param tokens: Vector<Token>
+    Param source: string
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    LetStatement left: ParseResult
+      CallExpr
+        Callee
+          Identifier parse_unary
+        Args
+          Identifier tokens
+          Identifier source
+          Identifier arena
+          Identifier pos
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier is_parse_ok
+            Args
+              Identifier left
+          BoolLiteral false
+      Then
+        ReturnStatement
+          Identifier left
+    LetStatement result: ParseResult
+      Identifier left
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr ==
+          Identifier done
+          BoolLiteral false
+      LetStatement op: TK
+        CallExpr
+          Callee
+            Identifier peek
+          Args
+            Identifier tokens
+            FieldExpr .pos
+              Identifier result
+      IfStatement
+        Condition
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .Star
+                Identifier TK
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .Slash
+                Identifier TK
+        Then
+          LetStatement right: ParseResult
+            CallExpr
+              Callee
+                Identifier parse_unary
+              Args
+                Identifier tokens
+                Identifier source
+                FieldExpr .arena
+                  Identifier result
+                BinaryExpr +
+                  FieldExpr .pos
+                    Identifier result
+                  IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr ==
+                CallExpr
+                  Callee
+                    Identifier is_parse_ok
+                  Args
+                    Identifier right
+                BoolLiteral false
+            Then
+              ReturnStatement
+                Identifier right
+          LetStatement idx: i64
+            CallExpr
+              Callee
+                FieldExpr .length
+                  FieldExpr .arena
+                    Identifier right
+          LetStatement new_arena: Vector<ExprNode>
+            CallExpr
+              Callee
+                FieldExpr .push
+                  FieldExpr .arena
+                    Identifier right
+              Args
+                CallExpr
+                  Callee
+                    Identifier binary_node
+                  Args
+                    Identifier op
+                    FieldExpr .node
+                      Identifier result
+                    FieldExpr .node
+                      Identifier right
+          Assignment
+            Target
+              Identifier result
+            Value
+              CallExpr
+                Callee
+                  Identifier ParseResult
+                Args
+                  Identifier new_arena
+                  Identifier idx
+                  FieldExpr .pos
+                    Identifier right
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier result
+  FunctionDecl parse_additive
+    Param tokens: Vector<Token>
+    Param source: string
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    LetStatement left: ParseResult
+      CallExpr
+        Callee
+          Identifier parse_multiplicative
+        Args
+          Identifier tokens
+          Identifier source
+          Identifier arena
+          Identifier pos
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier is_parse_ok
+            Args
+              Identifier left
+          BoolLiteral false
+      Then
+        ReturnStatement
+          Identifier left
+    LetStatement result: ParseResult
+      Identifier left
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr ==
+          Identifier done
+          BoolLiteral false
+      LetStatement op: TK
+        CallExpr
+          Callee
+            Identifier peek
+          Args
+            Identifier tokens
+            FieldExpr .pos
+              Identifier result
+      IfStatement
+        Condition
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .Plus
+                Identifier TK
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .Minus
+                Identifier TK
+        Then
+          LetStatement right: ParseResult
+            CallExpr
+              Callee
+                Identifier parse_multiplicative
+              Args
+                Identifier tokens
+                Identifier source
+                FieldExpr .arena
+                  Identifier result
+                BinaryExpr +
+                  FieldExpr .pos
+                    Identifier result
+                  IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr ==
+                CallExpr
+                  Callee
+                    Identifier is_parse_ok
+                  Args
+                    Identifier right
+                BoolLiteral false
+            Then
+              ReturnStatement
+                Identifier right
+          LetStatement idx: i64
+            CallExpr
+              Callee
+                FieldExpr .length
+                  FieldExpr .arena
+                    Identifier right
+          LetStatement new_arena: Vector<ExprNode>
+            CallExpr
+              Callee
+                FieldExpr .push
+                  FieldExpr .arena
+                    Identifier right
+              Args
+                CallExpr
+                  Callee
+                    Identifier binary_node
+                  Args
+                    Identifier op
+                    FieldExpr .node
+                      Identifier result
+                    FieldExpr .node
+                      Identifier right
+          Assignment
+            Target
+              Identifier result
+            Value
+              CallExpr
+                Callee
+                  Identifier ParseResult
+                Args
+                  Identifier new_arena
+                  Identifier idx
+                  FieldExpr .pos
+                    Identifier right
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier result
+  FunctionDecl parse_expr
+    Param tokens: Vector<Token>
+    Param source: string
+    Param arena: Vector<ExprNode>
+    Param pos: i64
+    ReturnType: ParseResult
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier parse_additive
+        Args
+          Identifier tokens
+          Identifier source
+          Identifier arena
+          Identifier pos
+  FunctionDecl parse
+    Param tokens: Vector<Token>
+    Param source: string
+    ReturnType: ParseResult
+    LetStatement arena
+      CallExpr
+        Callee
+          Identifier Vector.new
+        TypeArgs
+          ExprNode
+    LetStatement result: ParseResult
+      CallExpr
+        Callee
+          Identifier parse_expr
+        Args
+          Identifier tokens
+          Identifier source
+          Identifier arena
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_parse_ok
+          Args
+            Identifier result
+      Then
+        IfStatement
+          Condition
+            BinaryExpr !=
+              CallExpr
+                Callee
+                  Identifier peek
+                Args
+                  Identifier tokens
+                  FieldExpr .pos
+                    Identifier result
+              FieldExpr .Eof
+                Identifier TK
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  StringLiteral "error: unexpected token after expression"
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier parse_error
+                Args
+                  FieldExpr .arena
+                    Identifier result
+                  FieldExpr .pos
+                    Identifier result
+    ReturnStatement
+      Identifier result
+  FunctionDecl eval_node
+    Param arena: Vector<ExprNode>
+    Param idx: i64
+    ReturnType: i64
+    LetStatement node: ExprNode
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier arena
+        Args
+          Identifier idx
+    MatchStatement
+      Scrutinee
+        FieldExpr .kind
+          Identifier node
+      Arm
+        Pattern
+          FieldExpr .IntLit
+            Identifier NK
+        ReturnStatement
+          FieldExpr .value
+            Identifier node
+      Arm
+        Pattern
+          FieldExpr .Unary
+            Identifier NK
+        LetStatement operand: i64
+          CallExpr
+            Callee
+              Identifier eval_node
+            Args
+              Identifier arena
+              FieldExpr .left
+                Identifier node
+        ReturnStatement
+          BinaryExpr -
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+            Identifier operand
+      Arm
+        Pattern
+          FieldExpr .Binary
+            Identifier NK
+        LetStatement lval: i64
+          CallExpr
+            Callee
+              Identifier eval_node
+            Args
+              Identifier arena
+              FieldExpr .left
+                Identifier node
+        LetStatement rval: i64
+          CallExpr
+            Callee
+              Identifier eval_node
+            Args
+              Identifier arena
+              FieldExpr .right
+                Identifier node
+        MatchStatement
+          Scrutinee
+            FieldExpr .op
+              Identifier node
+          Arm
+            Pattern
+              FieldExpr .Plus
+                Identifier TK
+            ReturnStatement
+              BinaryExpr +
+                Identifier lval
+                Identifier rval
+          Arm
+            Pattern
+              FieldExpr .Minus
+                Identifier TK
+            ReturnStatement
+              BinaryExpr -
+                Identifier lval
+                Identifier rval
+          Arm
+            Pattern
+              FieldExpr .Star
+                Identifier TK
+            ReturnStatement
+              BinaryExpr *
+                Identifier lval
+                Identifier rval
+          Arm
+            Pattern
+              FieldExpr .Slash
+                Identifier TK
+            IfStatement
+              Condition
+                BinaryExpr !=
+                  Identifier rval
+                  CallExpr
+                    Callee
+                      Identifier to_i64
+                    Args
+                      IntLiteral 0
+              Then
+                ReturnStatement
+                  BinaryExpr /
+                    Identifier lval
+                    Identifier rval
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  StringLiteral "error: division by zero"
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "error: unknown node kind"
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier to_i64
+        Args
+          IntLiteral 0
+  FunctionDecl op_name
+    Param op: TK
+    ReturnType: string
+    MatchStatement
+      Scrutinee
+        Identifier op
+      Arm
+        Pattern
+          FieldExpr .Plus
+            Identifier TK
+        ReturnStatement
+          StringLiteral "+"
+      Arm
+        Pattern
+          FieldExpr .Minus
+            Identifier TK
+        ReturnStatement
+          StringLiteral "-"
+      Arm
+        Pattern
+          FieldExpr .Star
+            Identifier TK
+        ReturnStatement
+          StringLiteral "*"
+      Arm
+        Pattern
+          FieldExpr .Slash
+            Identifier TK
+        ReturnStatement
+          StringLiteral "/"
+    ReturnStatement
+      StringLiteral "?"
+  FunctionDecl print_node
+    Param arena: Vector<ExprNode>
+    Param idx: i64
+    Param depth: i32
+    ReturnType: i32
+    LetStatement node: ExprNode
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier arena
+        Args
+          Identifier idx
+    LetStatement indent: string
+      StringLiteral ""
+    LetStatement d: i32
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier d
+          Identifier depth
+      Assignment
+        Target
+          Identifier indent
+        Value
+          BinaryExpr +
+            Identifier indent
+            StringLiteral "  "
+      Assignment
+        Target
+          Identifier d
+        Value
+          BinaryExpr +
+            Identifier d
+            IntLiteral 1
+    MatchStatement
+      Scrutinee
+        FieldExpr .kind
+          Identifier node
+      Arm
+        Pattern
+          FieldExpr .IntLit
+            Identifier NK
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  Identifier indent
+                  StringLiteral "INT "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    FieldExpr .value
+                      Identifier node
+      Arm
+        Pattern
+          FieldExpr .Unary
+            Identifier NK
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                Identifier indent
+                StringLiteral "NEG"
+        LetStatement unused: i32
+          CallExpr
+            Callee
+              Identifier print_node
+            Args
+              Identifier arena
+              FieldExpr .left
+                Identifier node
+              BinaryExpr +
+                Identifier depth
+                IntLiteral 1
+      Arm
+        Pattern
+          FieldExpr .Binary
+            Identifier NK
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  Identifier indent
+                  StringLiteral "BIN "
+                CallExpr
+                  Callee
+                    Identifier op_name
+                  Args
+                    FieldExpr .op
+                      Identifier node
+        LetStatement unused1: i32
+          CallExpr
+            Callee
+              Identifier print_node
+            Args
+              Identifier arena
+              FieldExpr .left
+                Identifier node
+              BinaryExpr +
+                Identifier depth
+                IntLiteral 1
+        LetStatement unused2: i32
+          CallExpr
+            Callee
+              Identifier print_node
+            Args
+              Identifier arena
+              FieldExpr .right
+                Identifier node
+              BinaryExpr +
+                Identifier depth
+                IntLiteral 1
+    ReturnStatement
+      IntLiteral 0
+  FunctionDecl test_expr
+    Param label: string
+    Param source: string
+    Param expected: i64
+    ReturnType: bool
+    LetStatement tokens: Vector<Token>
+      CallExpr
+        Callee
+          Identifier lex
+        Args
+          Identifier source
+    LetStatement result: ParseResult
+      CallExpr
+        Callee
+          Identifier parse
+        Args
+          Identifier tokens
+          Identifier source
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier is_parse_ok
+            Args
+              Identifier result
+          BoolLiteral false
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "FAIL "
+                  Identifier label
+                StringLiteral ": parse error"
+        ReturnStatement
+          BoolLiteral false
+    LetStatement actual: i64
+      CallExpr
+        Callee
+          Identifier eval_node
+        Args
+          FieldExpr .arena
+            Identifier result
+          FieldExpr .node
+            Identifier result
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier actual
+          Identifier expected
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    StringLiteral "PASS "
+                    Identifier label
+                  StringLiteral " = "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    Identifier actual
+        ReturnStatement
+          BoolLiteral true
+      Else
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    BinaryExpr +
+                      BinaryExpr +
+                        StringLiteral "FAIL "
+                        Identifier label
+                      StringLiteral ": expected "
+                    CallExpr
+                      Callee
+                        Identifier i64_to_string
+                      Args
+                        Identifier expected
+                  StringLiteral ", got "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    Identifier actual
+        ReturnStatement
+          BoolLiteral false
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== expr_parser: lex -> parse -> eval ==="
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    LetStatement pass_count: i32
+      IntLiteral 0
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "literal"
+            StringLiteral "42"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 42
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "add"
+            StringLiteral "1 + 2"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 3
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "sub"
+            StringLiteral "10 - 3"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 7
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "mul"
+            StringLiteral "4 * 5"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 20
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "div"
+            StringLiteral "20 / 4"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 5
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "prec1"
+            StringLiteral "2 + 3 * 4"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 14
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "prec2"
+            StringLiteral "2 * 3 + 4"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 10
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "prec3"
+            StringLiteral "10 - 2 * 3"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 4
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "assoc_sub"
+            StringLiteral "10 - 3 - 2"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 5
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "assoc_div"
+            StringLiteral "24 / 4 / 2"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 3
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "parens1"
+            StringLiteral "(2 + 3) * 4"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 20
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "parens2"
+            StringLiteral "2 * (3 + 4)"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 14
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "nested_parens"
+            StringLiteral "((2 + 3))"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 5
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "neg"
+            StringLiteral "-5"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 5
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "neg_expr"
+            StringLiteral "-(3 + 4)"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 7
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "double_neg"
+            StringLiteral "--5"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 5
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "complex1"
+            StringLiteral "2 + 3 * 4 - 1"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 13
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "complex2"
+            StringLiteral "(1 + 2) * (3 + 4)"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 21
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier test_expr
+          Args
+            StringLiteral "complex3"
+            StringLiteral "-2 * (3 + -4) * -5"
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 10
+      Then
+        Assignment
+          Target
+            Identifier pass_count
+          Value
+            BinaryExpr +
+              Identifier pass_count
+              IntLiteral 1
+    LetStatement total: i32
+      IntLiteral 19
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "--- results ---"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            BinaryExpr +
+              BinaryExpr +
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    Identifier pass_count
+                StringLiteral " / "
+              CallExpr
+                Callee
+                  Identifier i32_to_string
+                Args
+                  Identifier total
+            StringLiteral " passed"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "--- arena dump: (2 + 3) * 4 ---"
+    LetStatement demo_source: string
+      StringLiteral "(2 + 3) * 4"
+    LetStatement demo_tokens: Vector<Token>
+      CallExpr
+        Callee
+          Identifier lex
+        Args
+          Identifier demo_source
+    LetStatement demo_result: ParseResult
+      CallExpr
+        Callee
+          Identifier parse
+        Args
+          Identifier demo_tokens
+          Identifier demo_source
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_parse_ok
+          Args
+            Identifier demo_result
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "arena size: "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      CallExpr
+                        Callee
+                          FieldExpr .length
+                            FieldExpr .arena
+                              Identifier demo_result
+                StringLiteral " nodes"
+        LetStatement unused: i32
+          CallExpr
+            Callee
+              Identifier print_node
+            Args
+              FieldExpr .arena
+                Identifier demo_result
+              FieldExpr .node
+                Identifier demo_result
+              IntLiteral 0
+    ReturnStatement
+      IntLiteral 0


### PR DESCRIPTION
## Summary

Rewrite the expression parser bootstrap probe to use enums, match, and else-if — validating that the language features added in #170 and #171 deliver on the demonstrated pain points from the original probe.

## Highlights

- **Magic numbers eliminated**: 12 `fn TK_INT(): i32 -> 1` constant functions replaced by two enums (`TK` with 9 variants, `NK` with 3 variants)
- **Enum-typed fields**: `Token.kind: TK` and `ExprNode.kind: NK` replace `i32` kind fields; `ExprNode.op: TK` replaces cast-to-i64 operator storage
- **Flat lexer**: 8-level nested if/else cascade replaced by flat else-if chain
- **Match dispatch**: evaluator and arena printer use `match node.kind:` with `NK.IntLit` / `NK.Binary` / `NK.Unary` arms; nested `match node.op:` for operator dispatch
- **Vector\<T\> with enum fields**: confirms `Vector<ExprNode>` works correctly when ExprNode contains two enum-typed fields
- **19/19 test cases pass**: identical semantics, materially better readability

## Test plan

- [x] All 12 compiler tests pass (`ctest`) including AST golden files
- [x] 19/19 expression evaluation tests pass (same test suite as before)
- [x] Arena dump output matches expected tree structure
- [x] All other examples compile and run unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)