### PR TITLE
feat(lang): ✨ add generic enum types — Option<T> and Result<T, E>

### DIFF
--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -234,6 +234,7 @@ struct EnumVariantSpec {
 struct EnumDeclNode {
   std::string_view name;
   Span name_span;
+  std::vector<GenericParam> type_params;
   std::vector<EnumVariantSpec> variants;
 };
 

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -415,6 +415,7 @@ private:
   auto parse_enum_decl() -> Decl* {
     const auto& kw = consume(TokenKind::KwEnum);
     const auto& name_tok = consume(TokenKind::Identifier);
+    auto type_params = parse_type_params();
     consume(TokenKind::Colon);
     consume(TokenKind::Newline);
     consume(TokenKind::Indent);
@@ -456,6 +457,7 @@ private:
     Span span = span_from(kw.span);
     return ctx_.alloc<Decl>(
         span, EnumDeclNode{.name = name_tok.text, .name_span = name_tok.span,
+                           .type_params = std::move(type_params),
                            .variants = std::move(variants)});
   }
 

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -335,10 +335,17 @@ private:
       break;
     case NodeKind::EnumDecl: {
       // Resolve payload type nodes in variant declarations.
+      // Create a scope for generic type parameters if present.
       const auto& en = decl.as<EnumDeclNode>();
+      auto* enum_scope = scope;
+      if (!en.type_params.empty()) {
+        enum_scope = ctx_.make_scope(ScopeKind::Struct, scope);
+        enum_scope->set_range(decl.span);
+        declare_type_params(en.type_params, enum_scope, decl);
+      }
       for (const auto& variant : en.variants) {
         for (const auto* type_node : variant.payload_types) {
-          resolve_type(*type_node, scope);
+          resolve_type(*type_node, enum_scope);
         }
       }
       break;

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -171,6 +171,55 @@ auto TypeChecker::resolve_type_node(const TypeNode* node) -> const Type* {
         }
       }
 
+      // Generic enum instantiation: Option<i32>, Result<i64, string>, etc.
+      if (base_type != nullptr && base_type->kind() == TypeKind::Enum) {
+        const auto* decl_node = sym->decl_as_decl();
+        const std::vector<GenericParam>* type_params = nullptr;
+        if (decl_node->is<EnumDeclNode>()) {
+          type_params = &decl_node->as<EnumDeclNode>().type_params;
+        }
+
+        if (type_params != nullptr && !type_params->empty()) {
+          if (named.type_args.empty()) {
+            error(node->span,
+                  "generic type '" + std::string(name) + "' requires " +
+                      std::to_string(type_params->size()) +
+                      " type argument(s)");
+            return nullptr;
+          }
+          if (named.type_args.size() != type_params->size()) {
+            error(node->span,
+                  "'" + std::string(name) + "' expects " +
+                      std::to_string(type_params->size()) +
+                      " type argument(s), got " +
+                      std::to_string(named.type_args.size()));
+            return nullptr;
+          }
+          std::unordered_map<uint32_t, const Type*> bindings;
+          bool valid = true;
+          for (size_t i = 0; i < named.type_args.size(); ++i) {
+            const auto* arg_type = resolve_type_node(named.type_args[i]);
+            if (arg_type == nullptr) {
+              valid = false;
+            } else {
+              bindings[static_cast<uint32_t>(i)] = arg_type;
+            }
+          }
+          if (valid) {
+            return substitute_generics(base_type, bindings);
+          }
+          return nullptr;
+        }
+
+        if (type_params != nullptr && type_params->empty() &&
+            !named.type_args.empty()) {
+          error(node->span,
+                "'" + std::string(name) +
+                    "' is not generic but was given type arguments");
+          return nullptr;
+        }
+      }
+
       return base_type;
     }
 
@@ -1101,7 +1150,7 @@ void TypeChecker::check_match(const Stmt* stmt) {
 
   for (const auto& arm : match.arms) {
     suppress_payload_check_ = true;
-    const auto* pattern_type = check_expr(arm.pattern);
+    const auto* pattern_type = check_expr(arm.pattern, scrutinee_type);
     suppress_payload_check_ = false;
     pending_payload_constructions_.erase(arm.pattern);
     if (scrutinee_type != nullptr && pattern_type != nullptr) {
@@ -1279,6 +1328,21 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
   default:
     error(expr->span, "unsupported expression in type checker");
     break;
+  }
+
+  // Coerce generic enum types to the expected instantiated type when
+  // the expected type is an enum with the same decl_id. This handles
+  // cases like `let x: Option<i64> = Option.None` where the variant
+  // expression has the uninstantiated generic type.
+  if (result != nullptr && expected != nullptr &&
+      result->kind() == TypeKind::Enum &&
+      expected->kind() == TypeKind::Enum) {
+    const auto* result_enum = static_cast<const TypeEnum*>(result);
+    const auto* expected_enum = static_cast<const TypeEnum*>(expected);
+    if (result_enum->decl_id() == expected_enum->decl_id() &&
+        result_enum != expected_enum) {
+      result = expected;
+    }
   }
 
   if (result != nullptr) {
@@ -1678,6 +1742,26 @@ auto TypeChecker::substitute_generics(
                                     std::move(new_fields))
                : type;
   }
+  case TypeKind::Enum: {
+    const auto* en = static_cast<const TypeEnum*>(type);
+    bool changed = false;
+    std::vector<EnumVariant> new_variants;
+    new_variants.reserve(en->variants().size());
+    for (const auto& variant : en->variants()) {
+      std::vector<const Type*> new_payload;
+      new_payload.reserve(variant.payload_types.size());
+      for (const auto* pt : variant.payload_types) {
+        const auto* sub = substitute_generics(pt, bindings);
+        if (sub != pt) changed = true;
+        new_payload.push_back(sub);
+      }
+      new_variants.push_back({variant.name, std::move(new_payload)});
+    }
+    return changed
+               ? types_.make_enum(en->decl_id(), en->name(),
+                                  std::move(new_variants))
+               : type;
+  }
   default:
     return type;
   }
@@ -1769,18 +1853,29 @@ auto TypeChecker::check_call(const Expr* expr) -> const Type* {
                     std::to_string(call.args.size()));
           return callee_type;
         }
+        // Infer generic bindings from arguments and return the
+        // instantiated enum type.
+        std::unordered_map<uint32_t, const Type*> type_bindings;
         for (size_t i = 0; i < call.args.size(); ++i) {
           const auto* arg_type = check_expr(call.args[i]);
-          if (arg_type != nullptr && variant.payload_types[i] != nullptr &&
-              !is_assignable(arg_type, variant.payload_types[i])) {
-            error(call.args[i]->span,
-                  "payload field type '" + print_type(arg_type) +
-                      "' is not assignable to '" +
-                      print_type(variant.payload_types[i]) + "'");
+          if (arg_type != nullptr && variant.payload_types[i] != nullptr) {
+            if (!is_assignable(arg_type, variant.payload_types[i])) {
+              error(call.args[i]->span,
+                    "payload field type '" + print_type(arg_type) +
+                        "' is not assignable to '" +
+                        print_type(variant.payload_types[i]) + "'");
+            }
+            // Infer generic param bindings from concrete arg types.
+            infer_type_bindings(variant.payload_types[i], arg_type,
+                                type_bindings, call.args[i]->span);
           }
         }
         // Clear the "needs-construction" mark set by check_field.
         pending_payload_constructions_.erase(call.callee);
+        // If generic bindings were inferred, return instantiated type.
+        if (!type_bindings.empty()) {
+          return substitute_generics(callee_type, type_bindings);
+        }
         return callee_type;
       }
     }
@@ -2448,6 +2543,8 @@ auto TypeChecker::find_generic_param_index(const Symbol* sym) -> uint32_t {
     type_params = &decl->as<FunctionDecl>().type_params;
   } else if (decl->is<ClassDecl>()) {
     type_params = &decl->as<ClassDecl>().type_params;
+  } else if (decl->is<EnumDeclNode>()) {
+    type_params = &decl->as<EnumDeclNode>().type_params;
   }
 
   if (type_params != nullptr) {

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1330,10 +1330,15 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
     break;
   }
 
-  // Coerce generic enum types to the expected instantiated type when
-  // the expected type is an enum with the same decl_id. This handles
-  // cases like `let x: Option<i64> = Option.None` where the variant
-  // expression has the uninstantiated generic type.
+  // Coerce uninstantiated generic enum types to the expected instantiated
+  // type when the expected type is an enum with the same decl_id. This
+  // handles cases like `let x: Option<i64> = Option.None` where the
+  // variant expression has the uninstantiated generic type.
+  //
+  // Only fires when the result still contains unresolved generic params.
+  // If the result is already a concrete instantiation (e.g. Option<string>
+  // inferred from Option.Some("oops")), it is NOT overwritten — the normal
+  // is_assignable check catches mismatches.
   if (result != nullptr && expected != nullptr &&
       result->kind() == TypeKind::Enum &&
       expected->kind() == TypeKind::Enum) {
@@ -1341,9 +1346,44 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
     const auto* expected_enum = static_cast<const TypeEnum*>(expected);
     if (result_enum->decl_id() == expected_enum->decl_id() &&
         result_enum != expected_enum) {
-      result = expected;
+      // Check if the result enum has any unresolved generic params.
+      bool has_generic = false;
+      for (const auto& variant : result_enum->variants()) {
+        for (const auto* pt : variant.payload_types) {
+          if (pt != nullptr && pt->kind() == TypeKind::GenericParam) {
+            has_generic = true;
+          }
+        }
+      }
+      if (has_generic) {
+        result = expected;
+      }
     }
   }
+
+  // Reject generic enum values that still have unresolved type params
+  // and no expected type to coerce to. Only check value-producing
+  // expressions (FieldExpr for variant access, CallExpr for construction),
+  // not type-name identifiers.
+  if (result != nullptr && result->kind() == TypeKind::Enum &&
+      !suppress_payload_check_ &&
+      (expr->kind() == NodeKind::FieldExpr ||
+       expr->kind() == NodeKind::CallExpr)) {
+    const auto* re = static_cast<const TypeEnum*>(result);
+    for (const auto& variant : re->variants()) {
+      for (const auto* pt : variant.payload_types) {
+        if (pt != nullptr && pt->kind() == TypeKind::GenericParam) {
+          error(expr->span,
+                "cannot infer type argument(s) for generic enum '" +
+                    std::string(re->name()) +
+                    "'; provide an explicit type annotation");
+          result = nullptr;
+          goto done_generic_check; // NOLINT
+        }
+      }
+    }
+  }
+  done_generic_check:
 
   if (result != nullptr) {
     typed_.set_expr_type(expr, result);

--- a/compiler/frontend/typecheck/type_conversion.cpp
+++ b/compiler/frontend/typecheck/type_conversion.cpp
@@ -97,10 +97,36 @@ auto is_assignable(const Type* source, const Type* target) -> bool {
       return true;
     }
     case TypeKind::Enum: {
-      // Same enum type: match by decl_id.
       const auto* se = static_cast<const TypeEnum*>(source);
       const auto* te = static_cast<const TypeEnum*>(target);
-      return se->decl_id() == te->decl_id();
+      // Same enum: match by decl_id.
+      if (se->decl_id() != te->decl_id() || se->name() != te->name()) {
+        return false;
+      }
+      // Check variant payload types.
+      if (se->variants().size() != te->variants().size()) {
+        return false;
+      }
+      for (size_t i = 0; i < se->variants().size(); ++i) {
+        const auto& sv = se->variants()[i];
+        const auto& tv = te->variants()[i];
+        if (sv.payload_types.size() != tv.payload_types.size()) {
+          return false;
+        }
+        for (size_t j = 0; j < sv.payload_types.size(); ++j) {
+          const auto* sp = sv.payload_types[j];
+          const auto* tp = tv.payload_types[j];
+          if (sp == tp) {
+            continue;
+          }
+          if (sp->kind() == TypeKind::GenericParam ||
+              tp->kind() == TypeKind::GenericParam) {
+            continue;
+          }
+          return false;
+        }
+      }
+      return true;
     }
     default:
       break;

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -484,10 +484,15 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
     }
 
     // Enum variant construction: Token.Int(42) → HirEnumConstruct
+    // Use the CallExpr's type (which may be instantiated for generic enums)
+    // rather than the callee's type (which may be the uninstantiated generic).
     if (callee_type != nullptr && callee_type->kind() == TypeKind::Enum &&
         call.callee->is<FieldExpr>()) {
       const auto& field = call.callee->as<FieldExpr>();
-      const auto* enum_type = static_cast<const TypeEnum*>(callee_type);
+      const auto* enum_type =
+          (type != nullptr && type->kind() == TypeKind::Enum)
+              ? static_cast<const TypeEnum*>(type)
+              : static_cast<const TypeEnum*>(callee_type);
       for (size_t i = 0; i < enum_type->variants().size(); ++i) {
         if (enum_type->variants()[i].name == field.field &&
             !enum_type->variants()[i].payload_types.empty()) {

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -94,6 +94,30 @@ auto substitute_type(const Type* type, const TypeSubst& subst,
                              std::move(new_fields));
   }
 
+  case TypeKind::Enum: {
+    const auto* en = static_cast<const TypeEnum*>(type);
+    bool changed = false;
+    std::vector<EnumVariant> new_variants;
+    new_variants.reserve(en->variants().size());
+    for (const auto& variant : en->variants()) {
+      std::vector<const Type*> new_payload;
+      new_payload.reserve(variant.payload_types.size());
+      for (const auto* pt : variant.payload_types) {
+        auto* sub = substitute_type(pt, subst, types);
+        if (sub != pt) {
+          changed = true;
+        }
+        new_payload.push_back(sub);
+      }
+      new_variants.push_back({variant.name, std::move(new_payload)});
+    }
+    if (!changed) {
+      return type;
+    }
+    return types.make_enum(en->decl_id(), en->name(),
+                           std::move(new_variants));
+  }
+
   default:
     return type;
   }
@@ -131,6 +155,17 @@ auto type_has_generic(const Type* type) -> bool {
     for (const auto& field : st->fields()) {
       if (type_has_generic(field.type)) {
         return true;
+      }
+    }
+    return false;
+  }
+  case TypeKind::Enum: {
+    const auto* en = static_cast<const TypeEnum*>(type);
+    for (const auto& variant : en->variants()) {
+      for (const auto* pt : variant.payload_types) {
+        if (type_has_generic(pt)) {
+          return true;
+        }
       }
     }
     return false;
@@ -429,6 +464,22 @@ void infer_bindings_recursive(const Type* pattern, const Type* concrete,
       for (size_t i = 0; i < sp->fields().size(); ++i) {
         infer_bindings_recursive(sp->fields()[i].type,
                                  sc->fields()[i].type, subst);
+      }
+    }
+  } else if (pattern->kind() == TypeKind::Enum &&
+             concrete->kind() == TypeKind::Enum) {
+    const auto* ep = static_cast<const TypeEnum*>(pattern);
+    const auto* ec = static_cast<const TypeEnum*>(concrete);
+    if (ep->variants().size() == ec->variants().size()) {
+      for (size_t vi = 0; vi < ep->variants().size(); ++vi) {
+        const auto& vp = ep->variants()[vi];
+        const auto& vc = ec->variants()[vi];
+        if (vp.payload_types.size() == vc.payload_types.size()) {
+          for (size_t pi = 0; pi < vp.payload_types.size(); ++pi) {
+            infer_bindings_recursive(vp.payload_types[pi],
+                                     vc.payload_types[pi], subst);
+          }
+        }
       }
     }
   }

--- a/examples/generic_enums.dao
+++ b/examples/generic_enums.dao
@@ -1,0 +1,85 @@
+// generic_enums.dao — generic payload-bearing enums.
+//
+// Demonstrates Option<T> and Result<T, E> as user-defined generic enums.
+
+// ---------------------------------------------------------------
+// Option<T> — presence or absence of a value
+// ---------------------------------------------------------------
+
+enum Option<T>:
+  Some(T)
+  None
+
+fn unwrap_i64_or(opt: Option<i64>, default_val: i64): i64
+  match opt:
+    Option.Some(value):
+      return value
+    Option.None:
+      return default_val
+
+// ---------------------------------------------------------------
+// Result<T, E> — success or failure
+// ---------------------------------------------------------------
+
+enum Result<T, E>:
+  Ok(T)
+  Err(E)
+
+// ---------------------------------------------------------------
+// Test functions
+// ---------------------------------------------------------------
+
+fn safe_divide(a: i64, b: i64): Result<i64, string>
+  if b == to_i64(0):
+    return Result.Err("division by zero")
+  return Result.Ok(a / b)
+
+fn find_first_positive(a: i64, b: i64, c: i64): Option<i64>
+  if a > to_i64(0):
+    return Option.Some(a)
+  if b > to_i64(0):
+    return Option.Some(b)
+  if c > to_i64(0):
+    return Option.Some(c)
+  return Option.None
+
+fn main(): i32
+  // --- Option<i64> ---
+  print("=== Option<T> ===")
+
+  let some_val: Option<i64> = Option.Some(to_i64(42))
+  let none_val: Option<i64> = Option.None
+
+  print("unwrap Some(42): " + i64_to_string(unwrap_i64_or(some_val, to_i64(0))))
+  print("unwrap None:     " + i64_to_string(unwrap_i64_or(none_val, to_i64(-1))))
+
+  let found: Option<i64> = find_first_positive(to_i64(-1), to_i64(7), to_i64(3))
+  print("first positive:  " + i64_to_string(unwrap_i64_or(found, to_i64(0))))
+
+  let not_found: Option<i64> = find_first_positive(to_i64(-1), to_i64(-2), to_i64(-3))
+  print("none found:      " + i64_to_string(unwrap_i64_or(not_found, to_i64(0))))
+
+  // --- Result<i64, string> ---
+  print("")
+  print("=== Result<T, E> ===")
+
+  let ok_result: Result<i64, string> = safe_divide(to_i64(20), to_i64(4))
+  let err_result: Result<i64, string> = safe_divide(to_i64(10), to_i64(0))
+
+  match ok_result:
+    Result.Ok(value):
+      print("20 / 4 = " + i64_to_string(value))
+    Result.Err(msg):
+      print("error: " + msg)
+
+  match err_result:
+    Result.Ok(value):
+      print("10 / 0 = " + i64_to_string(value))
+    Result.Err(msg):
+      print("error: " + msg)
+
+  // Note: generic functions taking generic enum params (e.g.
+  // is_ok<T, E>(r: Result<T, E>)) are deferred pending
+  // monomorphization support for generic enum function parameters.
+
+  return 0

--- a/testdata/ast/examples_generic_enums.ast
+++ b/testdata/ast/examples_generic_enums.ast
@@ -1,0 +1,372 @@
+File
+  EnumDecl Option
+    Variant Some
+    Variant None
+  FunctionDecl unwrap_i64_or
+    Param opt: Option<i64>
+    Param default_val: i64
+    ReturnType: i64
+    MatchStatement
+      Scrutinee
+        Identifier opt
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
+        ReturnStatement
+          Identifier value
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ReturnStatement
+          Identifier default_val
+  EnumDecl Result
+    Variant Ok
+    Variant Err
+  FunctionDecl safe_divide
+    Param a: i64
+    Param b: i64
+    ReturnType: Result<i64, string>
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier b
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Err
+                Identifier Result
+            Args
+              StringLiteral "division by zero"
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Ok
+            Identifier Result
+        Args
+          BinaryExpr /
+            Identifier a
+            Identifier b
+  FunctionDecl find_first_positive
+    Param a: i64
+    Param b: i64
+    Param c: i64
+    ReturnType: Option<i64>
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier a
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              Identifier a
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier b
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              Identifier b
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier c
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              Identifier c
+    ReturnStatement
+      FieldExpr .None
+        Identifier Option
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== Option<T> ==="
+    LetStatement some_val: Option<i64>
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 42
+    LetStatement none_val: Option<i64>
+      FieldExpr .None
+        Identifier Option
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "unwrap Some(42): "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    Identifier unwrap_i64_or
+                  Args
+                    Identifier some_val
+                    CallExpr
+                      Callee
+                        Identifier to_i64
+                      Args
+                        IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "unwrap None:     "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    Identifier unwrap_i64_or
+                  Args
+                    Identifier none_val
+                    CallExpr
+                      Callee
+                        Identifier to_i64
+                      Args
+                        UnaryExpr -
+                          IntLiteral 1
+    LetStatement found: Option<i64>
+      CallExpr
+        Callee
+          Identifier find_first_positive
+        Args
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 7
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 3
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "first positive:  "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    Identifier unwrap_i64_or
+                  Args
+                    Identifier found
+                    CallExpr
+                      Callee
+                        Identifier to_i64
+                      Args
+                        IntLiteral 0
+    LetStatement not_found: Option<i64>
+      CallExpr
+        Callee
+          Identifier find_first_positive
+        Args
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 2
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 3
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "none found:      "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    Identifier unwrap_i64_or
+                  Args
+                    Identifier not_found
+                    CallExpr
+                      Callee
+                        Identifier to_i64
+                      Args
+                        IntLiteral 0
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== Result<T, E> ==="
+    LetStatement ok_result: Result<i64, string>
+      CallExpr
+        Callee
+          Identifier safe_divide
+        Args
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 20
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 4
+    LetStatement err_result: Result<i64, string>
+      CallExpr
+        Callee
+          Identifier safe_divide
+        Args
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 10
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+    MatchStatement
+      Scrutinee
+        Identifier ok_result
+      Arm
+        Pattern
+          FieldExpr .Ok
+            Identifier Result
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "20 / 4 = "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    Identifier value
+      Arm
+        Pattern
+          FieldExpr .Err
+            Identifier Result
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "error: "
+                Identifier msg
+    MatchStatement
+      Scrutinee
+        Identifier err_result
+      Arm
+        Pattern
+          FieldExpr .Ok
+            Identifier Result
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "10 / 0 = "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    Identifier value
+      Arm
+        Pattern
+          FieldExpr .Err
+            Identifier Result
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "error: "
+                Identifier msg
+    ReturnStatement
+      IntLiteral 0


### PR DESCRIPTION
## Summary

Adds generic enum declarations with type parameter substitution, making `Option<T>` and `Result<T, E>` expressible as user-defined Dao types. Full pipeline from parsing through LLVM codegen, with type argument inference on variant constructors and generic-to-instantiated coercion for expected types.

## Highlights

- `enum Option<T>: Some(T) | None` and `enum Result<T, E>: Ok(T) | Err(E)` compile and run end-to-end
- Type argument inference: `Option.Some(to_i64(42))` infers `Option<i64>` from the argument type
- Expected-type coercion: `let x: Option<i64> = Option.None` uses the declared type to instantiate the generic
- `substitute_generics` and monomorphization `substitute_type` both handle the new TypeEnum case
- `is_assignable` extended with structural enum comparison for generic param tolerance
- `find_generic_param_index` extended for EnumDeclNode (previously only handled FunctionDecl and ClassDecl, causing all type params to get index 0)

## Known Limitations

- Generic functions taking generic enum parameters (e.g. `fn unwrap<T>(opt: Option<T>): T`) are not yet monomorphized correctly — the monomorphizer detects them as generic but the specialization/cloning path doesn't fully handle enum type argument inference from call sites. Concrete functions that consume/return specific enum instantiations (e.g. `fn safe_divide(...): Result<i64, string>`) work correctly.

## Test plan

- [x] `examples/generic_enums.dao` compiles and runs: Option and Result with construction, match destructuring, function returns
- [x] All 20 examples compile without errors
- [x] All 12 ctest targets pass
- [x] No regressions on payload-free or non-generic payload enums

🤖 Generated with [Claude Code](https://claude.com/claude-code)