### PR TITLE
feat(numeric): ✨ add checked arithmetic returning Option<T> — Task 14 Tier A+ complete

### DIFF
--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -18,6 +18,7 @@
 
 #include <llvm/Support/Program.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdlib>
 #include <filesystem>
@@ -142,11 +143,17 @@ auto load_prelude_source() -> std::string {
     if (!std::filesystem::exists(dir)) {
       continue;
     }
+    // Collect and sort entries so prelude loading order is stable
+    // and dependency-aware (e.g. option.dao before overflow.dao).
+    std::vector<std::filesystem::path> paths;
     for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-      if (entry.path().extension() != ".dao") {
-        continue;
+      if (entry.path().extension() == ".dao") {
+        paths.push_back(entry.path());
       }
-      prelude += read_file(entry.path());
+    }
+    std::sort(paths.begin(), paths.end());
+    for (const auto& p : paths) {
+      prelude += read_file(p);
       prelude += '\n';
     }
   }

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -317,18 +317,17 @@ Status: **complete**
 
 #### Tier A+ — Post-baseline (no blocking dependency)
 
-Status: **wrapping and saturating complete; checked deferred**
-
-Priority: **medium** — enriches the numeric surface but does not
-block other tiers.
+Status: **complete**
 
 - ✓ explicit wrapping operations for i32 and i64: `wrapping_add`,
   `wrapping_sub`, `wrapping_mul` (+ `_i64` variants)
 - ✓ explicit saturating operations for i32 and i64: `saturating_add`,
   `saturating_sub`, `saturating_mul` (+ `_i64` variants)
-- ✗ explicit checked operations: `checked_add`, `checked_sub`,
-  `checked_mul` — deferred until Dao has a Result/Option type to
-  express the error-or-value return; default operators already trap
+- ✓ explicit checked operations for all signed types (i8–i64):
+  `checked_add`, `checked_sub`, `checked_mul` — return
+  `Option.None` on overflow, `Option.Some(result)` otherwise;
+  pure Dao implementations (no runtime hooks), enabled by
+  `Option<T>` prelude promotion
 
 #### Tier B — Phase 6 prerequisite
 

--- a/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
+++ b/docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md
@@ -117,8 +117,11 @@ Explicit overflow operations:
 - `saturating_add`, `saturating_sub`, `saturating_mul` — clamp to
   min/max representable value — **implemented** for all signed types
   (i8–i64)
-- `checked_add`, `checked_sub`, `checked_mul` — return an error
-  value or status on overflow — **deferred** until Result type exists
+- `checked_add`, `checked_sub`, `checked_mul` — return
+  `Option.None` on overflow, `Option.Some(result)` otherwise —
+  **implemented** for all signed types (i8–i64); pure Dao
+  implementations using widening (i8/i16/i32) or wrapping +
+  overflow detection (i64)
 
 If Dao later wants relaxed arithmetic for high-performance numerics,
 it must be introduced as an explicit mode, operator family, or
@@ -126,8 +129,8 @@ intrinsic family — not by overloading `unsafe` or by making
 semantics build-configuration-dependent.
 
 Status: **Specified, implemented** — default signed arithmetic traps
-on overflow for all signed types (i8–i64); explicit wrapping and
-saturating operations available for all signed types
+on overflow for all signed types (i8–i64); explicit wrapping,
+saturating, and checked operations available for all signed types
 
 ### 4.3 Division and remainder
 

--- a/examples/checked_arithmetic.dao
+++ b/examples/checked_arithmetic.dao
@@ -1,0 +1,61 @@
+// checked_arithmetic.dao — checked overflow operations returning Option<T>.
+//
+// Demonstrates checked_add, checked_sub, checked_mul for i32 and i64.
+// Each returns Option.Some(result) on success, Option.None on overflow.
+
+fn show_i32(label: string, result: Option<i32>): i32
+  match result:
+    Option.Some(value):
+      print(label + " = Some(" + i32_to_string(value) + ")")
+    Option.None:
+      print(label + " = None (overflow)")
+  return 0
+
+fn show_i64(label: string, result: Option<i64>): i32
+  match result:
+    Option.Some(value):
+      print(label + " = Some(" + i64_to_string(value) + ")")
+    Option.None:
+      print(label + " = None (overflow)")
+  return 0
+
+fn main(): i32
+  print("=== checked i32 arithmetic ===")
+  print("")
+
+  // Normal cases — no overflow.
+  let unused1: i32 = show_i32("checked_add(10, 20)", checked_add(10, 20))
+  let unused2: i32 = show_i32("checked_sub(100, 42)", checked_sub(100, 42))
+  let unused3: i32 = show_i32("checked_mul(7, 6)", checked_mul(7, 6))
+
+  // Overflow cases — near i32 max (2147483647).
+  let unused4: i32 = show_i32("checked_add(2147483647, 1)", checked_add(2147483647, 1))
+  let unused5: i32 = show_i32("checked_sub(-2147483648, 1)", checked_sub(-2147483648, 1))
+  let unused6: i32 = show_i32("checked_mul(2147483647, 2)", checked_mul(2147483647, 2))
+
+  // Edge: zero and identity.
+  let unused7: i32 = show_i32("checked_add(0, 0)", checked_add(0, 0))
+  let unused8: i32 = show_i32("checked_mul(0, 2147483647)", checked_mul(0, 2147483647))
+
+  print("")
+  print("=== checked i64 arithmetic ===")
+  print("")
+
+  // Normal cases.
+  let unused9: i32 = show_i64("checked_add_i64(100, 200)", checked_add_i64(to_i64(100), to_i64(200)))
+  let unused10: i32 = show_i64("checked_sub_i64(50, 30)", checked_sub_i64(to_i64(50), to_i64(30)))
+  let unused11: i32 = show_i64("checked_mul_i64(1000, 1000)", checked_mul_i64(to_i64(1000), to_i64(1000)))
+
+  // Overflow: MAX + 1.
+  let max64: i64 = to_i64(2147483647) * to_i64(4) + to_i64(3)
+  // max64 = 8589934591 (well within i64 range, but useful for non-trivial test)
+  let unused12: i32 = show_i64("checked_add_i64(max64, max64)", checked_add_i64(max64, max64))
+  let unused13: i32 = show_i64("checked_mul_i64(max64, max64)", checked_mul_i64(max64, max64))
+
+  // Edge: multiply by -1 (non-overflow).
+  let unused14: i32 = show_i64("checked_mul_i64(-1, 42)", checked_mul_i64(to_i64(-1), to_i64(42)))
+
+  // Edge: multiply by zero.
+  let unused15: i32 = show_i64("checked_mul_i64(0, 999)", checked_mul_i64(to_i64(0), to_i64(999)))
+
+  return 0

--- a/examples/generic_enums.dao
+++ b/examples/generic_enums.dao
@@ -1,14 +1,11 @@
 // generic_enums.dao — generic payload-bearing enums.
 //
-// Demonstrates Option<T> and Result<T, E> as user-defined generic enums.
+// Demonstrates Option<T> and Result<T, E> from the prelude.
 
 // ---------------------------------------------------------------
-// Option<T> — presence or absence of a value
+// Option<T> and Result<T, E> are provided by the prelude
+// (stdlib/core/option.dao and stdlib/core/result.dao).
 // ---------------------------------------------------------------
-
-enum Option<T>:
-  Some(T)
-  None
 
 fn unwrap_i64_or(opt: Option<i64>, default_val: i64): i64
   match opt:
@@ -16,14 +13,6 @@ fn unwrap_i64_or(opt: Option<i64>, default_val: i64): i64
       return value
     Option.None:
       return default_val
-
-// ---------------------------------------------------------------
-// Result<T, E> — success or failure
-// ---------------------------------------------------------------
-
-enum Result<T, E>:
-  Ok(T)
-  Err(E)
 
 // ---------------------------------------------------------------
 // Test functions

--- a/stdlib/core/option.dao
+++ b/stdlib/core/option.dao
@@ -1,0 +1,3 @@
+enum Option<T>:
+  Some(T)
+  None

--- a/stdlib/core/overflow.dao
+++ b/stdlib/core/overflow.dao
@@ -49,3 +49,117 @@ fn saturating_mul(a: i32, b: i32): i32 -> __dao_saturating_mul_i32(a, b)
 fn saturating_add_i64(a: i64, b: i64): i64 -> __dao_saturating_add_i64(a, b)
 fn saturating_sub_i64(a: i64, b: i64): i64 -> __dao_saturating_sub_i64(a, b)
 fn saturating_mul_i64(a: i64, b: i64): i64 -> __dao_saturating_mul_i64(a, b)
+
+// ---------------------------------------------------------------------------
+// Checked operations — return Option.None on overflow
+//
+// Pure Dao implementations using widening (i8/i16/i32) or wrapping +
+// overflow detection (i64). No runtime hooks required.
+// Authority: docs/contracts/CONTRACT_NUMERIC_SEMANTICS.md §4.2
+// ---------------------------------------------------------------------------
+
+// --- i8 (widen to i32) ---
+
+fn checked_add_i8(a: i8, b: i8): Option<i8>
+  let r: i32 = i8_to_i32(a) + i8_to_i32(b)
+  if r > 127 or r < -128:
+    return Option.None
+  return Option.Some(i32_to_i8(r))
+
+fn checked_sub_i8(a: i8, b: i8): Option<i8>
+  let r: i32 = i8_to_i32(a) - i8_to_i32(b)
+  if r > 127 or r < -128:
+    return Option.None
+  return Option.Some(i32_to_i8(r))
+
+fn checked_mul_i8(a: i8, b: i8): Option<i8>
+  let r: i32 = i8_to_i32(a) * i8_to_i32(b)
+  if r > 127 or r < -128:
+    return Option.None
+  return Option.Some(i32_to_i8(r))
+
+// --- i16 (widen to i32) ---
+
+fn checked_add_i16(a: i16, b: i16): Option<i16>
+  let r: i32 = i16_to_i32(a) + i16_to_i32(b)
+  if r > 32767 or r < -32768:
+    return Option.None
+  return Option.Some(i32_to_i16(r))
+
+fn checked_sub_i16(a: i16, b: i16): Option<i16>
+  let r: i32 = i16_to_i32(a) - i16_to_i32(b)
+  if r > 32767 or r < -32768:
+    return Option.None
+  return Option.Some(i32_to_i16(r))
+
+fn checked_mul_i16(a: i16, b: i16): Option<i16>
+  let r: i32 = i16_to_i32(a) * i16_to_i32(b)
+  if r > 32767 or r < -32768:
+    return Option.None
+  return Option.Some(i32_to_i16(r))
+
+// --- i32 (widen to i64) ---
+
+fn checked_add(a: i32, b: i32): Option<i32>
+  let r: i64 = to_i64(a) + to_i64(b)
+  if r > to_i64(2147483647) or r < to_i64(-2147483648):
+    return Option.None
+  return Option.Some(i64_to_i32(r))
+
+fn checked_sub(a: i32, b: i32): Option<i32>
+  let r: i64 = to_i64(a) - to_i64(b)
+  if r > to_i64(2147483647) or r < to_i64(-2147483648):
+    return Option.None
+  return Option.Some(i64_to_i32(r))
+
+fn checked_mul(a: i32, b: i32): Option<i32>
+  let r: i64 = to_i64(a) * to_i64(b)
+  if r > to_i64(2147483647) or r < to_i64(-2147483648):
+    return Option.None
+  return Option.Some(i64_to_i32(r))
+
+// --- i64 (cannot widen — use wrapping + overflow detection) ---
+
+fn checked_add_i64(a: i64, b: i64): Option<i64>
+  let r: i64 = wrapping_add_i64(a, b)
+  // Overflow iff operand and result signs disagree.
+  if b >= to_i64(0):
+    if r < a:
+      return Option.None
+  else:
+    if r > a:
+      return Option.None
+  return Option.Some(r)
+
+fn checked_sub_i64(a: i64, b: i64): Option<i64>
+  let r: i64 = wrapping_sub_i64(a, b)
+  // Subtraction overflow: subtracting positive made it bigger,
+  // or subtracting negative made it smaller.
+  if b > to_i64(0):
+    if r > a:
+      return Option.None
+  else if b < to_i64(0):
+    if r < a:
+      return Option.None
+  return Option.Some(r)
+
+fn checked_mul_i64(a: i64, b: i64): Option<i64>
+  if a == to_i64(0) or b == to_i64(0):
+    return Option.Some(to_i64(0))
+  let r: i64 = wrapping_mul_i64(a, b)
+  // Guard -1 edge cases to avoid MIN/-1 divide trap in the
+  // divide-back check below. -1 * x overflows only when x is
+  // MIN_I64 (the only value where wrapping negation is identity).
+  // Detection: wrapping_mul(-1, MIN) = MIN = b, so r == b.
+  if a == to_i64(-1):
+    if r == b:
+      return Option.None
+    return Option.Some(r)
+  if b == to_i64(-1):
+    if r == a:
+      return Option.None
+    return Option.Some(r)
+  // General case: divide-back (safe since a != 0, a != -1).
+  if r / a != b:
+    return Option.None
+  return Option.Some(r)

--- a/stdlib/core/result.dao
+++ b/stdlib/core/result.dao
@@ -1,0 +1,3 @@
+enum Result<T, E>:
+  Ok(T)
+  Err(E)

--- a/testdata/ast/examples_checked_arithmetic.ast
+++ b/testdata/ast/examples_checked_arithmetic.ast
@@ -1,0 +1,357 @@
+File
+  FunctionDecl show_i32
+    Param label: string
+    Param result: Option<i32>
+    ReturnType: i32
+    MatchStatement
+      Scrutinee
+        Identifier result
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    Identifier label
+                    StringLiteral " = Some("
+                  CallExpr
+                    Callee
+                      Identifier i32_to_string
+                    Args
+                      Identifier value
+                StringLiteral ")"
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                Identifier label
+                StringLiteral " = None (overflow)"
+    ReturnStatement
+      IntLiteral 0
+  FunctionDecl show_i64
+    Param label: string
+    Param result: Option<i64>
+    ReturnType: i32
+    MatchStatement
+      Scrutinee
+        Identifier result
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    Identifier label
+                    StringLiteral " = Some("
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier value
+                StringLiteral ")"
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                Identifier label
+                StringLiteral " = None (overflow)"
+    ReturnStatement
+      IntLiteral 0
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== checked i32 arithmetic ==="
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    LetStatement unused1: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_add(10, 20)"
+          CallExpr
+            Callee
+              Identifier checked_add
+            Args
+              IntLiteral 10
+              IntLiteral 20
+    LetStatement unused2: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_sub(100, 42)"
+          CallExpr
+            Callee
+              Identifier checked_sub
+            Args
+              IntLiteral 100
+              IntLiteral 42
+    LetStatement unused3: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_mul(7, 6)"
+          CallExpr
+            Callee
+              Identifier checked_mul
+            Args
+              IntLiteral 7
+              IntLiteral 6
+    LetStatement unused4: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_add(2147483647, 1)"
+          CallExpr
+            Callee
+              Identifier checked_add
+            Args
+              IntLiteral 2147483647
+              IntLiteral 1
+    LetStatement unused5: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_sub(-2147483648, 1)"
+          CallExpr
+            Callee
+              Identifier checked_sub
+            Args
+              UnaryExpr -
+                IntLiteral 2147483648
+              IntLiteral 1
+    LetStatement unused6: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_mul(2147483647, 2)"
+          CallExpr
+            Callee
+              Identifier checked_mul
+            Args
+              IntLiteral 2147483647
+              IntLiteral 2
+    LetStatement unused7: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_add(0, 0)"
+          CallExpr
+            Callee
+              Identifier checked_add
+            Args
+              IntLiteral 0
+              IntLiteral 0
+    LetStatement unused8: i32
+      CallExpr
+        Callee
+          Identifier show_i32
+        Args
+          StringLiteral "checked_mul(0, 2147483647)"
+          CallExpr
+            Callee
+              Identifier checked_mul
+            Args
+              IntLiteral 0
+              IntLiteral 2147483647
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== checked i64 arithmetic ==="
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    LetStatement unused9: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_add_i64(100, 200)"
+          CallExpr
+            Callee
+              Identifier checked_add_i64
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 100
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 200
+    LetStatement unused10: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_sub_i64(50, 30)"
+          CallExpr
+            Callee
+              Identifier checked_sub_i64
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 50
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 30
+    LetStatement unused11: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_mul_i64(1000, 1000)"
+          CallExpr
+            Callee
+              Identifier checked_mul_i64
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 1000
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 1000
+    LetStatement max64: i64
+      BinaryExpr +
+        BinaryExpr *
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 2147483647
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 4
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            IntLiteral 3
+    LetStatement unused12: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_add_i64(max64, max64)"
+          CallExpr
+            Callee
+              Identifier checked_add_i64
+            Args
+              Identifier max64
+              Identifier max64
+    LetStatement unused13: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_mul_i64(max64, max64)"
+          CallExpr
+            Callee
+              Identifier checked_mul_i64
+            Args
+              Identifier max64
+              Identifier max64
+    LetStatement unused14: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_mul_i64(-1, 42)"
+          CallExpr
+            Callee
+              Identifier checked_mul_i64
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  UnaryExpr -
+                    IntLiteral 1
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 42
+    LetStatement unused15: i32
+      CallExpr
+        Callee
+          Identifier show_i64
+        Args
+          StringLiteral "checked_mul_i64(0, 999)"
+          CallExpr
+            Callee
+              Identifier checked_mul_i64
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 0
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 999
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_generic_enums.ast
+++ b/testdata/ast/examples_generic_enums.ast
@@ -1,7 +1,4 @@
 File
-  EnumDecl Option
-    Variant Some
-    Variant None
   FunctionDecl unwrap_i64_or
     Param opt: Option<i64>
     Param default_val: i64
@@ -21,9 +18,6 @@ File
             Identifier Option
         ReturnStatement
           Identifier default_val
-  EnumDecl Result
-    Variant Ok
-    Variant Err
   FunctionDecl safe_divide
     Param a: i64
     Param b: i64

--- a/testdata/ast/stdlib_core_option.ast
+++ b/testdata/ast/stdlib_core_option.ast
@@ -1,0 +1,4 @@
+File
+  EnumDecl Option
+    Variant Some
+    Variant None

--- a/testdata/ast/stdlib_core_overflow.ast
+++ b/testdata/ast/stdlib_core_overflow.ast
@@ -359,3 +359,612 @@ File
         Args
           Identifier a
           Identifier b
+  FunctionDecl checked_add_i8
+    Param a: i8
+    Param b: i8
+    ReturnType: Option<i8>
+    LetStatement r: i32
+      BinaryExpr +
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 127
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 128
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i8
+            Args
+              Identifier r
+  FunctionDecl checked_sub_i8
+    Param a: i8
+    Param b: i8
+    ReturnType: Option<i8>
+    LetStatement r: i32
+      BinaryExpr -
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 127
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 128
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i8
+            Args
+              Identifier r
+  FunctionDecl checked_mul_i8
+    Param a: i8
+    Param b: i8
+    ReturnType: Option<i8>
+    LetStatement r: i32
+      BinaryExpr *
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i8_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 127
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 128
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i8
+            Args
+              Identifier r
+  FunctionDecl checked_add_i16
+    Param a: i16
+    Param b: i16
+    ReturnType: Option<i16>
+    LetStatement r: i32
+      BinaryExpr +
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 32767
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 32768
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i16
+            Args
+              Identifier r
+  FunctionDecl checked_sub_i16
+    Param a: i16
+    Param b: i16
+    ReturnType: Option<i16>
+    LetStatement r: i32
+      BinaryExpr -
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 32767
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 32768
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i16
+            Args
+              Identifier r
+  FunctionDecl checked_mul_i16
+    Param a: i16
+    Param b: i16
+    ReturnType: Option<i16>
+    LetStatement r: i32
+      BinaryExpr *
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier i16_to_i32
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            IntLiteral 32767
+          BinaryExpr <
+            Identifier r
+            UnaryExpr -
+              IntLiteral 32768
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i32_to_i16
+            Args
+              Identifier r
+  FunctionDecl checked_add
+    Param a: i32
+    Param b: i32
+    ReturnType: Option<i32>
+    LetStatement r: i64
+      BinaryExpr +
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 2147483647
+          BinaryExpr <
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 2147483648
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i64_to_i32
+            Args
+              Identifier r
+  FunctionDecl checked_sub
+    Param a: i32
+    Param b: i32
+    ReturnType: Option<i32>
+    LetStatement r: i64
+      BinaryExpr -
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 2147483647
+          BinaryExpr <
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 2147483648
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i64_to_i32
+            Args
+              Identifier r
+  FunctionDecl checked_mul
+    Param a: i32
+    Param b: i32
+    ReturnType: Option<i32>
+    LetStatement r: i64
+      BinaryExpr *
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier a
+        CallExpr
+          Callee
+            Identifier to_i64
+          Args
+            Identifier b
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr >
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 2147483647
+          BinaryExpr <
+            Identifier r
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                UnaryExpr -
+                  IntLiteral 2147483648
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          CallExpr
+            Callee
+              Identifier i64_to_i32
+            Args
+              Identifier r
+  FunctionDecl checked_add_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: Option<i64>
+    LetStatement r: i64
+      CallExpr
+        Callee
+          Identifier wrapping_add_i64
+        Args
+          Identifier a
+          Identifier b
+    IfStatement
+      Condition
+        BinaryExpr >=
+          Identifier b
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        IfStatement
+          Condition
+            BinaryExpr <
+              Identifier r
+              Identifier a
+          Then
+            ReturnStatement
+              FieldExpr .None
+                Identifier Option
+      Else
+        IfStatement
+          Condition
+            BinaryExpr >
+              Identifier r
+              Identifier a
+          Then
+            ReturnStatement
+              FieldExpr .None
+                Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          Identifier r
+  FunctionDecl checked_sub_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: Option<i64>
+    LetStatement r: i64
+      CallExpr
+        Callee
+          Identifier wrapping_sub_i64
+        Args
+          Identifier a
+          Identifier b
+    IfStatement
+      Condition
+        BinaryExpr >
+          Identifier b
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        IfStatement
+          Condition
+            BinaryExpr >
+              Identifier r
+              Identifier a
+          Then
+            ReturnStatement
+              FieldExpr .None
+                Identifier Option
+      Else
+        IfStatement
+          Condition
+            BinaryExpr <
+              Identifier b
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 0
+          Then
+            IfStatement
+              Condition
+                BinaryExpr <
+                  Identifier r
+                  Identifier a
+              Then
+                ReturnStatement
+                  FieldExpr .None
+                    Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          Identifier r
+  FunctionDecl checked_mul_i64
+    Param a: i64
+    Param b: i64
+    ReturnType: Option<i64>
+    IfStatement
+      Condition
+        BinaryExpr or
+          BinaryExpr ==
+            Identifier a
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+          BinaryExpr ==
+            Identifier b
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 0
+    LetStatement r: i64
+      CallExpr
+        Callee
+          Identifier wrapping_mul_i64
+        Args
+          Identifier a
+          Identifier b
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier a
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+      Then
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier r
+              Identifier b
+          Then
+            ReturnStatement
+              FieldExpr .None
+                Identifier Option
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              Identifier r
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier b
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              UnaryExpr -
+                IntLiteral 1
+      Then
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier r
+              Identifier a
+          Then
+            ReturnStatement
+              FieldExpr .None
+                Identifier Option
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Some
+                Identifier Option
+            Args
+              Identifier r
+    IfStatement
+      Condition
+        BinaryExpr !=
+          BinaryExpr /
+            Identifier r
+            Identifier a
+          Identifier b
+      Then
+        ReturnStatement
+          FieldExpr .None
+            Identifier Option
+    ReturnStatement
+      CallExpr
+        Callee
+          FieldExpr .Some
+            Identifier Option
+        Args
+          Identifier r

--- a/testdata/ast/stdlib_core_result.ast
+++ b/testdata/ast/stdlib_core_result.ast
@@ -1,0 +1,4 @@
+File
+  EnumDecl Result
+    Variant Ok
+    Variant Err

--- a/tools/playground/compiler_service/pipeline.cpp
+++ b/tools/playground/compiler_service/pipeline.cpp
@@ -11,12 +11,18 @@ auto load_prelude(const std::filesystem::path& repo_root) -> std::string {
   if (!std::filesystem::exists(stdlib_core)) {
     return prelude;
   }
+  // Collect and sort entries so prelude loading order is stable
+  // and dependency-aware (e.g. option.dao before overflow.dao).
+  std::vector<std::filesystem::path> paths;
   for (const auto& entry :
        std::filesystem::directory_iterator(stdlib_core)) {
-    if (entry.path().extension() != ".dao") {
-      continue;
+    if (entry.path().extension() == ".dao") {
+      paths.push_back(entry.path());
     }
-    std::ifstream file(entry.path());
+  }
+  std::sort(paths.begin(), paths.end());
+  for (const auto& p : paths) {
+    std::ifstream file(p);
     if (!file) {
       continue;
     }


### PR DESCRIPTION
## Summary

Implement `checked_add`, `checked_sub`, `checked_mul` for all signed integer types (i8–i64), returning `Option.Some(result)` on success and `Option.None` on overflow. Closes the last deferred item in Task 14 Tier A+, which was blocked on `Option<T>` availability.

## Highlights

- Promote `Option<T>` and `Result<T, E>` from examples to stdlib/core prelude types (`option.dao`, `result.dao`)
- Pure Dao implementations — no new C runtime hooks, no LLVM backend changes, no `CONTRACT_RUNTIME_ABI.md` churn
- i8/i16/i32: widen to i32/i64, compute, range-check
- i64 add/sub: wrapping + sign-based overflow detection
- i64 mul: wrapping + edge-case guards + divide-back verification
- Update `generic_enums` example to use prelude types (removes local duplication)
- Update `CONTRACT_NUMERIC_SEMANTICS.md` §4.2 and `IMPLEMENTATION_PLAN.md` Tier A+ to mark checked ops as complete

## Test plan

- [x] 12/12 compiler tests pass
- [x] 21/21 examples compile and run
- [x] 6/6 bootstrap probes compile
- [x] `checked_arithmetic.dao` exercises i32 and i64 checked ops with overflow and non-overflow cases
- [x] Golden AST files regenerated for all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)