### PR TITLE
feat(stdlib): ✨ add string-keyed HashMap<V> with O(1) lookup

### DIFF
--- a/compiler/backend/llvm/llvm_runtime_hooks.cpp
+++ b/compiler/backend/llvm/llvm_runtime_hooks.cpp
@@ -406,6 +406,10 @@ void LlvmRuntimeHooks::declare_string_hooks() {
   // __dao_str_compare(a: *dao.string, b: *dao.string): i32
   ensure_declared(runtime_hooks::kStrCompare,
                   llvm::FunctionType::get(i32, {str_ptr, str_ptr}, false));
+
+  // __dao_hash_string(s: *dao.string): i64
+  ensure_declared(runtime_hooks::kStrHash,
+                  llvm::FunctionType::get(i64, {str_ptr}, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/backend/llvm/llvm_runtime_hooks.h
+++ b/compiler/backend/llvm/llvm_runtime_hooks.h
@@ -152,6 +152,7 @@ inline constexpr std::string_view kStrIndexOf    = "__dao_str_index_of";
 inline constexpr std::string_view kStrStartsWith = "__dao_str_starts_with";
 inline constexpr std::string_view kStrEndsWith   = "__dao_str_ends_with";
 inline constexpr std::string_view kStrCompare    = "__dao_str_compare";
+inline constexpr std::string_view kStrHash       = "__dao_str_hash";
 
 // All hook names, for iteration / validation.
 inline constexpr std::string_view kAllHooks[] = {
@@ -188,6 +189,7 @@ inline constexpr std::string_view kAllHooks[] = {
     kStrConcat, kStrLength,
     kStrCharAt, kStrSubstring, kStrIndexOf,
     kStrStartsWith, kStrEndsWith, kStrCompare,
+    kStrHash,
 };
 
 } // namespace runtime_hooks

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1365,6 +1365,11 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
   // and no expected type to coerce to. Only check value-producing
   // expressions (FieldExpr for variant access, CallExpr for construction),
   // not type-name identifiers.
+  //
+  // Exception: GenericParams whose binder is NOT the enum's own
+  // declaration are bound parameters from an enclosing class or
+  // function and will be resolved at monomorphization. Only reject
+  // GenericParams that belong to the enum itself (truly unresolved).
   if (result != nullptr && result->kind() == TypeKind::Enum &&
       !suppress_payload_check_ &&
       (expr->kind() == NodeKind::FieldExpr ||
@@ -1373,12 +1378,16 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
     for (const auto& variant : re->variants()) {
       for (const auto* pt : variant.payload_types) {
         if (pt != nullptr && pt->kind() == TypeKind::GenericParam) {
-          error(expr->span,
-                "cannot infer type argument(s) for generic enum '" +
-                    std::string(re->name()) +
-                    "'; provide an explicit type annotation");
-          result = nullptr;
-          goto done_generic_check; // NOLINT
+          const auto* gp = static_cast<const TypeGenericParam*>(pt);
+          // Allow params from enclosing scopes (class/function generics).
+          if (gp->binder() == re->decl_id()) {
+            error(expr->span,
+                  "cannot infer type argument(s) for generic enum '" +
+                      std::string(re->name()) +
+                      "'; provide an explicit type annotation");
+            result = nullptr;
+            goto done_generic_check; // NOLINT
+          }
         }
       }
     }

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -135,6 +135,7 @@ Examples:
 | `__dao_str_starts_with`  | `(s: string, prefix: string): bool`   |
 | `__dao_str_ends_with`    | `(s: string, suffix: string): bool`   |
 | `__dao_str_compare`      | `(a: string, b: string): i32`         |
+| `__dao_str_hash`         | `(s: string): i64`                    |
 | `__dao_wrapping_add_i8`  | `(a: i8, b: i8): i8`                 |
 | `__dao_wrapping_sub_i8`  | `(a: i8, b: i8): i8`                 |
 | `__dao_wrapping_mul_i8`  | `(a: i8, b: i8): i8`                 |

--- a/examples/bootstrap_probe/type_checker.dao
+++ b/examples/bootstrap_probe/type_checker.dao
@@ -4,10 +4,9 @@
 // booleans, comparisons, and logical operators, then adds a combined
 // resolve + typecheck pass over the arena.
 //
-// Tests: Option<T> for fallible symbol lookup, Result<T, E> for
-// error-bearing analysis, Vector<T> as a linear symbol table,
-// multi-pass compiler architecture (lex → parse → analyze), and
-// match destructuring for control flow.
+// Tests: HashMap<V> for O(1) symbol lookup, Result<T, E> for
+// error-bearing analysis, multi-pass compiler architecture
+// (lex → parse → analyze), and match destructuring for control flow.
 //
 // Language surface:
 //   let x = 5; let y = x + 3; y > 0
@@ -444,22 +443,12 @@ fn type_name(ty: i32): string
   return "???"
 
 // ---------------------------------------------------------------
-// Symbol table — Vector<Symbol> with linear scan
+// Symbol table — HashMap<Symbol> with O(1) lookup
 // ---------------------------------------------------------------
 
 class Symbol:
   name: string
   ty: i32
-
-fn find_symbol(table: Vector<Symbol>, name: string): Option<i64>
-  // Scan backwards so later bindings shadow earlier ones.
-  let i: i64 = table.length() - 1
-  while i >= to_i64(0):
-    let sym: Symbol = table.get(i)
-    if sym.name == name:
-      return Option.Some(i)
-    i = i - 1
-  return Option.None
 
 // ---------------------------------------------------------------
 // Type checker — combined resolve + typecheck over the AST arena
@@ -486,7 +475,7 @@ fn check_binary_op(op: TK, left_ty: i32, right_ty: i32): Result<i32, string>
 
   return Result.Err("unknown binary operator")
 
-fn check_expr(arena: Vector<Node>, idx: i64, table: Vector<Symbol>, source: string): Result<i32, string>
+fn check_expr(arena: Vector<Node>, idx: i64, table: HashMap<Symbol>, source: string): Result<i32, string>
   let node: Node = arena.get(idx)
   match node:
     Node.IntLit(v):
@@ -497,13 +486,10 @@ fn check_expr(arena: Vector<Node>, idx: i64, table: Vector<Symbol>, source: stri
 
     Node.VarRef(off, len):
       let name: string = substring(source, off, len)
-      let found: Option<i64> = find_symbol(table, name)
-      match found:
-        Option.Some(sym_idx):
-          let sym: Symbol = table.get(sym_idx)
-          return Result.Ok(sym.ty)
-        Option.None:
-          return Result.Err("undefined variable '" + name + "'")
+      if table.contains(name):
+        let sym: Symbol = table.get(name)
+        return Result.Ok(sym.ty)
+      return Result.Err("undefined variable '" + name + "'")
 
     Node.Binary(op, left, right):
       let lt: Result<i32, string> = check_expr(arena, left, table, source)
@@ -539,7 +525,7 @@ fn check_expr(arena: Vector<Node>, idx: i64, table: Vector<Symbol>, source: stri
 // Analyze a program: walk statements, build symbol table, typecheck.
 // Returns the type of the last statement (Ok) or the first error (Err).
 fn analyze(arena: Vector<Node>, stmts: Vector<Stmt>, source: string): Result<i32, string>
-  let table = Vector<Symbol>::new()
+  let table = HashMap<Symbol>::new()
   let last_ty: i32 = 0
   let i: i64 = 0
   while i < stmts.length():
@@ -550,7 +536,7 @@ fn analyze(arena: Vector<Node>, stmts: Vector<Stmt>, source: string): Result<i32
         match result:
           Result.Ok(ty):
             let name: string = substring(source, name_off, name_len)
-            table = table.push(Symbol(name, ty))
+            table = table.set(name, Symbol(name, ty))
             last_ty = ty
           Result.Err(msg):
             return Result.Err(msg)

--- a/examples/hashmap.dao
+++ b/examples/hashmap.dao
@@ -1,0 +1,70 @@
+// hashmap.dao — HashMap<V> smoke test.
+
+class Entry:
+  name: string
+  value: i32
+
+fn main(): i32
+  print("=== HashMap<V> ===")
+
+  let m = HashMap<Entry>::new()
+  m = m.set("x", Entry("x", 10))
+  m = m.set("y", Entry("y", 20))
+  m = m.set("z", Entry("z", 30))
+
+  print("length: " + i64_to_string(m.length()))
+
+  // Two-phase lookup: contains + get.
+  if m.contains("x"):
+    let e: Entry = m.get("x")
+    print("x = " + i32_to_string(e.value))
+
+  if m.contains("y"):
+    let e: Entry = m.get("y")
+    print("y = " + i32_to_string(e.value))
+
+  // Update existing key.
+  m = m.set("x", Entry("x", 99))
+  if m.contains("x"):
+    let e: Entry = m.get("x")
+    print("x (updated) = " + i32_to_string(e.value))
+
+  // Missing key.
+  if m.contains("w"):
+    print("w found (unexpected)")
+  else:
+    print("w not found (correct)")
+
+  // Many inserts to trigger resize.
+  let big = HashMap<i32>::new()
+  big = big.set("a", 1)
+  big = big.set("b", 2)
+  big = big.set("c", 3)
+  big = big.set("d", 4)
+  big = big.set("e", 5)
+  big = big.set("f", 6)
+  big = big.set("g", 7)
+  big = big.set("h", 8)
+  big = big.set("i", 9)
+  big = big.set("j", 10)
+  print("big length: " + i64_to_string(big.length()))
+
+  if big.contains("j"):
+    print("j = " + i32_to_string(big.get("j")))
+  if big.contains("a"):
+    print("a = " + i32_to_string(big.get("a")))
+
+  // Verify all keys survived resize.
+  let all_ok: bool = true
+  if big.contains("a") == false:
+    all_ok = false
+  if big.contains("e") == false:
+    all_ok = false
+  if big.contains("j") == false:
+    all_ok = false
+  if big.contains("missing"):
+    all_ok = false
+  if all_ok:
+    print("all keys correct after resize")
+
+  return 0

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -220,6 +220,9 @@ bool __dao_str_ends_with(const struct dao_string *s,
 int32_t __dao_str_compare(const struct dao_string *a,
                            const struct dao_string *b);
 
+// FNV-1a 64-bit hash of a string's bytes.
+int64_t __dao_str_hash(const struct dao_string *s);
+
 // ---------------------------------------------------------------------------
 // Runtime hook declarations — Memory/resource domain
 // ---------------------------------------------------------------------------

--- a/runtime/core/string.c
+++ b/runtime/core/string.c
@@ -114,6 +114,21 @@ bool __dao_str_ends_with(const struct dao_string *s,
   return memcmp(s->ptr + offset, suffix->ptr, (size_t)suffix->len) == 0;
 }
 
+// FNV-1a 64-bit hash of a string's bytes. Returns a signed i64 whose
+// bit pattern is the unsigned FNV-1a result.
+int64_t __dao_str_hash(const struct dao_string *s) {
+  uint64_t hash = 14695981039346656037ULL;
+  int64_t len = (s != NULL) ? s->len : 0;
+  const char *ptr = (s != NULL) ? s->ptr : NULL;
+  for (int64_t i = 0; i < len; i++) {
+    hash ^= (uint8_t)ptr[i];
+    hash *= 1099511628211ULL;
+  }
+  int64_t result;
+  memcpy(&result, &hash, sizeof result);
+  return result;
+}
+
 // Lexicographic comparison. Returns -1 if a < b, 0 if equal, 1 if a > b.
 int32_t __dao_str_compare(const struct dao_string *a,
                            const struct dao_string *b) {

--- a/stdlib/core/hashmap.dao
+++ b/stdlib/core/hashmap.dao
@@ -1,0 +1,180 @@
+// hashmap.dao — String-keyed hash map.
+//
+// HashMap<V> is an open-addressing hash table with linear probing.
+// Keys are fixed to string; generic key dispatch (HashMap<K, V>)
+// is deferred until concept bounds on class generics are proven.
+//
+// Mutation semantics: set() mutates backing storage in-place and
+// returns a handle with updated metadata. Only resize allocates
+// new backing arrays. The caller must rebind: table = table.set(k, v).
+//
+// Hash function: FNV-1a via __dao_str_hash runtime hook.
+//
+// Known limitation: get() returns V (panics on missing) instead of
+// Option<V> due to a compiler bug where class methods returning
+// generic enum types lose type args during HIR→MIR lowering.
+// Use contains() + get() as a two-phase lookup pattern.
+
+extern fn __dao_str_hash(s: string): i64
+
+fn hash_string(s: string): i64 -> __dao_str_hash(s)
+
+// Compute a non-negative bucket index from a hash and capacity.
+fn hash_index(h: i64, cap: i64): i64
+  let idx: i64 = h % cap
+  if idx < to_i64(0):
+    return idx + cap
+  return idx
+
+class HashMap<V>:
+  key_data: *string
+  val_data: *V
+  state_data: *i32
+  count: i64
+  cap: i64
+
+  fn new(): HashMap<V>
+    return HashMap(
+      null_ptr<string>(), null_ptr<V>(), null_ptr<i32>(),
+      to_i64(0), to_i64(0))
+
+  fn length(self): i64 -> self.count
+
+  // get returns the value for key, or panics if not found.
+  // Use contains() first to check existence.
+  //
+  // Note: returning Option<V> from a class method is blocked by a
+  // compiler bug (generic enum return types lose type args during
+  // HIR→MIR lowering). This will be changed to Option<V> once fixed.
+  fn get(self, key: string): V
+    if self.cap == to_i64(0):
+      panic("HashMap.get: key not found")
+    let idx: i64 = hash_index(hash_string(key), self.cap)
+    mode unsafe =>
+      let probes: i64 = 0
+      while probes < self.cap:
+        let st: i32 = *ptr_offset(self.state_data, idx)
+        if st == 0:
+          panic("HashMap.get: key not found")
+        if st == 1:
+          if *ptr_offset(self.key_data, idx) == key:
+            return *ptr_offset(self.val_data, idx)
+        // st == 2 (tombstone) or different key — continue probing.
+        idx = idx + 1
+        if idx >= self.cap:
+          idx = to_i64(0)
+        probes = probes + 1
+    panic("HashMap.get: key not found")
+
+  fn contains(self, key: string): bool
+    if self.cap == to_i64(0):
+      return false
+    let idx: i64 = hash_index(hash_string(key), self.cap)
+    mode unsafe =>
+      let probes: i64 = 0
+      while probes < self.cap:
+        let st: i32 = *ptr_offset(self.state_data, idx)
+        if st == 0:
+          return false
+        if st == 1:
+          if *ptr_offset(self.key_data, idx) == key:
+            return true
+        idx = idx + 1
+        if idx >= self.cap:
+          idx = to_i64(0)
+        probes = probes + 1
+    return false
+
+  fn set(self, key: string, value: V): HashMap<V>
+    // Resize if empty or load factor > 75%.
+    if self.cap == to_i64(0) or (self.count + 1) * to_i64(4) > self.cap * to_i64(3):
+      let new_cap: i64 = self.cap * 2
+      if new_cap < to_i64(8):
+        new_cap = to_i64(8)
+      let new_key_raw = __dao_mem_alloc(
+        size_of<string>() * new_cap, align_of<string>())
+      let new_val_raw = __dao_mem_alloc(
+        size_of<V>() * new_cap, align_of<V>())
+      let new_state_raw = __dao_mem_alloc(
+        size_of<i32>() * new_cap, align_of<i32>())
+      mode unsafe =>
+        let nk = ptr_cast<string>(new_key_raw)
+        let nv = ptr_cast<V>(new_val_raw)
+        let ns = ptr_cast<i32>(new_state_raw)
+        // Zero-init state slots.
+        let z: i64 = 0
+        while z < new_cap:
+          *ptr_offset(ns, z) = 0
+          z = z + 1
+        // Rehash existing entries into new backing.
+        let j: i64 = 0
+        while j < self.cap:
+          if *ptr_offset(self.state_data, j) == 1:
+            let ek: string = *ptr_offset(self.key_data, j)
+            let ev: V = *ptr_offset(self.val_data, j)
+            let ri: i64 = hash_index(hash_string(ek), new_cap)
+            let placed: bool = false
+            while placed == false:
+              if *ptr_offset(ns, ri) == 0:
+                *ptr_offset(nk, ri) = ek
+                *ptr_offset(nv, ri) = ev
+                *ptr_offset(ns, ri) = 1
+                placed = true
+              else:
+                ri = ri + 1
+                if ri >= new_cap:
+                  ri = to_i64(0)
+          j = j + 1
+        // Insert the new entry into the resized backing.
+        let ni: i64 = hash_index(hash_string(key), new_cap)
+        let done: bool = false
+        while done == false:
+          let st: i32 = *ptr_offset(ns, ni)
+          if st == 0:
+            *ptr_offset(nk, ni) = key
+            *ptr_offset(nv, ni) = value
+            *ptr_offset(ns, ni) = 1
+            done = true
+          else if st == 1:
+            if *ptr_offset(nk, ni) == key:
+              *ptr_offset(nv, ni) = value
+              return HashMap(nk, nv, ns, self.count, new_cap)
+            ni = ni + 1
+            if ni >= new_cap:
+              ni = to_i64(0)
+          else:
+            *ptr_offset(nk, ni) = key
+            *ptr_offset(nv, ni) = value
+            *ptr_offset(ns, ni) = 1
+            done = true
+        return HashMap(nk, nv, ns, self.count + 1, new_cap)
+      panic("unreachable")
+
+    // No resize — insert or update in-place.
+    let idx: i64 = hash_index(hash_string(key), self.cap)
+    mode unsafe =>
+      let done: bool = false
+      while done == false:
+        let st: i32 = *ptr_offset(self.state_data, idx)
+        if st == 0:
+          *ptr_offset(self.key_data, idx) = key
+          *ptr_offset(self.val_data, idx) = value
+          *ptr_offset(self.state_data, idx) = 1
+          done = true
+        else if st == 1:
+          if *ptr_offset(self.key_data, idx) == key:
+            *ptr_offset(self.val_data, idx) = value
+            return HashMap(
+              self.key_data, self.val_data, self.state_data,
+              self.count, self.cap)
+          idx = idx + 1
+          if idx >= self.cap:
+            idx = to_i64(0)
+        else:
+          *ptr_offset(self.key_data, idx) = key
+          *ptr_offset(self.val_data, idx) = value
+          *ptr_offset(self.state_data, idx) = 1
+          done = true
+    return HashMap(
+      self.key_data, self.val_data, self.state_data,
+      self.count + 1, self.cap)

--- a/stdlib/core/hashmap.dao
+++ b/stdlib/core/hashmap.dao
@@ -4,9 +4,9 @@
 // Keys are fixed to string; generic key dispatch (HashMap<K, V>)
 // is deferred until concept bounds on class generics are proven.
 //
-// Mutation semantics: set() mutates backing storage in-place and
-// returns a handle with updated metadata. Only resize allocates
-// new backing arrays. The caller must rebind: table = table.set(k, v).
+// Value semantics: set() allocates a fresh copy of the backing
+// arrays for the returned map, matching Vector<T>'s copy-on-mutation
+// pattern. No aliased HashMap values share mutable storage.
 //
 // Hash function: FNV-1a via __dao_str_hash runtime hook.
 //
@@ -86,95 +86,68 @@ class HashMap<V>:
     return false
 
   fn set(self, key: string, value: V): HashMap<V>
-    // Resize if empty or load factor > 75%.
+    // Determine capacity for the new backing arrays.
+    let new_cap: i64 = self.cap
     if self.cap == to_i64(0) or (self.count + 1) * to_i64(4) > self.cap * to_i64(3):
-      let new_cap: i64 = self.cap * 2
+      new_cap = self.cap * 2
       if new_cap < to_i64(8):
         new_cap = to_i64(8)
-      let new_key_raw = __dao_mem_alloc(
-        size_of<string>() * new_cap, align_of<string>())
-      let new_val_raw = __dao_mem_alloc(
-        size_of<V>() * new_cap, align_of<V>())
-      let new_state_raw = __dao_mem_alloc(
-        size_of<i32>() * new_cap, align_of<i32>())
-      mode unsafe =>
-        let nk = ptr_cast<string>(new_key_raw)
-        let nv = ptr_cast<V>(new_val_raw)
-        let ns = ptr_cast<i32>(new_state_raw)
-        // Zero-init state slots.
-        let z: i64 = 0
-        while z < new_cap:
-          *ptr_offset(ns, z) = 0
-          z = z + 1
-        // Rehash existing entries into new backing.
-        let j: i64 = 0
-        while j < self.cap:
-          if *ptr_offset(self.state_data, j) == 1:
-            let ek: string = *ptr_offset(self.key_data, j)
-            let ev: V = *ptr_offset(self.val_data, j)
-            let ri: i64 = hash_index(hash_string(ek), new_cap)
-            let placed: bool = false
-            while placed == false:
-              if *ptr_offset(ns, ri) == 0:
-                *ptr_offset(nk, ri) = ek
-                *ptr_offset(nv, ri) = ev
-                *ptr_offset(ns, ri) = 1
-                placed = true
-              else:
-                ri = ri + 1
-                if ri >= new_cap:
-                  ri = to_i64(0)
-          j = j + 1
-        // Insert the new entry into the resized backing.
-        let ni: i64 = hash_index(hash_string(key), new_cap)
-        let done: bool = false
-        while done == false:
-          let st: i32 = *ptr_offset(ns, ni)
-          if st == 0:
-            *ptr_offset(nk, ni) = key
-            *ptr_offset(nv, ni) = value
-            *ptr_offset(ns, ni) = 1
-            done = true
-          else if st == 1:
-            if *ptr_offset(nk, ni) == key:
-              *ptr_offset(nv, ni) = value
-              return HashMap(nk, nv, ns, self.count, new_cap)
-            ni = ni + 1
-            if ni >= new_cap:
-              ni = to_i64(0)
-          else:
-            *ptr_offset(nk, ni) = key
-            *ptr_offset(nv, ni) = value
-            *ptr_offset(ns, ni) = 1
-            done = true
-        return HashMap(nk, nv, ns, self.count + 1, new_cap)
-      panic("unreachable")
-
-    // No resize — insert or update in-place.
-    let idx: i64 = hash_index(hash_string(key), self.cap)
+    // Always allocate fresh backing arrays (value semantics).
+    let new_key_raw = __dao_mem_alloc(
+      size_of<string>() * new_cap, align_of<string>())
+    let new_val_raw = __dao_mem_alloc(
+      size_of<V>() * new_cap, align_of<V>())
+    let new_state_raw = __dao_mem_alloc(
+      size_of<i32>() * new_cap, align_of<i32>())
     mode unsafe =>
+      let nk = ptr_cast<string>(new_key_raw)
+      let nv = ptr_cast<V>(new_val_raw)
+      let ns = ptr_cast<i32>(new_state_raw)
+      // Zero-init state slots.
+      let z: i64 = 0
+      while z < new_cap:
+        *ptr_offset(ns, z) = 0
+        z = z + 1
+      // Rehash existing entries into fresh backing.
+      let j: i64 = 0
+      while j < self.cap:
+        if *ptr_offset(self.state_data, j) == 1:
+          let ek: string = *ptr_offset(self.key_data, j)
+          let ev: V = *ptr_offset(self.val_data, j)
+          let ri: i64 = hash_index(hash_string(ek), new_cap)
+          let placed: bool = false
+          while placed == false:
+            if *ptr_offset(ns, ri) == 0:
+              *ptr_offset(nk, ri) = ek
+              *ptr_offset(nv, ri) = ev
+              *ptr_offset(ns, ri) = 1
+              placed = true
+            else:
+              ri = ri + 1
+              if ri >= new_cap:
+                ri = to_i64(0)
+        j = j + 1
+      // Insert the new entry.
+      let ni: i64 = hash_index(hash_string(key), new_cap)
       let done: bool = false
       while done == false:
-        let st: i32 = *ptr_offset(self.state_data, idx)
+        let st: i32 = *ptr_offset(ns, ni)
         if st == 0:
-          *ptr_offset(self.key_data, idx) = key
-          *ptr_offset(self.val_data, idx) = value
-          *ptr_offset(self.state_data, idx) = 1
+          *ptr_offset(nk, ni) = key
+          *ptr_offset(nv, ni) = value
+          *ptr_offset(ns, ni) = 1
           done = true
         else if st == 1:
-          if *ptr_offset(self.key_data, idx) == key:
-            *ptr_offset(self.val_data, idx) = value
-            return HashMap(
-              self.key_data, self.val_data, self.state_data,
-              self.count, self.cap)
-          idx = idx + 1
-          if idx >= self.cap:
-            idx = to_i64(0)
+          if *ptr_offset(nk, ni) == key:
+            *ptr_offset(nv, ni) = value
+            return HashMap(nk, nv, ns, self.count, new_cap)
+          ni = ni + 1
+          if ni >= new_cap:
+            ni = to_i64(0)
         else:
-          *ptr_offset(self.key_data, idx) = key
-          *ptr_offset(self.val_data, idx) = value
-          *ptr_offset(self.state_data, idx) = 1
+          *ptr_offset(nk, ni) = key
+          *ptr_offset(nv, ni) = value
+          *ptr_offset(ns, ni) = 1
           done = true
-    return HashMap(
-      self.key_data, self.val_data, self.state_data,
-      self.count + 1, self.cap)
+      return HashMap(nk, nv, ns, self.count + 1, new_cap)
+    panic("unreachable")

--- a/testdata/ast/examples_bootstrap_probe_type_checker.ast
+++ b/testdata/ast/examples_bootstrap_probe_type_checker.ast
@@ -2322,57 +2322,6 @@ File
   ClassDecl Symbol
     Field name: string
     Field ty: i32
-  FunctionDecl find_symbol
-    Param table: Vector<Symbol>
-    Param name: string
-    ReturnType: Option<i64>
-    LetStatement i: i64
-      BinaryExpr -
-        CallExpr
-          Callee
-            FieldExpr .length
-              Identifier table
-        IntLiteral 1
-    WhileStatement
-      Condition
-        BinaryExpr >=
-          Identifier i
-          CallExpr
-            Callee
-              Identifier to_i64
-            Args
-              IntLiteral 0
-      LetStatement sym: Symbol
-        CallExpr
-          Callee
-            FieldExpr .get
-              Identifier table
-          Args
-            Identifier i
-      IfStatement
-        Condition
-          BinaryExpr ==
-            FieldExpr .name
-              Identifier sym
-            Identifier name
-        Then
-          ReturnStatement
-            CallExpr
-              Callee
-                FieldExpr .Some
-                  Identifier Option
-              Args
-                Identifier i
-      Assignment
-        Target
-          Identifier i
-        Value
-          BinaryExpr -
-            Identifier i
-            IntLiteral 1
-    ReturnStatement
-      FieldExpr .None
-        Identifier Option
   FunctionDecl check_binary_op
     Param op: TK
     Param left_ty: i32
@@ -2571,7 +2520,7 @@ File
   FunctionDecl check_expr
     Param arena: Vector<Node>
     Param idx: i64
-    Param table: Vector<Symbol>
+    Param table: HashMap<Symbol>
     Param source: string
     ReturnType: Result<i32, string>
     LetStatement node: Node
@@ -2622,27 +2571,22 @@ File
               Identifier source
               Identifier off
               Identifier len
-        LetStatement found: Option<i64>
-          CallExpr
-            Callee
-              Identifier find_symbol
-            Args
-              Identifier table
-              Identifier name
-        MatchStatement
-          Scrutinee
-            Identifier found
-          Arm
-            Pattern
-              FieldExpr .Some
-                Identifier Option
+        IfStatement
+          Condition
+            CallExpr
+              Callee
+                FieldExpr .contains
+                  Identifier table
+              Args
+                Identifier name
+          Then
             LetStatement sym: Symbol
               CallExpr
                 Callee
                   FieldExpr .get
                     Identifier table
                 Args
-                  Identifier sym_idx
+                  Identifier name
             ReturnStatement
               CallExpr
                 Callee
@@ -2651,21 +2595,17 @@ File
                 Args
                   FieldExpr .ty
                     Identifier sym
-          Arm
-            Pattern
-              FieldExpr .None
-                Identifier Option
-            ReturnStatement
-              CallExpr
-                Callee
-                  FieldExpr .Err
-                    Identifier Result
-                Args
-                  BinaryExpr +
-                    BinaryExpr +
-                      StringLiteral "undefined variable '"
-                      Identifier name
-                    StringLiteral "'"
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Err
+                Identifier Result
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "undefined variable '"
+                  Identifier name
+                StringLiteral "'"
       Arm
         Pattern
           FieldExpr .Binary
@@ -2859,7 +2799,7 @@ File
     LetStatement table
       CallExpr
         Callee
-          Identifier Vector.new
+          Identifier HashMap.new
         TypeArgs
           Symbol
     LetStatement last_ty: i32
@@ -2918,9 +2858,10 @@ File
                 Value
                   CallExpr
                     Callee
-                      FieldExpr .push
+                      FieldExpr .set
                         Identifier table
                     Args
+                      Identifier name
                       CallExpr
                         Callee
                           Identifier Symbol

--- a/testdata/ast/examples_hashmap.ast
+++ b/testdata/ast/examples_hashmap.ast
@@ -1,0 +1,465 @@
+File
+  ClassDecl Entry
+    Field name: string
+    Field value: i32
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== HashMap<V> ==="
+    LetStatement m
+      CallExpr
+        Callee
+          Identifier HashMap.new
+        TypeArgs
+          Entry
+    Assignment
+      Target
+        Identifier m
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier m
+          Args
+            StringLiteral "x"
+            CallExpr
+              Callee
+                Identifier Entry
+              Args
+                StringLiteral "x"
+                IntLiteral 10
+    Assignment
+      Target
+        Identifier m
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier m
+          Args
+            StringLiteral "y"
+            CallExpr
+              Callee
+                Identifier Entry
+              Args
+                StringLiteral "y"
+                IntLiteral 20
+    Assignment
+      Target
+        Identifier m
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier m
+          Args
+            StringLiteral "z"
+            CallExpr
+              Callee
+                Identifier Entry
+              Args
+                StringLiteral "z"
+                IntLiteral 30
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "length: "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    FieldExpr .length
+                      Identifier m
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier m
+          Args
+            StringLiteral "x"
+      Then
+        LetStatement e: Entry
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier m
+            Args
+              StringLiteral "x"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "x = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    FieldExpr .value
+                      Identifier e
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier m
+          Args
+            StringLiteral "y"
+      Then
+        LetStatement e: Entry
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier m
+            Args
+              StringLiteral "y"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "y = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    FieldExpr .value
+                      Identifier e
+    Assignment
+      Target
+        Identifier m
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier m
+          Args
+            StringLiteral "x"
+            CallExpr
+              Callee
+                Identifier Entry
+              Args
+                StringLiteral "x"
+                IntLiteral 99
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier m
+          Args
+            StringLiteral "x"
+      Then
+        LetStatement e: Entry
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier m
+            Args
+              StringLiteral "x"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "x (updated) = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    FieldExpr .value
+                      Identifier e
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier m
+          Args
+            StringLiteral "w"
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "w found (unexpected)"
+      Else
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "w not found (correct)"
+    LetStatement big
+      CallExpr
+        Callee
+          Identifier HashMap.new
+        TypeArgs
+          i32
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "a"
+            IntLiteral 1
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "b"
+            IntLiteral 2
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "c"
+            IntLiteral 3
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "d"
+            IntLiteral 4
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "e"
+            IntLiteral 5
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "f"
+            IntLiteral 6
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "g"
+            IntLiteral 7
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "h"
+            IntLiteral 8
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "i"
+            IntLiteral 9
+    Assignment
+      Target
+        Identifier big
+      Value
+        CallExpr
+          Callee
+            FieldExpr .set
+              Identifier big
+          Args
+            StringLiteral "j"
+            IntLiteral 10
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "big length: "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    FieldExpr .length
+                      Identifier big
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier big
+          Args
+            StringLiteral "j"
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "j = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    CallExpr
+                      Callee
+                        FieldExpr .get
+                          Identifier big
+                      Args
+                        StringLiteral "j"
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier big
+          Args
+            StringLiteral "a"
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "a = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    CallExpr
+                      Callee
+                        FieldExpr .get
+                          Identifier big
+                      Args
+                        StringLiteral "a"
+    LetStatement all_ok: bool
+      BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              FieldExpr .contains
+                Identifier big
+            Args
+              StringLiteral "a"
+          BoolLiteral false
+      Then
+        Assignment
+          Target
+            Identifier all_ok
+          Value
+            BoolLiteral false
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              FieldExpr .contains
+                Identifier big
+            Args
+              StringLiteral "e"
+          BoolLiteral false
+      Then
+        Assignment
+          Target
+            Identifier all_ok
+          Value
+            BoolLiteral false
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              FieldExpr .contains
+                Identifier big
+            Args
+              StringLiteral "j"
+          BoolLiteral false
+      Then
+        Assignment
+          Target
+            Identifier all_ok
+          Value
+            BoolLiteral false
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            FieldExpr .contains
+              Identifier big
+          Args
+            StringLiteral "missing"
+      Then
+        Assignment
+          Target
+            Identifier all_ok
+          Value
+            BoolLiteral false
+    IfStatement
+      Condition
+        Identifier all_ok
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "all keys correct after resize"
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/stdlib_core_hashmap.ast
+++ b/testdata/ast/stdlib_core_hashmap.ast
@@ -319,6 +319,9 @@ File
       Param key: string
       Param value: V
       ReturnType: HashMap<V>
+      LetStatement new_cap: i64
+        FieldExpr .cap
+          Identifier self
       IfStatement
         Condition
           BinaryExpr or
@@ -350,11 +353,14 @@ File
                   Args
                     IntLiteral 3
         Then
-          LetStatement new_cap: i64
-            BinaryExpr *
-              FieldExpr .cap
-                Identifier self
-              IntLiteral 2
+          Assignment
+            Target
+              Identifier new_cap
+            Value
+              BinaryExpr *
+                FieldExpr .cap
+                  Identifier self
+                IntLiteral 2
           IfStatement
             Condition
               BinaryExpr <
@@ -374,89 +380,298 @@ File
                       Identifier to_i64
                     Args
                       IntLiteral 8
-          LetStatement new_key_raw
-            CallExpr
-              Callee
-                Identifier __dao_mem_alloc
-              Args
-                BinaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier size_of
-                    TypeArgs
-                      string
-                  Identifier new_cap
-                CallExpr
-                  Callee
-                    Identifier align_of
-                  TypeArgs
-                    string
-          LetStatement new_val_raw
-            CallExpr
-              Callee
-                Identifier __dao_mem_alloc
-              Args
-                BinaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier size_of
-                    TypeArgs
-                      V
-                  Identifier new_cap
-                CallExpr
-                  Callee
-                    Identifier align_of
-                  TypeArgs
-                    V
-          LetStatement new_state_raw
-            CallExpr
-              Callee
-                Identifier __dao_mem_alloc
-              Args
-                BinaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier size_of
-                    TypeArgs
-                      i32
-                  Identifier new_cap
-                CallExpr
-                  Callee
-                    Identifier align_of
-                  TypeArgs
-                    i32
-          ModeBlock unsafe
-            LetStatement nk
+      LetStatement new_key_raw
+        CallExpr
+          Callee
+            Identifier __dao_mem_alloc
+          Args
+            BinaryExpr *
               CallExpr
                 Callee
-                  Identifier ptr_cast
+                  Identifier size_of
                 TypeArgs
                   string
-                Args
-                  Identifier new_key_raw
-            LetStatement nv
+              Identifier new_cap
+            CallExpr
+              Callee
+                Identifier align_of
+              TypeArgs
+                string
+      LetStatement new_val_raw
+        CallExpr
+          Callee
+            Identifier __dao_mem_alloc
+          Args
+            BinaryExpr *
               CallExpr
                 Callee
-                  Identifier ptr_cast
+                  Identifier size_of
                 TypeArgs
                   V
-                Args
-                  Identifier new_val_raw
-            LetStatement ns
+              Identifier new_cap
+            CallExpr
+              Callee
+                Identifier align_of
+              TypeArgs
+                V
+      LetStatement new_state_raw
+        CallExpr
+          Callee
+            Identifier __dao_mem_alloc
+          Args
+            BinaryExpr *
               CallExpr
                 Callee
-                  Identifier ptr_cast
+                  Identifier size_of
                 TypeArgs
                   i32
-                Args
-                  Identifier new_state_raw
-            LetStatement z: i64
+              Identifier new_cap
+            CallExpr
+              Callee
+                Identifier align_of
+              TypeArgs
+                i32
+      ModeBlock unsafe
+        LetStatement nk
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              string
+            Args
+              Identifier new_key_raw
+        LetStatement nv
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              V
+            Args
+              Identifier new_val_raw
+        LetStatement ns
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              i32
+            Args
+              Identifier new_state_raw
+        LetStatement z: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier z
+              Identifier new_cap
+          Assignment
+            Target
+              UnaryExpr *
+                CallExpr
+                  Callee
+                    Identifier ptr_offset
+                  Args
+                    Identifier ns
+                    Identifier z
+            Value
               IntLiteral 0
-            WhileStatement
-              Condition
-                BinaryExpr <
-                  Identifier z
-                  Identifier new_cap
+          Assignment
+            Target
+              Identifier z
+            Value
+              BinaryExpr +
+                Identifier z
+                IntLiteral 1
+        LetStatement j: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier j
+              FieldExpr .cap
+                Identifier self
+          IfStatement
+            Condition
+              BinaryExpr ==
+                UnaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier ptr_offset
+                    Args
+                      FieldExpr .state_data
+                        Identifier self
+                      Identifier j
+                IntLiteral 1
+            Then
+              LetStatement ek: string
+                UnaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier ptr_offset
+                    Args
+                      FieldExpr .key_data
+                        Identifier self
+                      Identifier j
+              LetStatement ev: V
+                UnaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier ptr_offset
+                    Args
+                      FieldExpr .val_data
+                        Identifier self
+                      Identifier j
+              LetStatement ri: i64
+                CallExpr
+                  Callee
+                    Identifier hash_index
+                  Args
+                    CallExpr
+                      Callee
+                        Identifier hash_string
+                      Args
+                        Identifier ek
+                    Identifier new_cap
+              LetStatement placed: bool
+                BoolLiteral false
+              WhileStatement
+                Condition
+                  BinaryExpr ==
+                    Identifier placed
+                    BoolLiteral false
+                IfStatement
+                  Condition
+                    BinaryExpr ==
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            Identifier ns
+                            Identifier ri
+                      IntLiteral 0
+                  Then
+                    Assignment
+                      Target
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              Identifier nk
+                              Identifier ri
+                      Value
+                        Identifier ek
+                    Assignment
+                      Target
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              Identifier nv
+                              Identifier ri
+                      Value
+                        Identifier ev
+                    Assignment
+                      Target
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              Identifier ns
+                              Identifier ri
+                      Value
+                        IntLiteral 1
+                    Assignment
+                      Target
+                        Identifier placed
+                      Value
+                        BoolLiteral true
+                  Else
+                    Assignment
+                      Target
+                        Identifier ri
+                      Value
+                        BinaryExpr +
+                          Identifier ri
+                          IntLiteral 1
+                    IfStatement
+                      Condition
+                        BinaryExpr >=
+                          Identifier ri
+                          Identifier new_cap
+                      Then
+                        Assignment
+                          Target
+                            Identifier ri
+                          Value
+                            CallExpr
+                              Callee
+                                Identifier to_i64
+                              Args
+                                IntLiteral 0
+          Assignment
+            Target
+              Identifier j
+            Value
+              BinaryExpr +
+                Identifier j
+                IntLiteral 1
+        LetStatement ni: i64
+          CallExpr
+            Callee
+              Identifier hash_index
+            Args
+              CallExpr
+                Callee
+                  Identifier hash_string
+                Args
+                  Identifier key
+              Identifier new_cap
+        LetStatement done: bool
+          BoolLiteral false
+        WhileStatement
+          Condition
+            BinaryExpr ==
+              Identifier done
+              BoolLiteral false
+          LetStatement st: i32
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  Identifier ns
+                  Identifier ni
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 0
+            Then
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        Identifier nk
+                        Identifier ni
+                Value
+                  Identifier key
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        Identifier nv
+                        Identifier ni
+                Value
+                  Identifier value
               Assignment
                 Target
                   UnaryExpr *
@@ -465,185 +680,78 @@ File
                         Identifier ptr_offset
                       Args
                         Identifier ns
-                        Identifier z
+                        Identifier ni
                 Value
-                  IntLiteral 0
+                  IntLiteral 1
               Assignment
                 Target
-                  Identifier z
+                  Identifier done
                 Value
-                  BinaryExpr +
-                    Identifier z
-                    IntLiteral 1
-            LetStatement j: i64
-              IntLiteral 0
-            WhileStatement
-              Condition
-                BinaryExpr <
-                  Identifier j
-                  FieldExpr .cap
-                    Identifier self
+                  BoolLiteral true
+            Else
               IfStatement
                 Condition
                   BinaryExpr ==
-                    UnaryExpr *
-                      CallExpr
-                        Callee
-                          Identifier ptr_offset
-                        Args
-                          FieldExpr .state_data
-                            Identifier self
-                          Identifier j
+                    Identifier st
                     IntLiteral 1
                 Then
-                  LetStatement ek: string
-                    UnaryExpr *
-                      CallExpr
-                        Callee
-                          Identifier ptr_offset
-                        Args
-                          FieldExpr .key_data
-                            Identifier self
-                          Identifier j
-                  LetStatement ev: V
-                    UnaryExpr *
-                      CallExpr
-                        Callee
-                          Identifier ptr_offset
-                        Args
-                          FieldExpr .val_data
-                            Identifier self
-                          Identifier j
-                  LetStatement ri: i64
-                    CallExpr
-                      Callee
-                        Identifier hash_index
-                      Args
-                        CallExpr
-                          Callee
-                            Identifier hash_string
-                          Args
-                            Identifier ek
-                        Identifier new_cap
-                  LetStatement placed: bool
-                    BoolLiteral false
-                  WhileStatement
+                  IfStatement
                     Condition
                       BinaryExpr ==
-                        Identifier placed
-                        BoolLiteral false
-                    IfStatement
-                      Condition
-                        BinaryExpr ==
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              Identifier nk
+                              Identifier ni
+                        Identifier key
+                    Then
+                      Assignment
+                        Target
                           UnaryExpr *
                             CallExpr
                               Callee
                                 Identifier ptr_offset
                               Args
-                                Identifier ns
-                                Identifier ri
-                          IntLiteral 0
-                      Then
-                        Assignment
-                          Target
-                            UnaryExpr *
-                              CallExpr
-                                Callee
-                                  Identifier ptr_offset
-                                Args
-                                  Identifier nk
-                                  Identifier ri
-                          Value
-                            Identifier ek
-                        Assignment
-                          Target
-                            UnaryExpr *
-                              CallExpr
-                                Callee
-                                  Identifier ptr_offset
-                                Args
-                                  Identifier nv
-                                  Identifier ri
-                          Value
-                            Identifier ev
-                        Assignment
-                          Target
-                            UnaryExpr *
-                              CallExpr
-                                Callee
-                                  Identifier ptr_offset
-                                Args
-                                  Identifier ns
-                                  Identifier ri
-                          Value
-                            IntLiteral 1
-                        Assignment
-                          Target
-                            Identifier placed
-                          Value
-                            BoolLiteral true
-                      Else
-                        Assignment
-                          Target
-                            Identifier ri
-                          Value
-                            BinaryExpr +
-                              Identifier ri
-                              IntLiteral 1
-                        IfStatement
-                          Condition
-                            BinaryExpr >=
-                              Identifier ri
-                              Identifier new_cap
-                          Then
-                            Assignment
-                              Target
-                                Identifier ri
-                              Value
-                                CallExpr
-                                  Callee
-                                    Identifier to_i64
-                                  Args
-                                    IntLiteral 0
-              Assignment
-                Target
-                  Identifier j
-                Value
-                  BinaryExpr +
-                    Identifier j
-                    IntLiteral 1
-            LetStatement ni: i64
-              CallExpr
-                Callee
-                  Identifier hash_index
-                Args
-                  CallExpr
-                    Callee
-                      Identifier hash_string
-                    Args
-                      Identifier key
-                  Identifier new_cap
-            LetStatement done: bool
-              BoolLiteral false
-            WhileStatement
-              Condition
-                BinaryExpr ==
-                  Identifier done
-                  BoolLiteral false
-              LetStatement st: i32
-                UnaryExpr *
-                  CallExpr
-                    Callee
-                      Identifier ptr_offset
-                    Args
-                      Identifier ns
+                                Identifier nv
+                                Identifier ni
+                        Value
+                          Identifier value
+                      ReturnStatement
+                        CallExpr
+                          Callee
+                            Identifier HashMap
+                          Args
+                            Identifier nk
+                            Identifier nv
+                            Identifier ns
+                            FieldExpr .count
+                              Identifier self
+                            Identifier new_cap
+                  Assignment
+                    Target
                       Identifier ni
-              IfStatement
-                Condition
-                  BinaryExpr ==
-                    Identifier st
-                    IntLiteral 0
-                Then
+                    Value
+                      BinaryExpr +
+                        Identifier ni
+                        IntLiteral 1
+                  IfStatement
+                    Condition
+                      BinaryExpr >=
+                        Identifier ni
+                        Identifier new_cap
+                    Then
+                      Assignment
+                        Target
+                          Identifier ni
+                        Value
+                          CallExpr
+                            Callee
+                              Identifier to_i64
+                            Args
+                              IntLiteral 0
+                Else
                   Assignment
                     Target
                       UnaryExpr *
@@ -682,329 +790,22 @@ File
                       Identifier done
                     Value
                       BoolLiteral true
-                Else
-                  IfStatement
-                    Condition
-                      BinaryExpr ==
-                        Identifier st
-                        IntLiteral 1
-                    Then
-                      IfStatement
-                        Condition
-                          BinaryExpr ==
-                            UnaryExpr *
-                              CallExpr
-                                Callee
-                                  Identifier ptr_offset
-                                Args
-                                  Identifier nk
-                                  Identifier ni
-                            Identifier key
-                        Then
-                          Assignment
-                            Target
-                              UnaryExpr *
-                                CallExpr
-                                  Callee
-                                    Identifier ptr_offset
-                                  Args
-                                    Identifier nv
-                                    Identifier ni
-                            Value
-                              Identifier value
-                          ReturnStatement
-                            CallExpr
-                              Callee
-                                Identifier HashMap
-                              Args
-                                Identifier nk
-                                Identifier nv
-                                Identifier ns
-                                FieldExpr .count
-                                  Identifier self
-                                Identifier new_cap
-                      Assignment
-                        Target
-                          Identifier ni
-                        Value
-                          BinaryExpr +
-                            Identifier ni
-                            IntLiteral 1
-                      IfStatement
-                        Condition
-                          BinaryExpr >=
-                            Identifier ni
-                            Identifier new_cap
-                        Then
-                          Assignment
-                            Target
-                              Identifier ni
-                            Value
-                              CallExpr
-                                Callee
-                                  Identifier to_i64
-                                Args
-                                  IntLiteral 0
-                    Else
-                      Assignment
-                        Target
-                          UnaryExpr *
-                            CallExpr
-                              Callee
-                                Identifier ptr_offset
-                              Args
-                                Identifier nk
-                                Identifier ni
-                        Value
-                          Identifier key
-                      Assignment
-                        Target
-                          UnaryExpr *
-                            CallExpr
-                              Callee
-                                Identifier ptr_offset
-                              Args
-                                Identifier nv
-                                Identifier ni
-                        Value
-                          Identifier value
-                      Assignment
-                        Target
-                          UnaryExpr *
-                            CallExpr
-                              Callee
-                                Identifier ptr_offset
-                              Args
-                                Identifier ns
-                                Identifier ni
-                        Value
-                          IntLiteral 1
-                      Assignment
-                        Target
-                          Identifier done
-                        Value
-                          BoolLiteral true
-            ReturnStatement
-              CallExpr
-                Callee
-                  Identifier HashMap
-                Args
-                  Identifier nk
-                  Identifier nv
-                  Identifier ns
-                  BinaryExpr +
-                    FieldExpr .count
-                      Identifier self
-                    IntLiteral 1
-                  Identifier new_cap
-          ExpressionStatement
-            CallExpr
-              Callee
-                Identifier panic
-              Args
-                StringLiteral "unreachable"
-      LetStatement idx: i64
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier HashMap
+            Args
+              Identifier nk
+              Identifier nv
+              Identifier ns
+              BinaryExpr +
+                FieldExpr .count
+                  Identifier self
+                IntLiteral 1
+              Identifier new_cap
+      ExpressionStatement
         CallExpr
           Callee
-            Identifier hash_index
+            Identifier panic
           Args
-            CallExpr
-              Callee
-                Identifier hash_string
-              Args
-                Identifier key
-            FieldExpr .cap
-              Identifier self
-      ModeBlock unsafe
-        LetStatement done: bool
-          BoolLiteral false
-        WhileStatement
-          Condition
-            BinaryExpr ==
-              Identifier done
-              BoolLiteral false
-          LetStatement st: i32
-            UnaryExpr *
-              CallExpr
-                Callee
-                  Identifier ptr_offset
-                Args
-                  FieldExpr .state_data
-                    Identifier self
-                  Identifier idx
-          IfStatement
-            Condition
-              BinaryExpr ==
-                Identifier st
-                IntLiteral 0
-            Then
-              Assignment
-                Target
-                  UnaryExpr *
-                    CallExpr
-                      Callee
-                        Identifier ptr_offset
-                      Args
-                        FieldExpr .key_data
-                          Identifier self
-                        Identifier idx
-                Value
-                  Identifier key
-              Assignment
-                Target
-                  UnaryExpr *
-                    CallExpr
-                      Callee
-                        Identifier ptr_offset
-                      Args
-                        FieldExpr .val_data
-                          Identifier self
-                        Identifier idx
-                Value
-                  Identifier value
-              Assignment
-                Target
-                  UnaryExpr *
-                    CallExpr
-                      Callee
-                        Identifier ptr_offset
-                      Args
-                        FieldExpr .state_data
-                          Identifier self
-                        Identifier idx
-                Value
-                  IntLiteral 1
-              Assignment
-                Target
-                  Identifier done
-                Value
-                  BoolLiteral true
-            Else
-              IfStatement
-                Condition
-                  BinaryExpr ==
-                    Identifier st
-                    IntLiteral 1
-                Then
-                  IfStatement
-                    Condition
-                      BinaryExpr ==
-                        UnaryExpr *
-                          CallExpr
-                            Callee
-                              Identifier ptr_offset
-                            Args
-                              FieldExpr .key_data
-                                Identifier self
-                              Identifier idx
-                        Identifier key
-                    Then
-                      Assignment
-                        Target
-                          UnaryExpr *
-                            CallExpr
-                              Callee
-                                Identifier ptr_offset
-                              Args
-                                FieldExpr .val_data
-                                  Identifier self
-                                Identifier idx
-                        Value
-                          Identifier value
-                      ReturnStatement
-                        CallExpr
-                          Callee
-                            Identifier HashMap
-                          Args
-                            FieldExpr .key_data
-                              Identifier self
-                            FieldExpr .val_data
-                              Identifier self
-                            FieldExpr .state_data
-                              Identifier self
-                            FieldExpr .count
-                              Identifier self
-                            FieldExpr .cap
-                              Identifier self
-                  Assignment
-                    Target
-                      Identifier idx
-                    Value
-                      BinaryExpr +
-                        Identifier idx
-                        IntLiteral 1
-                  IfStatement
-                    Condition
-                      BinaryExpr >=
-                        Identifier idx
-                        FieldExpr .cap
-                          Identifier self
-                    Then
-                      Assignment
-                        Target
-                          Identifier idx
-                        Value
-                          CallExpr
-                            Callee
-                              Identifier to_i64
-                            Args
-                              IntLiteral 0
-                Else
-                  Assignment
-                    Target
-                      UnaryExpr *
-                        CallExpr
-                          Callee
-                            Identifier ptr_offset
-                          Args
-                            FieldExpr .key_data
-                              Identifier self
-                            Identifier idx
-                    Value
-                      Identifier key
-                  Assignment
-                    Target
-                      UnaryExpr *
-                        CallExpr
-                          Callee
-                            Identifier ptr_offset
-                          Args
-                            FieldExpr .val_data
-                              Identifier self
-                            Identifier idx
-                    Value
-                      Identifier value
-                  Assignment
-                    Target
-                      UnaryExpr *
-                        CallExpr
-                          Callee
-                            Identifier ptr_offset
-                          Args
-                            FieldExpr .state_data
-                              Identifier self
-                            Identifier idx
-                    Value
-                      IntLiteral 1
-                  Assignment
-                    Target
-                      Identifier done
-                    Value
-                      BoolLiteral true
-      ReturnStatement
-        CallExpr
-          Callee
-            Identifier HashMap
-          Args
-            FieldExpr .key_data
-              Identifier self
-            FieldExpr .val_data
-              Identifier self
-            FieldExpr .state_data
-              Identifier self
-            BinaryExpr +
-              FieldExpr .count
-                Identifier self
-              IntLiteral 1
-            FieldExpr .cap
-              Identifier self
+            StringLiteral "unreachable"

--- a/testdata/ast/stdlib_core_hashmap.ast
+++ b/testdata/ast/stdlib_core_hashmap.ast
@@ -1,0 +1,1010 @@
+File
+  ExternFunctionDecl __dao_str_hash
+    Param s: string
+    ReturnType: i64
+  FunctionDecl hash_string
+    Param s: string
+    ReturnType: i64
+    ExprBody
+      CallExpr
+        Callee
+          Identifier __dao_str_hash
+        Args
+          Identifier s
+  FunctionDecl hash_index
+    Param h: i64
+    Param cap: i64
+    ReturnType: i64
+    LetStatement idx: i64
+      BinaryExpr %
+        Identifier h
+        Identifier cap
+    IfStatement
+      Condition
+        BinaryExpr <
+          Identifier idx
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        ReturnStatement
+          BinaryExpr +
+            Identifier idx
+            Identifier cap
+    ReturnStatement
+      Identifier idx
+  ClassDecl HashMap<V>
+    Field key_data: *string
+    Field val_data: *V
+    Field state_data: *i32
+    Field count: i64
+    Field cap: i64
+    FunctionDecl new
+      ReturnType: HashMap<V>
+      ReturnStatement
+        CallExpr
+          Callee
+            Identifier HashMap
+          Args
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                string
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                V
+            CallExpr
+              Callee
+                Identifier null_ptr
+              TypeArgs
+                i32
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+    FunctionDecl length
+      Param self
+      ReturnType: i64
+      ExprBody
+        FieldExpr .count
+          Identifier self
+    FunctionDecl get
+      Param self
+      Param key: string
+      ReturnType: V
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .cap
+              Identifier self
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+        Then
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "HashMap.get: key not found"
+      LetStatement idx: i64
+        CallExpr
+          Callee
+            Identifier hash_index
+          Args
+            CallExpr
+              Callee
+                Identifier hash_string
+              Args
+                Identifier key
+            FieldExpr .cap
+              Identifier self
+      ModeBlock unsafe
+        LetStatement probes: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier probes
+              FieldExpr .cap
+                Identifier self
+          LetStatement st: i32
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .state_data
+                    Identifier self
+                  Identifier idx
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 0
+            Then
+              ExpressionStatement
+                CallExpr
+                  Callee
+                    Identifier panic
+                  Args
+                    StringLiteral "HashMap.get: key not found"
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 1
+            Then
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .key_data
+                            Identifier self
+                          Identifier idx
+                    Identifier key
+                Then
+                  ReturnStatement
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .val_data
+                            Identifier self
+                          Identifier idx
+          Assignment
+            Target
+              Identifier idx
+            Value
+              BinaryExpr +
+                Identifier idx
+                IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr >=
+                Identifier idx
+                FieldExpr .cap
+                  Identifier self
+            Then
+              Assignment
+                Target
+                  Identifier idx
+                Value
+                  CallExpr
+                    Callee
+                      Identifier to_i64
+                    Args
+                      IntLiteral 0
+          Assignment
+            Target
+              Identifier probes
+            Value
+              BinaryExpr +
+                Identifier probes
+                IntLiteral 1
+      ExpressionStatement
+        CallExpr
+          Callee
+            Identifier panic
+          Args
+            StringLiteral "HashMap.get: key not found"
+    FunctionDecl contains
+      Param self
+      Param key: string
+      ReturnType: bool
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .cap
+              Identifier self
+            CallExpr
+              Callee
+                Identifier to_i64
+              Args
+                IntLiteral 0
+        Then
+          ReturnStatement
+            BoolLiteral false
+      LetStatement idx: i64
+        CallExpr
+          Callee
+            Identifier hash_index
+          Args
+            CallExpr
+              Callee
+                Identifier hash_string
+              Args
+                Identifier key
+            FieldExpr .cap
+              Identifier self
+      ModeBlock unsafe
+        LetStatement probes: i64
+          IntLiteral 0
+        WhileStatement
+          Condition
+            BinaryExpr <
+              Identifier probes
+              FieldExpr .cap
+                Identifier self
+          LetStatement st: i32
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .state_data
+                    Identifier self
+                  Identifier idx
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 0
+            Then
+              ReturnStatement
+                BoolLiteral false
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 1
+            Then
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .key_data
+                            Identifier self
+                          Identifier idx
+                    Identifier key
+                Then
+                  ReturnStatement
+                    BoolLiteral true
+          Assignment
+            Target
+              Identifier idx
+            Value
+              BinaryExpr +
+                Identifier idx
+                IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr >=
+                Identifier idx
+                FieldExpr .cap
+                  Identifier self
+            Then
+              Assignment
+                Target
+                  Identifier idx
+                Value
+                  CallExpr
+                    Callee
+                      Identifier to_i64
+                    Args
+                      IntLiteral 0
+          Assignment
+            Target
+              Identifier probes
+            Value
+              BinaryExpr +
+                Identifier probes
+                IntLiteral 1
+      ReturnStatement
+        BoolLiteral false
+    FunctionDecl set
+      Param self
+      Param key: string
+      Param value: V
+      ReturnType: HashMap<V>
+      IfStatement
+        Condition
+          BinaryExpr or
+            BinaryExpr ==
+              FieldExpr .cap
+                Identifier self
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 0
+            BinaryExpr >
+              BinaryExpr *
+                BinaryExpr +
+                  FieldExpr .count
+                    Identifier self
+                  IntLiteral 1
+                CallExpr
+                  Callee
+                    Identifier to_i64
+                  Args
+                    IntLiteral 4
+              BinaryExpr *
+                FieldExpr .cap
+                  Identifier self
+                CallExpr
+                  Callee
+                    Identifier to_i64
+                  Args
+                    IntLiteral 3
+        Then
+          LetStatement new_cap: i64
+            BinaryExpr *
+              FieldExpr .cap
+                Identifier self
+              IntLiteral 2
+          IfStatement
+            Condition
+              BinaryExpr <
+                Identifier new_cap
+                CallExpr
+                  Callee
+                    Identifier to_i64
+                  Args
+                    IntLiteral 8
+            Then
+              Assignment
+                Target
+                  Identifier new_cap
+                Value
+                  CallExpr
+                    Callee
+                      Identifier to_i64
+                    Args
+                      IntLiteral 8
+          LetStatement new_key_raw
+            CallExpr
+              Callee
+                Identifier __dao_mem_alloc
+              Args
+                BinaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier size_of
+                    TypeArgs
+                      string
+                  Identifier new_cap
+                CallExpr
+                  Callee
+                    Identifier align_of
+                  TypeArgs
+                    string
+          LetStatement new_val_raw
+            CallExpr
+              Callee
+                Identifier __dao_mem_alloc
+              Args
+                BinaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier size_of
+                    TypeArgs
+                      V
+                  Identifier new_cap
+                CallExpr
+                  Callee
+                    Identifier align_of
+                  TypeArgs
+                    V
+          LetStatement new_state_raw
+            CallExpr
+              Callee
+                Identifier __dao_mem_alloc
+              Args
+                BinaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier size_of
+                    TypeArgs
+                      i32
+                  Identifier new_cap
+                CallExpr
+                  Callee
+                    Identifier align_of
+                  TypeArgs
+                    i32
+          ModeBlock unsafe
+            LetStatement nk
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  string
+                Args
+                  Identifier new_key_raw
+            LetStatement nv
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  V
+                Args
+                  Identifier new_val_raw
+            LetStatement ns
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  i32
+                Args
+                  Identifier new_state_raw
+            LetStatement z: i64
+              IntLiteral 0
+            WhileStatement
+              Condition
+                BinaryExpr <
+                  Identifier z
+                  Identifier new_cap
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        Identifier ns
+                        Identifier z
+                Value
+                  IntLiteral 0
+              Assignment
+                Target
+                  Identifier z
+                Value
+                  BinaryExpr +
+                    Identifier z
+                    IntLiteral 1
+            LetStatement j: i64
+              IntLiteral 0
+            WhileStatement
+              Condition
+                BinaryExpr <
+                  Identifier j
+                  FieldExpr .cap
+                    Identifier self
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .state_data
+                            Identifier self
+                          Identifier j
+                    IntLiteral 1
+                Then
+                  LetStatement ek: string
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .key_data
+                            Identifier self
+                          Identifier j
+                  LetStatement ev: V
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .val_data
+                            Identifier self
+                          Identifier j
+                  LetStatement ri: i64
+                    CallExpr
+                      Callee
+                        Identifier hash_index
+                      Args
+                        CallExpr
+                          Callee
+                            Identifier hash_string
+                          Args
+                            Identifier ek
+                        Identifier new_cap
+                  LetStatement placed: bool
+                    BoolLiteral false
+                  WhileStatement
+                    Condition
+                      BinaryExpr ==
+                        Identifier placed
+                        BoolLiteral false
+                    IfStatement
+                      Condition
+                        BinaryExpr ==
+                          UnaryExpr *
+                            CallExpr
+                              Callee
+                                Identifier ptr_offset
+                              Args
+                                Identifier ns
+                                Identifier ri
+                          IntLiteral 0
+                      Then
+                        Assignment
+                          Target
+                            UnaryExpr *
+                              CallExpr
+                                Callee
+                                  Identifier ptr_offset
+                                Args
+                                  Identifier nk
+                                  Identifier ri
+                          Value
+                            Identifier ek
+                        Assignment
+                          Target
+                            UnaryExpr *
+                              CallExpr
+                                Callee
+                                  Identifier ptr_offset
+                                Args
+                                  Identifier nv
+                                  Identifier ri
+                          Value
+                            Identifier ev
+                        Assignment
+                          Target
+                            UnaryExpr *
+                              CallExpr
+                                Callee
+                                  Identifier ptr_offset
+                                Args
+                                  Identifier ns
+                                  Identifier ri
+                          Value
+                            IntLiteral 1
+                        Assignment
+                          Target
+                            Identifier placed
+                          Value
+                            BoolLiteral true
+                      Else
+                        Assignment
+                          Target
+                            Identifier ri
+                          Value
+                            BinaryExpr +
+                              Identifier ri
+                              IntLiteral 1
+                        IfStatement
+                          Condition
+                            BinaryExpr >=
+                              Identifier ri
+                              Identifier new_cap
+                          Then
+                            Assignment
+                              Target
+                                Identifier ri
+                              Value
+                                CallExpr
+                                  Callee
+                                    Identifier to_i64
+                                  Args
+                                    IntLiteral 0
+              Assignment
+                Target
+                  Identifier j
+                Value
+                  BinaryExpr +
+                    Identifier j
+                    IntLiteral 1
+            LetStatement ni: i64
+              CallExpr
+                Callee
+                  Identifier hash_index
+                Args
+                  CallExpr
+                    Callee
+                      Identifier hash_string
+                    Args
+                      Identifier key
+                  Identifier new_cap
+            LetStatement done: bool
+              BoolLiteral false
+            WhileStatement
+              Condition
+                BinaryExpr ==
+                  Identifier done
+                  BoolLiteral false
+              LetStatement st: i32
+                UnaryExpr *
+                  CallExpr
+                    Callee
+                      Identifier ptr_offset
+                    Args
+                      Identifier ns
+                      Identifier ni
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    Identifier st
+                    IntLiteral 0
+                Then
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            Identifier nk
+                            Identifier ni
+                    Value
+                      Identifier key
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            Identifier nv
+                            Identifier ni
+                    Value
+                      Identifier value
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            Identifier ns
+                            Identifier ni
+                    Value
+                      IntLiteral 1
+                  Assignment
+                    Target
+                      Identifier done
+                    Value
+                      BoolLiteral true
+                Else
+                  IfStatement
+                    Condition
+                      BinaryExpr ==
+                        Identifier st
+                        IntLiteral 1
+                    Then
+                      IfStatement
+                        Condition
+                          BinaryExpr ==
+                            UnaryExpr *
+                              CallExpr
+                                Callee
+                                  Identifier ptr_offset
+                                Args
+                                  Identifier nk
+                                  Identifier ni
+                            Identifier key
+                        Then
+                          Assignment
+                            Target
+                              UnaryExpr *
+                                CallExpr
+                                  Callee
+                                    Identifier ptr_offset
+                                  Args
+                                    Identifier nv
+                                    Identifier ni
+                            Value
+                              Identifier value
+                          ReturnStatement
+                            CallExpr
+                              Callee
+                                Identifier HashMap
+                              Args
+                                Identifier nk
+                                Identifier nv
+                                Identifier ns
+                                FieldExpr .count
+                                  Identifier self
+                                Identifier new_cap
+                      Assignment
+                        Target
+                          Identifier ni
+                        Value
+                          BinaryExpr +
+                            Identifier ni
+                            IntLiteral 1
+                      IfStatement
+                        Condition
+                          BinaryExpr >=
+                            Identifier ni
+                            Identifier new_cap
+                        Then
+                          Assignment
+                            Target
+                              Identifier ni
+                            Value
+                              CallExpr
+                                Callee
+                                  Identifier to_i64
+                                Args
+                                  IntLiteral 0
+                    Else
+                      Assignment
+                        Target
+                          UnaryExpr *
+                            CallExpr
+                              Callee
+                                Identifier ptr_offset
+                              Args
+                                Identifier nk
+                                Identifier ni
+                        Value
+                          Identifier key
+                      Assignment
+                        Target
+                          UnaryExpr *
+                            CallExpr
+                              Callee
+                                Identifier ptr_offset
+                              Args
+                                Identifier nv
+                                Identifier ni
+                        Value
+                          Identifier value
+                      Assignment
+                        Target
+                          UnaryExpr *
+                            CallExpr
+                              Callee
+                                Identifier ptr_offset
+                              Args
+                                Identifier ns
+                                Identifier ni
+                        Value
+                          IntLiteral 1
+                      Assignment
+                        Target
+                          Identifier done
+                        Value
+                          BoolLiteral true
+            ReturnStatement
+              CallExpr
+                Callee
+                  Identifier HashMap
+                Args
+                  Identifier nk
+                  Identifier nv
+                  Identifier ns
+                  BinaryExpr +
+                    FieldExpr .count
+                      Identifier self
+                    IntLiteral 1
+                  Identifier new_cap
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier panic
+              Args
+                StringLiteral "unreachable"
+      LetStatement idx: i64
+        CallExpr
+          Callee
+            Identifier hash_index
+          Args
+            CallExpr
+              Callee
+                Identifier hash_string
+              Args
+                Identifier key
+            FieldExpr .cap
+              Identifier self
+      ModeBlock unsafe
+        LetStatement done: bool
+          BoolLiteral false
+        WhileStatement
+          Condition
+            BinaryExpr ==
+              Identifier done
+              BoolLiteral false
+          LetStatement st: i32
+            UnaryExpr *
+              CallExpr
+                Callee
+                  Identifier ptr_offset
+                Args
+                  FieldExpr .state_data
+                    Identifier self
+                  Identifier idx
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier st
+                IntLiteral 0
+            Then
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        FieldExpr .key_data
+                          Identifier self
+                        Identifier idx
+                Value
+                  Identifier key
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        FieldExpr .val_data
+                          Identifier self
+                        Identifier idx
+                Value
+                  Identifier value
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        FieldExpr .state_data
+                          Identifier self
+                        Identifier idx
+                Value
+                  IntLiteral 1
+              Assignment
+                Target
+                  Identifier done
+                Value
+                  BoolLiteral true
+            Else
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    Identifier st
+                    IntLiteral 1
+                Then
+                  IfStatement
+                    Condition
+                      BinaryExpr ==
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              FieldExpr .key_data
+                                Identifier self
+                              Identifier idx
+                        Identifier key
+                    Then
+                      Assignment
+                        Target
+                          UnaryExpr *
+                            CallExpr
+                              Callee
+                                Identifier ptr_offset
+                              Args
+                                FieldExpr .val_data
+                                  Identifier self
+                                Identifier idx
+                        Value
+                          Identifier value
+                      ReturnStatement
+                        CallExpr
+                          Callee
+                            Identifier HashMap
+                          Args
+                            FieldExpr .key_data
+                              Identifier self
+                            FieldExpr .val_data
+                              Identifier self
+                            FieldExpr .state_data
+                              Identifier self
+                            FieldExpr .count
+                              Identifier self
+                            FieldExpr .cap
+                              Identifier self
+                  Assignment
+                    Target
+                      Identifier idx
+                    Value
+                      BinaryExpr +
+                        Identifier idx
+                        IntLiteral 1
+                  IfStatement
+                    Condition
+                      BinaryExpr >=
+                        Identifier idx
+                        FieldExpr .cap
+                          Identifier self
+                    Then
+                      Assignment
+                        Target
+                          Identifier idx
+                        Value
+                          CallExpr
+                            Callee
+                              Identifier to_i64
+                            Args
+                              IntLiteral 0
+                Else
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            FieldExpr .key_data
+                              Identifier self
+                            Identifier idx
+                    Value
+                      Identifier key
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            FieldExpr .val_data
+                              Identifier self
+                            Identifier idx
+                    Value
+                      Identifier value
+                  Assignment
+                    Target
+                      UnaryExpr *
+                        CallExpr
+                          Callee
+                            Identifier ptr_offset
+                          Args
+                            FieldExpr .state_data
+                              Identifier self
+                            Identifier idx
+                    Value
+                      IntLiteral 1
+                  Assignment
+                    Target
+                      Identifier done
+                    Value
+                      BoolLiteral true
+      ReturnStatement
+        CallExpr
+          Callee
+            Identifier HashMap
+          Args
+            FieldExpr .key_data
+              Identifier self
+            FieldExpr .val_data
+              Identifier self
+            FieldExpr .state_data
+              Identifier self
+            BinaryExpr +
+              FieldExpr .count
+                Identifier self
+              IntLiteral 1
+            FieldExpr .cap
+              Identifier self


### PR DESCRIPTION
## Summary

Add the first associative container: `HashMap<V>`, a string-keyed hash map with open addressing and linear probing. Rewrite the type-checker bootstrap probe to use it for symbol table lookup, replacing O(n) Vector scan with O(1) hash lookup. This was identified as the structural blocker by Probe 6.

## Highlights

- `__dao_str_hash` runtime hook: FNV-1a 64-bit string hashing across all four layers (C runtime, LLVM backend declarations, Dao extern, contract)
- `HashMap<V>` in `stdlib/core/hashmap.dao`: `new()`, `set()`, `get()`, `contains()`, `length()` — in-place mutation of backing storage (no deep copy per write), resize only on load factor breach
- Type checker fix: allow `GenericParam` from enclosing class scope in generic enum types (the rejection check now only errors on params belonging to the enum's own declaration, not bound class/function params)
- Bootstrap probe 6 rewritten: symbol table is `HashMap<Symbol>` instead of `Vector<Symbol>` with linear scan — 28/28 tests pass
- `examples/hashmap.dao`: smoke test covering insert, update, lookup, missing key, and resize

## Known Limitations

- `get()` returns `V` and panics on missing key (instead of `Option<V>`) due to a separate compiler bug: class methods returning generic enum types lose type args during HIR→MIR lowering. The type checker fix in this PR is necessary but not sufficient — the MIR builder also needs updating. Tracked for separate fix.
- Keys are fixed to `string`. Generic key dispatch (`HashMap<K: Hashable, V>`) is deferred until concept bounds on class generics are proven.
- No iteration, no remove. Minimum viable map for compiler/bootstrap work.

## Test plan

- [x] 12/12 compiler tests pass
- [x] 28/28 type-checker probe tests pass (HashMap-backed symbol table)
- [x] All 22 examples + 7 bootstrap probes compile
- [x] HashMap smoke test: insert, update, contains, missing key, resize to 10+ entries
- [x] Golden AST files generated for all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)