### PR TITLE
fix(typecheck): 🐛 fix generic enum returns from class methods

### DIFF
--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -418,19 +418,86 @@ void TypeChecker::register_declarations(const FileNode& file) {
     }
   }
 
-  // Pass 1b: register functions and structs, which may reference aliases.
+  // Pass 1b: register type shells (enums and class structs) so that
+  // function signatures processed in pass 1c can reference them
+  // regardless of source order.
+  for (const auto* decl : file.declarations) {
+    if (decl->kind() == NodeKind::ClassDecl) {
+      const auto& st = decl->as<ClassDecl>();
+      auto decl_it = decl_symbols_.find(st.name_span.offset);
+      if (decl_it == decl_symbols_.end()) {
+        continue;
+      }
+      const auto* sym = decl_it->second;
+
+      std::vector<StructField> fields;
+      for (const auto* field : st.fields) {
+        const auto* field_type = resolve_type_node(field->type);
+        if (field_type != nullptr) {
+          fields.push_back({field->name, field_type});
+        }
+      }
+      const auto* struct_type =
+          types_.make_struct(sym, st.name, std::move(fields));
+      symbol_types_[sym] = struct_type;
+      typed_.set_decl_type(decl, struct_type);
+    } else if (decl->kind() == NodeKind::EnumDecl) {
+      const auto& en = decl->as<EnumDeclNode>();
+      auto decl_it = decl_symbols_.find(en.name_span.offset);
+      if (decl_it == decl_symbols_.end()) {
+        continue;
+      }
+      const auto* sym = decl_it->second;
+
+      // Build enum type from variant specifiers, resolving payload types.
+      // Unresolved types are kept as nullptr to preserve arity — the
+      // primary diagnostic comes from resolve_type_node; dropping the
+      // slot would silently mutate the variant shape and produce
+      // misleading secondary errors.
+      std::vector<EnumVariant> variants;
+      for (const auto& variant : en.variants) {
+        std::vector<const Type*> payload_types;
+        for (size_t i = 0; i < variant.payload_types.size(); ++i) {
+          const auto* resolved = resolve_type_node(variant.payload_types[i]);
+          payload_types.push_back(resolved);
+          if (resolved == nullptr) {
+            if (variant.payload_types[i]->is<NamedType>()) {
+              const auto& named =
+                  variant.payload_types[i]->as<NamedType>();
+              if (named.name.segments.size() == 1 &&
+                  named.name.segments[0] == en.name) {
+                error(variant.payload_types[i]->span,
+                      "enum '" + std::string(en.name) +
+                          "' cannot contain itself by value in variant '" +
+                          std::string(variant.name) +
+                          "'; use a pointer (*" + std::string(en.name) +
+                          ") for recursive types");
+              }
+            }
+          }
+        }
+        variants.push_back({variant.name, std::move(payload_types)});
+      }
+      const auto* enum_type =
+          types_.make_enum(sym, en.name, std::move(variants));
+      symbol_types_[sym] = enum_type;
+      typed_.set_decl_type(decl, enum_type);
+    }
+  }
+
+  // Pass 1c: register function signatures, class method signatures,
+  // and extend method signatures. All type shells from pass 1b are
+  // available, so return types like Option<V> resolve correctly.
   for (const auto* decl : file.declarations) {
     switch (decl->kind()) {
     case NodeKind::FunctionDecl: {
       const auto& fn = decl->as<FunctionDecl>();
-      // Find the symbol for this function via declaration map.
       auto decl_it = decl_symbols_.find(fn.name_span.offset);
       if (decl_it == decl_symbols_.end()) {
         break;
       }
       const auto* sym = decl_it->second;
 
-      // Build function type.
       std::vector<const Type*> param_types;
       bool valid = true;
       for (const auto& param : fn.params) {
@@ -453,28 +520,14 @@ void TypeChecker::register_declarations(const FileNode& file) {
 
     case NodeKind::ClassDecl: {
       const auto& st = decl->as<ClassDecl>();
-      // Find symbol via declaration map.
       auto decl_it = decl_symbols_.find(st.name_span.offset);
       if (decl_it == decl_symbols_.end()) {
         break;
       }
-      const auto* sym = decl_it->second;
+      const auto* struct_type = static_cast<const TypeStruct*>(
+          symbol_types_[decl_it->second]);
 
-      // Build struct type from field specifiers.
-      std::vector<StructField> fields;
-      for (const auto* field : st.fields) {
-        const auto* field_type = resolve_type_node(field->type);
-        if (field_type != nullptr) {
-          fields.push_back({field->name, field_type});
-        }
-      }
-      const auto* struct_type =
-          types_.make_struct(sym, st.name, std::move(fields));
-      symbol_types_[sym] = struct_type;
-      typed_.set_decl_type(decl, struct_type);
-
-      // Register class body methods as function declarations so
-      // they get proper TypeFunction entries in the typed results.
+      // Register class body methods.
       for (const auto* method : st.methods) {
         const auto& fn = method->as<FunctionDecl>();
         auto mdecl_it = decl_symbols_.find(fn.name_span.offset);
@@ -502,62 +555,7 @@ void TypeChecker::register_declarations(const FileNode& file) {
       break;
     }
 
-    case NodeKind::EnumDecl: {
-      const auto& en = decl->as<EnumDeclNode>();
-      auto decl_it = decl_symbols_.find(en.name_span.offset);
-      if (decl_it == decl_symbols_.end()) {
-        break;
-      }
-      const auto* sym = decl_it->second;
-
-      // Build enum type from variant specifiers, resolving payload types.
-      // Unresolved types are kept as nullptr to preserve arity — the
-      // primary diagnostic comes from resolve_type_node; dropping the
-      // slot would silently mutate the variant shape and produce
-      // misleading secondary errors.
-      std::vector<EnumVariant> variants;
-      bool has_bad_payload = false;
-      for (const auto& variant : en.variants) {
-        std::vector<const Type*> payload_types;
-        for (size_t i = 0; i < variant.payload_types.size(); ++i) {
-          const auto* resolved = resolve_type_node(variant.payload_types[i]);
-          payload_types.push_back(resolved);
-          if (resolved == nullptr) {
-            has_bad_payload = true;
-            // Check for self-referential by-value payload: the type
-            // name matches the enum being defined, which hasn't been
-            // registered yet. Emit a specific diagnostic.
-            if (variant.payload_types[i]->is<NamedType>()) {
-              const auto& named =
-                  variant.payload_types[i]->as<NamedType>();
-              if (named.name.segments.size() == 1 &&
-                  named.name.segments[0] == en.name) {
-                error(variant.payload_types[i]->span,
-                      "enum '" + std::string(en.name) +
-                          "' cannot contain itself by value in variant '" +
-                          std::string(variant.name) +
-                          "'; use a pointer (*" + std::string(en.name) +
-                          ") for recursive types");
-              }
-            }
-          }
-        }
-        variants.push_back({variant.name, std::move(payload_types)});
-      }
-      const auto* enum_type =
-          types_.make_enum(sym, en.name, std::move(variants));
-      symbol_types_[sym] = enum_type;
-      typed_.set_decl_type(decl, enum_type);
-      if (has_bad_payload) {
-        // Don't proceed to codegen with broken payload types.
-        break;
-      }
-      break;
-    }
-
     case NodeKind::ExtendDecl: {
-      // Register extend methods as typed functions so HIR lowering
-      // can find their type info via decl_type().
       const auto& ext = decl->as<ExtendDecl>();
       const auto* target_type = resolve_type_node(ext.target_type);
       for (const auto* method : ext.methods) {
@@ -566,7 +564,6 @@ void TypeChecker::register_declarations(const FileNode& file) {
         bool valid = true;
         for (const auto& param : method_fn.params) {
           if (param.name == "self" && param.type == nullptr) {
-            // Bare self — use the extend target type.
             if (target_type != nullptr) {
               param_types.push_back(target_type);
             } else {
@@ -587,9 +584,9 @@ void TypeChecker::register_declarations(const FileNode& file) {
         if (valid && ret != nullptr) {
           const auto* fn_type =
               types_.function_type(std::move(param_types), ret);
-          auto decl_it = decl_symbols_.find(method_fn.name_span.offset);
-          if (decl_it != decl_symbols_.end()) {
-            symbol_types_[decl_it->second] = fn_type;
+          auto fn_decl_it = decl_symbols_.find(method_fn.name_span.offset);
+          if (fn_decl_it != decl_symbols_.end()) {
+            symbol_types_[fn_decl_it->second] = fn_type;
           }
           typed_.set_decl_type(method, fn_type);
         }

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -111,6 +111,7 @@ auto substitute_type(const Type* type, const TypeSubst& subst,
       }
       new_variants.push_back({variant.name, std::move(new_payload)});
     }
+    // END DEBUG
     if (!changed) {
       return type;
     }
@@ -280,10 +281,31 @@ auto clone_function(const MirFunction* src, const TypeSubst& subst,
           call->explicit_type_args = new_ta;
         }
       } else if (auto* ctor = std::get_if<MirConstruct>(&dst_inst->payload)) {
+        if (ctor->struct_type != nullptr) {
+          const auto* sub_st =
+              substitute_type(ctor->struct_type, subst, types);
+          if (sub_st != nullptr && sub_st->kind() == TypeKind::Struct) {
+            ctor->struct_type = static_cast<const TypeStruct*>(sub_st);
+          }
+        }
         if (ctor->field_values != nullptr) {
           auto* new_fv =
               ctx.alloc<std::vector<MirValueId>>(*ctor->field_values);
           ctor->field_values = new_fv;
+        }
+      } else if (auto* econ =
+                     std::get_if<MirEnumConstruct>(&dst_inst->payload)) {
+        if (econ->enum_type != nullptr) {
+          const auto* sub_et =
+              substitute_type(econ->enum_type, subst, types);
+          if (sub_et != nullptr && sub_et->kind() == TypeKind::Enum) {
+            econ->enum_type = static_cast<const TypeEnum*>(sub_et);
+          }
+        }
+        if (econ->payload_values != nullptr) {
+          auto* new_pv =
+              ctx.alloc<std::vector<MirValueId>>(*econ->payload_values);
+          econ->payload_values = new_pv;
         }
       } else if (auto* store = std::get_if<MirStore>(&dst_inst->payload)) {
         if (store->place != nullptr) {

--- a/examples/bootstrap_probe/type_checker.dao
+++ b/examples/bootstrap_probe/type_checker.dao
@@ -4,9 +4,10 @@
 // booleans, comparisons, and logical operators, then adds a combined
 // resolve + typecheck pass over the arena.
 //
-// Tests: HashMap<V> for O(1) symbol lookup, Result<T, E> for
-// error-bearing analysis, multi-pass compiler architecture
-// (lex → parse → analyze), and match destructuring for control flow.
+// Tests: HashMap<V> for O(1) symbol lookup, Option<V> for fallible
+// map get, Result<T, E> for error-bearing analysis, multi-pass
+// compiler architecture (lex → parse → analyze), and match
+// destructuring for control flow.
 //
 // Language surface:
 //   let x = 5; let y = x + 3; y > 0
@@ -486,10 +487,12 @@ fn check_expr(arena: Vector<Node>, idx: i64, table: HashMap<Symbol>, source: str
 
     Node.VarRef(off, len):
       let name: string = substring(source, off, len)
-      if table.contains(name):
-        let sym: Symbol = table.get(name)
-        return Result.Ok(sym.ty)
-      return Result.Err("undefined variable '" + name + "'")
+      let found: Option<Symbol> = table.get(name)
+      match found:
+        Option.Some(sym):
+          return Result.Ok(sym.ty)
+        Option.None:
+          return Result.Err("undefined variable '" + name + "'")
 
     Node.Binary(op, left, right):
       let lt: Result<i32, string> = check_expr(arena, left, table, source)

--- a/examples/hashmap.dao
+++ b/examples/hashmap.dao
@@ -4,6 +4,14 @@ class Entry:
   name: string
   value: i32
 
+fn show_entry(label: string, result: Option<Entry>): i32
+  match result:
+    Option.Some(e):
+      print(label + " = " + i32_to_string(e.value))
+    Option.None:
+      print(label + " not found")
+  return 0
+
 fn main(): i32
   print("=== HashMap<V> ===")
 
@@ -14,26 +22,14 @@ fn main(): i32
 
   print("length: " + i64_to_string(m.length()))
 
-  // Two-phase lookup: contains + get.
-  if m.contains("x"):
-    let e: Entry = m.get("x")
-    print("x = " + i32_to_string(e.value))
-
-  if m.contains("y"):
-    let e: Entry = m.get("y")
-    print("y = " + i32_to_string(e.value))
+  // Option-based lookup.
+  let unused1: i32 = show_entry("x", m.get("x"))
+  let unused2: i32 = show_entry("y", m.get("y"))
+  let unused3: i32 = show_entry("w", m.get("w"))
 
   // Update existing key.
   m = m.set("x", Entry("x", 99))
-  if m.contains("x"):
-    let e: Entry = m.get("x")
-    print("x (updated) = " + i32_to_string(e.value))
-
-  // Missing key.
-  if m.contains("w"):
-    print("w found (unexpected)")
-  else:
-    print("w not found (correct)")
+  let unused4: i32 = show_entry("x (updated)", m.get("x"))
 
   // Many inserts to trigger resize.
   let big = HashMap<i32>::new()
@@ -49,22 +45,26 @@ fn main(): i32
   big = big.set("j", 10)
   print("big length: " + i64_to_string(big.length()))
 
-  if big.contains("j"):
-    print("j = " + i32_to_string(big.get("j")))
-  if big.contains("a"):
-    print("a = " + i32_to_string(big.get("a")))
+  let rj: Option<i32> = big.get("j")
+  match rj:
+    Option.Some(v):
+      print("j = " + i32_to_string(v))
+    Option.None:
+      print("j not found")
 
-  // Verify all keys survived resize.
-  let all_ok: bool = true
-  if big.contains("a") == false:
-    all_ok = false
-  if big.contains("e") == false:
-    all_ok = false
-  if big.contains("j") == false:
-    all_ok = false
-  if big.contains("missing"):
-    all_ok = false
-  if all_ok:
-    print("all keys correct after resize")
+  let ra: Option<i32> = big.get("a")
+  match ra:
+    Option.Some(v):
+      print("a = " + i32_to_string(v))
+    Option.None:
+      print("a not found")
+
+  // Missing key returns None.
+  let rm: Option<i32> = big.get("missing")
+  match rm:
+    Option.Some(v):
+      print("missing found (unexpected)")
+    Option.None:
+      print("missing = None (correct)")
 
   return 0

--- a/stdlib/core/hashmap.dao
+++ b/stdlib/core/hashmap.dao
@@ -10,10 +10,6 @@
 //
 // Hash function: FNV-1a via __dao_str_hash runtime hook.
 //
-// Known limitation: get() returns V (panics on missing) instead of
-// Option<V> due to a compiler bug where class methods returning
-// generic enum types lose type args during HIR→MIR lowering.
-// Use contains() + get() as a two-phase lookup pattern.
 
 extern fn __dao_str_hash(s: string): i64
 
@@ -40,31 +36,25 @@ class HashMap<V>:
 
   fn length(self): i64 -> self.count
 
-  // get returns the value for key, or panics if not found.
-  // Use contains() first to check existence.
-  //
-  // Note: returning Option<V> from a class method is blocked by a
-  // compiler bug (generic enum return types lose type args during
-  // HIR→MIR lowering). This will be changed to Option<V> once fixed.
-  fn get(self, key: string): V
+  fn get(self, key: string): Option<V>
     if self.cap == to_i64(0):
-      panic("HashMap.get: key not found")
+      return Option.None
     let idx: i64 = hash_index(hash_string(key), self.cap)
     mode unsafe =>
       let probes: i64 = 0
       while probes < self.cap:
         let st: i32 = *ptr_offset(self.state_data, idx)
         if st == 0:
-          panic("HashMap.get: key not found")
+          return Option.None
         if st == 1:
           if *ptr_offset(self.key_data, idx) == key:
-            return *ptr_offset(self.val_data, idx)
+            return Option.Some(*ptr_offset(self.val_data, idx))
         // st == 2 (tombstone) or different key — continue probing.
         idx = idx + 1
         if idx >= self.cap:
           idx = to_i64(0)
         probes = probes + 1
-    panic("HashMap.get: key not found")
+    return Option.None
 
   fn contains(self, key: string): bool
     if self.cap == to_i64(0):

--- a/testdata/ast/examples_bootstrap_probe_dao_lexer.ast
+++ b/testdata/ast/examples_bootstrap_probe_dao_lexer.ast
@@ -1,0 +1,1385 @@
+File
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_alpha
+    Param ch: i32
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 65
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 90
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 97
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 122
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BinaryExpr ==
+        Identifier ch
+        IntLiteral 95
+  FunctionDecl is_alnum
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        CallExpr
+          Callee
+            Identifier is_digit
+          Args
+            Identifier ch
+        CallExpr
+          Callee
+            Identifier is_alpha
+          Args
+            Identifier ch
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 32
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 9
+  FunctionDecl skip_while
+    Param source: string
+    Param pos: i64
+    Param pred: fn(i32): bool
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier pred
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier cur
+  FunctionDecl is_keyword
+    Param word: string
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "fn"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "let"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "return"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "if"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "else"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "while"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "for"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "in"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "and"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "or"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "not"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "true"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "false"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "extern"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "class"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "concept"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "extend"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "as"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "yield"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "mode"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "resource"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BoolLiteral false
+  FunctionDecl lex_one
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    IfStatement
+      Condition
+        BinaryExpr >=
+          Identifier pos
+          Identifier slen
+      Then
+        ReturnStatement
+          Identifier pos
+    LetStatement ch: i32
+      CallExpr
+        Callee
+          Identifier char_at
+        Args
+          Identifier source
+          Identifier pos
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_whitespace
+          Args
+            Identifier ch
+      Then
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier skip_while
+            Args
+              Identifier source
+              Identifier pos
+              Identifier is_whitespace
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 10
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "NEWLINE "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr and
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 47
+            BinaryExpr <
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+              Identifier slen
+          BinaryExpr ==
+            CallExpr
+              Callee
+                Identifier char_at
+              Args
+                Identifier source
+                BinaryExpr +
+                  Identifier pos
+                  IntLiteral 1
+            IntLiteral 47
+      Then
+        LetStatement end: i64
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 2
+        LetStatement comment_done: bool
+          BoolLiteral false
+        WhileStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr <
+                Identifier end
+                Identifier slen
+              BinaryExpr ==
+                Identifier comment_done
+                BoolLiteral false
+          IfStatement
+            Condition
+              BinaryExpr ==
+                CallExpr
+                  Callee
+                    Identifier char_at
+                  Args
+                    Identifier source
+                    Identifier end
+                IntLiteral 10
+            Then
+              Assignment
+                Target
+                  Identifier comment_done
+                Value
+                  BoolLiteral true
+            Else
+              Assignment
+                Target
+                  Identifier end
+                Value
+                  BinaryExpr +
+                    Identifier end
+                    IntLiteral 1
+        ReturnStatement
+          Identifier end
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_alpha
+          Args
+            Identifier ch
+      Then
+        LetStatement end: i64
+          CallExpr
+            Callee
+              Identifier skip_while
+            Args
+              Identifier source
+              Identifier pos
+              Identifier is_alnum
+        LetStatement word: string
+          CallExpr
+            Callee
+              Identifier substring
+            Args
+              Identifier source
+              Identifier pos
+              BinaryExpr -
+                Identifier end
+                Identifier pos
+        IfStatement
+          Condition
+            CallExpr
+              Callee
+                Identifier is_keyword
+              Args
+                Identifier word
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      BinaryExpr +
+                        BinaryExpr +
+                          BinaryExpr +
+                            StringLiteral "KW "
+                            CallExpr
+                              Callee
+                                Identifier i64_to_string
+                              Args
+                                Identifier pos
+                          StringLiteral " "
+                        CallExpr
+                          Callee
+                            Identifier i64_to_string
+                          Args
+                            BinaryExpr -
+                              Identifier end
+                              Identifier pos
+                      StringLiteral " "
+                    Identifier word
+          Else
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      BinaryExpr +
+                        BinaryExpr +
+                          BinaryExpr +
+                            StringLiteral "IDENT "
+                            CallExpr
+                              Callee
+                                Identifier i64_to_string
+                              Args
+                                Identifier pos
+                          StringLiteral " "
+                        CallExpr
+                          Callee
+                            Identifier i64_to_string
+                          Args
+                            BinaryExpr -
+                              Identifier end
+                              Identifier pos
+                      StringLiteral " "
+                    Identifier word
+        ReturnStatement
+          Identifier end
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier is_digit
+          Args
+            Identifier ch
+      Then
+        LetStatement end: i64
+          CallExpr
+            Callee
+              Identifier skip_while
+            Args
+              Identifier source
+              Identifier pos
+              Identifier is_digit
+        LetStatement num: string
+          CallExpr
+            Callee
+              Identifier substring
+            Args
+              Identifier source
+              Identifier pos
+              BinaryExpr -
+                Identifier end
+                Identifier pos
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    BinaryExpr +
+                      BinaryExpr +
+                        StringLiteral "INT "
+                        CallExpr
+                          Callee
+                            Identifier i64_to_string
+                          Args
+                            Identifier pos
+                      StringLiteral " "
+                    CallExpr
+                      Callee
+                        Identifier i64_to_string
+                      Args
+                        BinaryExpr -
+                          Identifier end
+                          Identifier pos
+                  StringLiteral " "
+                Identifier num
+        ReturnStatement
+          Identifier end
+    IfStatement
+      Condition
+        BinaryExpr <
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+          Identifier slen
+      Then
+        LetStatement next: i32
+          CallExpr
+            Callee
+              Identifier char_at
+            Args
+              Identifier source
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 61
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 61
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 =="
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 33
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 61
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 !="
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 60
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 61
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 <="
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 62
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 61
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 >="
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 45
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 62
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 ->"
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 61
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 62
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 =>"
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 124
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 62
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 |>"
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 58
+              BinaryExpr ==
+                Identifier next
+                IntLiteral 58
+          Then
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "OP "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " 2 ::"
+            ReturnStatement
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 2
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 43
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 +"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 45
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 -"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 42
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 *"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 47
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 /"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 61
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 ="
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 60
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 <"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 62
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "OP "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1 >"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 58
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "COLON "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 40
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "LPAREN "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 41
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "RPAREN "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 44
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "COMMA "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 46
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "DOT "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 124
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  StringLiteral "PIPE "
+                  CallExpr
+                    Callee
+                      Identifier i64_to_string
+                    Args
+                      Identifier pos
+                StringLiteral " 1"
+        ReturnStatement
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 34
+      Then
+        LetStatement end: i64
+          BinaryExpr +
+            Identifier pos
+            IntLiteral 1
+        LetStatement str_done: bool
+          BoolLiteral false
+        WhileStatement
+          Condition
+            BinaryExpr and
+              BinaryExpr <
+                Identifier end
+                Identifier slen
+              BinaryExpr ==
+                Identifier str_done
+                BoolLiteral false
+          IfStatement
+            Condition
+              BinaryExpr ==
+                CallExpr
+                  Callee
+                    Identifier char_at
+                  Args
+                    Identifier source
+                    Identifier end
+                IntLiteral 34
+            Then
+              Assignment
+                Target
+                  Identifier str_done
+                Value
+                  BoolLiteral true
+            Else
+              Assignment
+                Target
+                  Identifier end
+                Value
+                  BinaryExpr +
+                    Identifier end
+                    IntLiteral 1
+        IfStatement
+          Condition
+            Identifier str_done
+          Then
+            LetStatement text: string
+              CallExpr
+                Callee
+                  Identifier substring
+                Args
+                  Identifier source
+                  Identifier pos
+                  BinaryExpr -
+                    BinaryExpr +
+                      Identifier end
+                      IntLiteral 1
+                    Identifier pos
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      BinaryExpr +
+                        BinaryExpr +
+                          BinaryExpr +
+                            StringLiteral "STRING "
+                            CallExpr
+                              Callee
+                                Identifier i64_to_string
+                              Args
+                                Identifier pos
+                          StringLiteral " "
+                        CallExpr
+                          Callee
+                            Identifier i64_to_string
+                          Args
+                            BinaryExpr -
+                              BinaryExpr +
+                                Identifier end
+                                IntLiteral 1
+                              Identifier pos
+                      StringLiteral " "
+                    Identifier text
+            ReturnStatement
+              BinaryExpr +
+                Identifier end
+                IntLiteral 1
+          Else
+            ExpressionStatement
+              CallExpr
+                Callee
+                  Identifier print
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "ERROR "
+                      CallExpr
+                        Callee
+                          Identifier i64_to_string
+                        Args
+                          Identifier pos
+                    StringLiteral " unterminated string"
+            ReturnStatement
+              Identifier slen
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            BinaryExpr +
+              StringLiteral "ERROR "
+              CallExpr
+                Callee
+                  Identifier i64_to_string
+                Args
+                  Identifier pos
+            StringLiteral " unexpected char"
+    ReturnStatement
+      BinaryExpr +
+        Identifier pos
+        IntLiteral 1
+  FunctionDecl lex_all
+    Param source: string
+    ReturnType: i32
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement token_count: i32
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement old_pos: i64
+        Identifier pos
+      Assignment
+        Target
+          Identifier pos
+        Value
+          CallExpr
+            Callee
+              Identifier lex_one
+            Args
+              Identifier source
+              Identifier pos
+      IfStatement
+        Condition
+          BinaryExpr and
+            BinaryExpr >
+              Identifier pos
+              Identifier old_pos
+            BinaryExpr <=
+              Identifier pos
+              Identifier slen
+        Then
+          Assignment
+            Target
+              Identifier token_count
+            Value
+              BinaryExpr +
+                Identifier token_count
+                IntLiteral 1
+        Else
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier pos
+                Identifier old_pos
+            Then
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  BinaryExpr +
+                    Identifier pos
+                    IntLiteral 1
+    ReturnStatement
+      Identifier token_count
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement self_path: string
+      StringLiteral "examples/bootstrap_probe/dao_lexer.dao"
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier file_exists
+          Args
+            Identifier self_path
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral ""
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "=== self-lex ==="
+        LetStatement source: string
+          CallExpr
+            Callee
+              Identifier read_file
+            Args
+              Identifier self_path
+        LetStatement self_count: i32
+          CallExpr
+            Callee
+              Identifier lex_all
+            Args
+              Identifier source
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "tokens: "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    Identifier self_count
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                StringLiteral "bytes: "
+                CallExpr
+                  Callee
+                    Identifier i64_to_string
+                  Args
+                    CallExpr
+                      Callee
+                        Identifier length
+                      Args
+                        Identifier source
+      Else
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier eprint
+            Args
+              BinaryExpr +
+                StringLiteral "file not found: "
+                Identifier self_path
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_bootstrap_probe_lex_self.ast
+++ b/testdata/ast/examples_bootstrap_probe_lex_self.ast
@@ -1,0 +1,345 @@
+File
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_alpha
+    Param ch: i32
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 65
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 90
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 97
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 122
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BinaryExpr ==
+        Identifier ch
+        IntLiteral 95
+  FunctionDecl is_alnum
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        CallExpr
+          Callee
+            Identifier is_digit
+          Args
+            Identifier ch
+        CallExpr
+          Callee
+            Identifier is_alpha
+          Args
+            Identifier ch
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr or
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 32
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 10
+          BinaryExpr ==
+            Identifier ch
+            IntLiteral 13
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 9
+  FunctionDecl skip_alnum
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_alnum
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier cur
+  FunctionDecl skip_digits
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_digit
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier cur
+  FunctionDecl lex_and_count
+    Param source: string
+    ReturnType: i32
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement count: i32
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier pos
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_whitespace
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier pos
+            Value
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        Else
+          IfStatement
+            Condition
+              CallExpr
+                Callee
+                  Identifier is_alpha
+                Args
+                  Identifier ch
+            Then
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  CallExpr
+                    Callee
+                      Identifier skip_alnum
+                    Args
+                      Identifier source
+                      Identifier pos
+              Assignment
+                Target
+                  Identifier count
+                Value
+                  BinaryExpr +
+                    Identifier count
+                    IntLiteral 1
+            Else
+              IfStatement
+                Condition
+                  CallExpr
+                    Callee
+                      Identifier is_digit
+                    Args
+                      Identifier ch
+                Then
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      CallExpr
+                        Callee
+                          Identifier skip_digits
+                        Args
+                          Identifier source
+                          Identifier pos
+                  Assignment
+                    Target
+                      Identifier count
+                    Value
+                      BinaryExpr +
+                        Identifier count
+                        IntLiteral 1
+                Else
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      BinaryExpr +
+                        Identifier pos
+                        IntLiteral 1
+                  Assignment
+                    Target
+                      Identifier count
+                    Value
+                      BinaryExpr +
+                        Identifier count
+                        IntLiteral 1
+    ReturnStatement
+      Identifier count
+  FunctionDecl main
+    ReturnType: i32
+    IfStatement
+      Condition
+        CallExpr
+          Callee
+            Identifier file_exists
+          Args
+            StringLiteral "examples/bootstrap_probe/lex_self.dao"
+      Then
+        LetStatement source: string
+          CallExpr
+            Callee
+              Identifier read_file
+            Args
+              StringLiteral "examples/bootstrap_probe/lex_self.dao"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "self-lex token count:"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              CallExpr
+                Callee
+                  Identifier lex_and_count
+                Args
+                  Identifier source
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "source length:"
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              CallExpr
+                Callee
+                  Identifier length
+                Args
+                  Identifier source
+      Else
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "file not found"
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_bootstrap_probe_mini_lexer.ast
+++ b/testdata/ast/examples_bootstrap_probe_mini_lexer.ast
@@ -1,0 +1,350 @@
+File
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr or
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 32
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 10
+          BinaryExpr ==
+            Identifier ch
+            IntLiteral 13
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 9
+  FunctionDecl lex_number
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement start: i64
+      Identifier pos
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier cur
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_digit
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    LetStatement value: string
+      CallExpr
+        Callee
+          Identifier substring
+        Args
+          Identifier source
+          Identifier start
+          BinaryExpr -
+            Identifier cur
+            Identifier start
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "INT: "
+            Identifier value
+    ReturnStatement
+      Identifier cur
+  FunctionDecl lex
+    Param source: string
+    ReturnType: i32
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier pos
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_whitespace
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier pos
+            Value
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        Else
+          IfStatement
+            Condition
+              CallExpr
+                Callee
+                  Identifier is_digit
+                Args
+                  Identifier ch
+            Then
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  CallExpr
+                    Callee
+                      Identifier lex_number
+                    Args
+                      Identifier source
+                      Identifier pos
+            Else
+              IfStatement
+                Condition
+                  BinaryExpr ==
+                    Identifier ch
+                    IntLiteral 43
+                Then
+                  ExpressionStatement
+                    CallExpr
+                      Callee
+                        Identifier print
+                      Args
+                        StringLiteral "PLUS: +"
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      BinaryExpr +
+                        Identifier pos
+                        IntLiteral 1
+                Else
+                  IfStatement
+                    Condition
+                      BinaryExpr ==
+                        Identifier ch
+                        IntLiteral 45
+                    Then
+                      ExpressionStatement
+                        CallExpr
+                          Callee
+                            Identifier print
+                          Args
+                            StringLiteral "MINUS: -"
+                      Assignment
+                        Target
+                          Identifier pos
+                        Value
+                          BinaryExpr +
+                            Identifier pos
+                            IntLiteral 1
+                    Else
+                      IfStatement
+                        Condition
+                          BinaryExpr ==
+                            Identifier ch
+                            IntLiteral 42
+                        Then
+                          ExpressionStatement
+                            CallExpr
+                              Callee
+                                Identifier print
+                              Args
+                                StringLiteral "STAR: *"
+                          Assignment
+                            Target
+                              Identifier pos
+                            Value
+                              BinaryExpr +
+                                Identifier pos
+                                IntLiteral 1
+                        Else
+                          IfStatement
+                            Condition
+                              BinaryExpr ==
+                                Identifier ch
+                                IntLiteral 47
+                            Then
+                              ExpressionStatement
+                                CallExpr
+                                  Callee
+                                    Identifier print
+                                  Args
+                                    StringLiteral "SLASH: /"
+                              Assignment
+                                Target
+                                  Identifier pos
+                                Value
+                                  BinaryExpr +
+                                    Identifier pos
+                                    IntLiteral 1
+                            Else
+                              IfStatement
+                                Condition
+                                  BinaryExpr ==
+                                    Identifier ch
+                                    IntLiteral 40
+                                Then
+                                  ExpressionStatement
+                                    CallExpr
+                                      Callee
+                                        Identifier print
+                                      Args
+                                        StringLiteral "LPAREN: ("
+                                  Assignment
+                                    Target
+                                      Identifier pos
+                                    Value
+                                      BinaryExpr +
+                                        Identifier pos
+                                        IntLiteral 1
+                                Else
+                                  IfStatement
+                                    Condition
+                                      BinaryExpr ==
+                                        Identifier ch
+                                        IntLiteral 41
+                                    Then
+                                      ExpressionStatement
+                                        CallExpr
+                                          Callee
+                                            Identifier print
+                                          Args
+                                            StringLiteral "RPAREN: )"
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 1
+                                    Else
+                                      ExpressionStatement
+                                        CallExpr
+                                          Callee
+                                            Identifier print
+                                          Args
+                                            StringLiteral "ERROR: unexpected"
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "EOF"
+    ReturnStatement
+      IntLiteral 0
+  FunctionDecl main
+    ReturnType: i32
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== Lexing: 42 + (10 - 3) * 5 ==="
+    LetStatement result: i32
+      CallExpr
+        Callee
+          Identifier lex
+        Args
+          StringLiteral "42 + (10 - 3) * 5"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== Lexing from file ==="
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier write_file
+        Args
+          StringLiteral "/tmp/dao_lex_input.txt"
+          StringLiteral "100 / 20 + 7"
+    LetStatement source: string
+      CallExpr
+        Callee
+          Identifier read_file
+        Args
+          StringLiteral "/tmp/dao_lex_input.txt"
+    LetStatement result2: i32
+      CallExpr
+        Callee
+          Identifier lex
+        Args
+          Identifier source
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_bootstrap_probe_token_stats.ast
+++ b/testdata/ast/examples_bootstrap_probe_token_stats.ast
@@ -1,0 +1,421 @@
+File
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_alpha
+    Param ch: i32
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 65
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 90
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 97
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 122
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BinaryExpr ==
+        Identifier ch
+        IntLiteral 95
+  FunctionDecl is_alnum
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        CallExpr
+          Callee
+            Identifier is_digit
+          Args
+            Identifier ch
+        CallExpr
+          Callee
+            Identifier is_alpha
+          Args
+            Identifier ch
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr or
+          BinaryExpr or
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 32
+            BinaryExpr ==
+              Identifier ch
+              IntLiteral 10
+          BinaryExpr ==
+            Identifier ch
+            IntLiteral 13
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 9
+  FunctionDecl skip_word
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_alnum
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier cur
+  FunctionDecl skip_number
+    Param source: string
+    Param pos: i64
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement done: bool
+      BoolLiteral false
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier cur
+            Identifier slen
+          BinaryExpr ==
+            Identifier done
+            BoolLiteral false
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_digit
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          Assignment
+            Target
+              Identifier done
+            Value
+              BoolLiteral true
+    ReturnStatement
+      Identifier cur
+  FunctionDecl count_tokens
+    Param source: string
+    ReturnType: i32
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    LetStatement num_idents: i32
+      IntLiteral 0
+    LetStatement num_numbers: i32
+      IntLiteral 0
+    LetStatement num_ops: i32
+      IntLiteral 0
+    LetStatement num_other: i32
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier pos
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_whitespace
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier pos
+            Value
+              BinaryExpr +
+                Identifier pos
+                IntLiteral 1
+        Else
+          IfStatement
+            Condition
+              CallExpr
+                Callee
+                  Identifier is_alpha
+                Args
+                  Identifier ch
+            Then
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  CallExpr
+                    Callee
+                      Identifier skip_word
+                    Args
+                      Identifier source
+                      Identifier pos
+              Assignment
+                Target
+                  Identifier num_idents
+                Value
+                  BinaryExpr +
+                    Identifier num_idents
+                    IntLiteral 1
+            Else
+              IfStatement
+                Condition
+                  CallExpr
+                    Callee
+                      Identifier is_digit
+                    Args
+                      Identifier ch
+                Then
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      CallExpr
+                        Callee
+                          Identifier skip_number
+                        Args
+                          Identifier source
+                          Identifier pos
+                  Assignment
+                    Target
+                      Identifier num_numbers
+                    Value
+                      BinaryExpr +
+                        Identifier num_numbers
+                        IntLiteral 1
+                Else
+                  IfStatement
+                    Condition
+                      BinaryExpr or
+                        BinaryExpr or
+                          BinaryExpr or
+                            BinaryExpr or
+                              BinaryExpr ==
+                                Identifier ch
+                                IntLiteral 43
+                              BinaryExpr ==
+                                Identifier ch
+                                IntLiteral 45
+                            BinaryExpr ==
+                              Identifier ch
+                              IntLiteral 42
+                          BinaryExpr ==
+                            Identifier ch
+                            IntLiteral 47
+                        BinaryExpr ==
+                          Identifier ch
+                          IntLiteral 61
+                    Then
+                      Assignment
+                        Target
+                          Identifier num_ops
+                        Value
+                          BinaryExpr +
+                            Identifier num_ops
+                            IntLiteral 1
+                      Assignment
+                        Target
+                          Identifier pos
+                        Value
+                          BinaryExpr +
+                            Identifier pos
+                            IntLiteral 1
+                    Else
+                      Assignment
+                        Target
+                          Identifier num_other
+                        Value
+                          BinaryExpr +
+                            Identifier num_other
+                            IntLiteral 1
+                      Assignment
+                        Target
+                          Identifier pos
+                        Value
+                          BinaryExpr +
+                            Identifier pos
+                            IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "identifiers:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier num_idents
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "numbers:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier num_numbers
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "operators:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier num_ops
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "other:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier num_other
+    ReturnStatement
+      BinaryExpr +
+        BinaryExpr +
+          BinaryExpr +
+            Identifier num_idents
+            Identifier num_numbers
+          Identifier num_ops
+        Identifier num_other
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement source: string
+      StringLiteral "fn add(a: i32, b: i32): i32 = a + b"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "source:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier source
+    LetStatement total: i32
+      CallExpr
+        Callee
+          Identifier count_tokens
+        Args
+          Identifier source
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "total tokens:"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          Identifier total
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_bootstrap_probe_type_checker.ast
+++ b/testdata/ast/examples_bootstrap_probe_type_checker.ast
@@ -2571,22 +2571,20 @@ File
               Identifier source
               Identifier off
               Identifier len
-        IfStatement
-          Condition
-            CallExpr
-              Callee
-                FieldExpr .contains
-                  Identifier table
-              Args
-                Identifier name
-          Then
-            LetStatement sym: Symbol
-              CallExpr
-                Callee
-                  FieldExpr .get
-                    Identifier table
-                Args
-                  Identifier name
+        LetStatement found: Option<Symbol>
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier table
+            Args
+              Identifier name
+        MatchStatement
+          Scrutinee
+            Identifier found
+          Arm
+            Pattern
+              FieldExpr .Some
+                Identifier Option
             ReturnStatement
               CallExpr
                 Callee
@@ -2595,17 +2593,21 @@ File
                 Args
                   FieldExpr .ty
                     Identifier sym
-        ReturnStatement
-          CallExpr
-            Callee
-              FieldExpr .Err
-                Identifier Result
-            Args
-              BinaryExpr +
-                BinaryExpr +
-                  StringLiteral "undefined variable '"
-                  Identifier name
-                StringLiteral "'"
+          Arm
+            Pattern
+              FieldExpr .None
+                Identifier Option
+            ReturnStatement
+              CallExpr
+                Callee
+                  FieldExpr .Err
+                    Identifier Result
+                Args
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "undefined variable '"
+                      Identifier name
+                    StringLiteral "'"
       Arm
         Pattern
           FieldExpr .Binary

--- a/testdata/ast/examples_bootstrap_probe_vector_tokenizer.ast
+++ b/testdata/ast/examples_bootstrap_probe_vector_tokenizer.ast
@@ -1,0 +1,1622 @@
+File
+  FunctionDecl TK_KW
+    ReturnType: i32
+    ExprBody
+      IntLiteral 1
+  FunctionDecl TK_IDENT
+    ReturnType: i32
+    ExprBody
+      IntLiteral 2
+  FunctionDecl TK_INT
+    ReturnType: i32
+    ExprBody
+      IntLiteral 3
+  FunctionDecl TK_STRING
+    ReturnType: i32
+    ExprBody
+      IntLiteral 4
+  FunctionDecl TK_OP
+    ReturnType: i32
+    ExprBody
+      IntLiteral 5
+  FunctionDecl TK_NEWLINE
+    ReturnType: i32
+    ExprBody
+      IntLiteral 6
+  FunctionDecl TK_ERROR
+    ReturnType: i32
+    ExprBody
+      IntLiteral 7
+  FunctionDecl kind_name
+    Param k: i32
+    ReturnType: string
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 1
+      Then
+        ReturnStatement
+          StringLiteral "KW"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 2
+      Then
+        ReturnStatement
+          StringLiteral "IDENT"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 3
+      Then
+        ReturnStatement
+          StringLiteral "INT"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 4
+      Then
+        ReturnStatement
+          StringLiteral "STRING"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 5
+      Then
+        ReturnStatement
+          StringLiteral "OP"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 6
+      Then
+        ReturnStatement
+          StringLiteral "NEWLINE"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier k
+          IntLiteral 7
+      Then
+        ReturnStatement
+          StringLiteral "ERROR"
+    ReturnStatement
+      StringLiteral "?"
+  ClassDecl Token
+    Field kind: i32
+    Field offset: i64
+    Field len: i64
+  FunctionDecl make_token
+    Param k: i32
+    Param off: i64
+    Param l: i64
+    ReturnType: Token
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Token
+        Args
+          Identifier k
+          Identifier off
+          Identifier l
+  FunctionDecl is_digit
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr and
+        BinaryExpr >=
+          Identifier ch
+          IntLiteral 48
+        BinaryExpr <=
+          Identifier ch
+          IntLiteral 57
+  FunctionDecl is_alpha
+    Param ch: i32
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 65
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 90
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr >=
+            Identifier ch
+            IntLiteral 97
+          BinaryExpr <=
+            Identifier ch
+            IntLiteral 122
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BinaryExpr ==
+        Identifier ch
+        IntLiteral 95
+  FunctionDecl is_alnum
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        CallExpr
+          Callee
+            Identifier is_digit
+          Args
+            Identifier ch
+        CallExpr
+          Callee
+            Identifier is_alpha
+          Args
+            Identifier ch
+  FunctionDecl is_whitespace
+    Param ch: i32
+    ReturnType: bool
+    ReturnStatement
+      BinaryExpr or
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 32
+        BinaryExpr ==
+          Identifier ch
+          IntLiteral 9
+  FunctionDecl is_keyword
+    Param word: string
+    ReturnType: bool
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "fn"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "let"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "return"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "if"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "else"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "while"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "for"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "in"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "and"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "or"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "not"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "true"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "false"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "extern"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "class"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "concept"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "extend"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "as"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "yield"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "mode"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "resource"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    IfStatement
+      Condition
+        BinaryExpr ==
+          Identifier word
+          StringLiteral "break"
+      Then
+        ReturnStatement
+          BoolLiteral true
+    ReturnStatement
+      BoolLiteral false
+  FunctionDecl skip_while
+    Param source: string
+    Param pos: i64
+    Param pred: fn(i32): bool
+    ReturnType: i64
+    LetStatement cur: i64
+      Identifier pos
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier cur
+          Identifier slen
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier pred
+            Args
+              CallExpr
+                Callee
+                  Identifier char_at
+                Args
+                  Identifier source
+                  Identifier cur
+        Then
+          Assignment
+            Target
+              Identifier cur
+            Value
+              BinaryExpr +
+                Identifier cur
+                IntLiteral 1
+        Else
+          BreakStatement
+    ReturnStatement
+      Identifier cur
+  FunctionDecl lex
+    Param source: string
+    ReturnType: Vector<Token>
+    LetStatement tokens
+      CallExpr
+        Callee
+          Identifier Vector.new
+        TypeArgs
+          Token
+    LetStatement pos: i64
+      IntLiteral 0
+    LetStatement slen: i64
+      CallExpr
+        Callee
+          Identifier length
+        Args
+          Identifier source
+    WhileStatement
+      Condition
+        BinaryExpr <
+          Identifier pos
+          Identifier slen
+      LetStatement ch: i32
+        CallExpr
+          Callee
+            Identifier char_at
+          Args
+            Identifier source
+            Identifier pos
+      IfStatement
+        Condition
+          CallExpr
+            Callee
+              Identifier is_whitespace
+            Args
+              Identifier ch
+        Then
+          Assignment
+            Target
+              Identifier pos
+            Value
+              CallExpr
+                Callee
+                  Identifier skip_while
+                Args
+                  Identifier source
+                  Identifier pos
+                  Identifier is_whitespace
+        Else
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 10
+            Then
+              Assignment
+                Target
+                  Identifier tokens
+                Value
+                  CallExpr
+                    Callee
+                      FieldExpr .push
+                        Identifier tokens
+                    Args
+                      CallExpr
+                        Callee
+                          Identifier make_token
+                        Args
+                          CallExpr
+                            Callee
+                              Identifier TK_NEWLINE
+                          Identifier pos
+                          CallExpr
+                            Callee
+                              Identifier to_i64
+                            Args
+                              IntLiteral 1
+              Assignment
+                Target
+                  Identifier pos
+                Value
+                  BinaryExpr +
+                    Identifier pos
+                    IntLiteral 1
+            Else
+              IfStatement
+                Condition
+                  BinaryExpr and
+                    BinaryExpr and
+                      BinaryExpr ==
+                        Identifier ch
+                        IntLiteral 47
+                      BinaryExpr <
+                        BinaryExpr +
+                          Identifier pos
+                          IntLiteral 1
+                        Identifier slen
+                    BinaryExpr ==
+                      CallExpr
+                        Callee
+                          Identifier char_at
+                        Args
+                          Identifier source
+                          BinaryExpr +
+                            Identifier pos
+                            IntLiteral 1
+                      IntLiteral 47
+                Then
+                  LetStatement end: i64
+                    BinaryExpr +
+                      Identifier pos
+                      IntLiteral 2
+                  WhileStatement
+                    Condition
+                      BinaryExpr <
+                        Identifier end
+                        Identifier slen
+                    IfStatement
+                      Condition
+                        BinaryExpr ==
+                          CallExpr
+                            Callee
+                              Identifier char_at
+                            Args
+                              Identifier source
+                              Identifier end
+                          IntLiteral 10
+                      Then
+                        BreakStatement
+                    Assignment
+                      Target
+                        Identifier end
+                      Value
+                        BinaryExpr +
+                          Identifier end
+                          IntLiteral 1
+                  Assignment
+                    Target
+                      Identifier pos
+                    Value
+                      Identifier end
+                Else
+                  IfStatement
+                    Condition
+                      CallExpr
+                        Callee
+                          Identifier is_alpha
+                        Args
+                          Identifier ch
+                    Then
+                      LetStatement end: i64
+                        CallExpr
+                          Callee
+                            Identifier skip_while
+                          Args
+                            Identifier source
+                            Identifier pos
+                            Identifier is_alnum
+                      LetStatement word: string
+                        CallExpr
+                          Callee
+                            Identifier substring
+                          Args
+                            Identifier source
+                            Identifier pos
+                            BinaryExpr -
+                              Identifier end
+                              Identifier pos
+                      IfStatement
+                        Condition
+                          CallExpr
+                            Callee
+                              Identifier is_keyword
+                            Args
+                              Identifier word
+                        Then
+                          Assignment
+                            Target
+                              Identifier tokens
+                            Value
+                              CallExpr
+                                Callee
+                                  FieldExpr .push
+                                    Identifier tokens
+                                Args
+                                  CallExpr
+                                    Callee
+                                      Identifier make_token
+                                    Args
+                                      CallExpr
+                                        Callee
+                                          Identifier TK_KW
+                                      Identifier pos
+                                      BinaryExpr -
+                                        Identifier end
+                                        Identifier pos
+                        Else
+                          Assignment
+                            Target
+                              Identifier tokens
+                            Value
+                              CallExpr
+                                Callee
+                                  FieldExpr .push
+                                    Identifier tokens
+                                Args
+                                  CallExpr
+                                    Callee
+                                      Identifier make_token
+                                    Args
+                                      CallExpr
+                                        Callee
+                                          Identifier TK_IDENT
+                                      Identifier pos
+                                      BinaryExpr -
+                                        Identifier end
+                                        Identifier pos
+                      Assignment
+                        Target
+                          Identifier pos
+                        Value
+                          Identifier end
+                    Else
+                      IfStatement
+                        Condition
+                          CallExpr
+                            Callee
+                              Identifier is_digit
+                            Args
+                              Identifier ch
+                        Then
+                          LetStatement end: i64
+                            CallExpr
+                              Callee
+                                Identifier skip_while
+                              Args
+                                Identifier source
+                                Identifier pos
+                                Identifier is_digit
+                          Assignment
+                            Target
+                              Identifier tokens
+                            Value
+                              CallExpr
+                                Callee
+                                  FieldExpr .push
+                                    Identifier tokens
+                                Args
+                                  CallExpr
+                                    Callee
+                                      Identifier make_token
+                                    Args
+                                      CallExpr
+                                        Callee
+                                          Identifier TK_INT
+                                      Identifier pos
+                                      BinaryExpr -
+                                        Identifier end
+                                        Identifier pos
+                          Assignment
+                            Target
+                              Identifier pos
+                            Value
+                              Identifier end
+                        Else
+                          IfStatement
+                            Condition
+                              BinaryExpr ==
+                                Identifier ch
+                                IntLiteral 34
+                            Then
+                              LetStatement end: i64
+                                BinaryExpr +
+                                  Identifier pos
+                                  IntLiteral 1
+                              LetStatement found_end: bool
+                                BoolLiteral false
+                              WhileStatement
+                                Condition
+                                  BinaryExpr <
+                                    Identifier end
+                                    Identifier slen
+                                IfStatement
+                                  Condition
+                                    BinaryExpr ==
+                                      CallExpr
+                                        Callee
+                                          Identifier char_at
+                                        Args
+                                          Identifier source
+                                          Identifier end
+                                      IntLiteral 34
+                                  Then
+                                    Assignment
+                                      Target
+                                        Identifier found_end
+                                      Value
+                                        BoolLiteral true
+                                    BreakStatement
+                                Assignment
+                                  Target
+                                    Identifier end
+                                  Value
+                                    BinaryExpr +
+                                      Identifier end
+                                      IntLiteral 1
+                              IfStatement
+                                Condition
+                                  Identifier found_end
+                                Then
+                                  Assignment
+                                    Target
+                                      Identifier tokens
+                                    Value
+                                      CallExpr
+                                        Callee
+                                          FieldExpr .push
+                                            Identifier tokens
+                                        Args
+                                          CallExpr
+                                            Callee
+                                              Identifier make_token
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier TK_STRING
+                                              Identifier pos
+                                              BinaryExpr -
+                                                BinaryExpr +
+                                                  Identifier end
+                                                  IntLiteral 1
+                                                Identifier pos
+                                  Assignment
+                                    Target
+                                      Identifier pos
+                                    Value
+                                      BinaryExpr +
+                                        Identifier end
+                                        IntLiteral 1
+                                Else
+                                  Assignment
+                                    Target
+                                      Identifier tokens
+                                    Value
+                                      CallExpr
+                                        Callee
+                                          FieldExpr .push
+                                            Identifier tokens
+                                        Args
+                                          CallExpr
+                                            Callee
+                                              Identifier make_token
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier TK_ERROR
+                                              Identifier pos
+                                              BinaryExpr -
+                                                Identifier slen
+                                                Identifier pos
+                                  Assignment
+                                    Target
+                                      Identifier pos
+                                    Value
+                                      Identifier slen
+                            Else
+                              IfStatement
+                                Condition
+                                  BinaryExpr <
+                                    BinaryExpr +
+                                      Identifier pos
+                                      IntLiteral 1
+                                    Identifier slen
+                                Then
+                                  LetStatement next: i32
+                                    CallExpr
+                                      Callee
+                                        Identifier char_at
+                                      Args
+                                        Identifier source
+                                        BinaryExpr +
+                                          Identifier pos
+                                          IntLiteral 1
+                                  IfStatement
+                                    Condition
+                                      BinaryExpr or
+                                        BinaryExpr or
+                                          BinaryExpr or
+                                            BinaryExpr or
+                                              BinaryExpr or
+                                                BinaryExpr or
+                                                  BinaryExpr or
+                                                    BinaryExpr and
+                                                      BinaryExpr ==
+                                                        Identifier ch
+                                                        IntLiteral 61
+                                                      BinaryExpr ==
+                                                        Identifier next
+                                                        IntLiteral 61
+                                                    BinaryExpr and
+                                                      BinaryExpr ==
+                                                        Identifier ch
+                                                        IntLiteral 33
+                                                      BinaryExpr ==
+                                                        Identifier next
+                                                        IntLiteral 61
+                                                  BinaryExpr and
+                                                    BinaryExpr ==
+                                                      Identifier ch
+                                                      IntLiteral 60
+                                                    BinaryExpr ==
+                                                      Identifier next
+                                                      IntLiteral 61
+                                                BinaryExpr and
+                                                  BinaryExpr ==
+                                                    Identifier ch
+                                                    IntLiteral 62
+                                                  BinaryExpr ==
+                                                    Identifier next
+                                                    IntLiteral 61
+                                              BinaryExpr and
+                                                BinaryExpr ==
+                                                  Identifier ch
+                                                  IntLiteral 45
+                                                BinaryExpr ==
+                                                  Identifier next
+                                                  IntLiteral 62
+                                            BinaryExpr and
+                                              BinaryExpr ==
+                                                Identifier ch
+                                                IntLiteral 61
+                                              BinaryExpr ==
+                                                Identifier next
+                                                IntLiteral 62
+                                          BinaryExpr and
+                                            BinaryExpr ==
+                                              Identifier ch
+                                              IntLiteral 124
+                                            BinaryExpr ==
+                                              Identifier next
+                                              IntLiteral 62
+                                        BinaryExpr and
+                                          BinaryExpr ==
+                                            Identifier ch
+                                            IntLiteral 58
+                                          BinaryExpr ==
+                                            Identifier next
+                                            IntLiteral 58
+                                    Then
+                                      Assignment
+                                        Target
+                                          Identifier tokens
+                                        Value
+                                          CallExpr
+                                            Callee
+                                              FieldExpr .push
+                                                Identifier tokens
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier make_token
+                                                Args
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier TK_OP
+                                                  Identifier pos
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier to_i64
+                                                    Args
+                                                      IntLiteral 2
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 2
+                                    Else
+                                      Assignment
+                                        Target
+                                          Identifier tokens
+                                        Value
+                                          CallExpr
+                                            Callee
+                                              FieldExpr .push
+                                                Identifier tokens
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier make_token
+                                                Args
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier TK_OP
+                                                  Identifier pos
+                                                  CallExpr
+                                                    Callee
+                                                      Identifier to_i64
+                                                    Args
+                                                      IntLiteral 1
+                                      Assignment
+                                        Target
+                                          Identifier pos
+                                        Value
+                                          BinaryExpr +
+                                            Identifier pos
+                                            IntLiteral 1
+                                Else
+                                  Assignment
+                                    Target
+                                      Identifier tokens
+                                    Value
+                                      CallExpr
+                                        Callee
+                                          FieldExpr .push
+                                            Identifier tokens
+                                        Args
+                                          CallExpr
+                                            Callee
+                                              Identifier make_token
+                                            Args
+                                              CallExpr
+                                                Callee
+                                                  Identifier TK_OP
+                                              Identifier pos
+                                              CallExpr
+                                                Callee
+                                                  Identifier to_i64
+                                                Args
+                                                  IntLiteral 1
+                                  Assignment
+                                    Target
+                                      Identifier pos
+                                    Value
+                                      BinaryExpr +
+                                        Identifier pos
+                                        IntLiteral 1
+    ReturnStatement
+      Identifier tokens
+  FunctionDecl count_by_kind
+    Param tokens: Vector<Token>
+    ReturnType: i32
+    LetStatement kw_count: i32
+      IntLiteral 0
+    LetStatement ident_count: i32
+      IntLiteral 0
+    LetStatement int_count: i32
+      IntLiteral 0
+    LetStatement string_count: i32
+      IntLiteral 0
+    LetStatement op_count: i32
+      IntLiteral 0
+    LetStatement newline_count: i32
+      IntLiteral 0
+    LetStatement error_count: i32
+      IntLiteral 0
+    ForStatement tok
+      Iterable
+        CallExpr
+          Callee
+            FieldExpr .iter
+              Identifier tokens
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_KW
+        Then
+          Assignment
+            Target
+              Identifier kw_count
+            Value
+              BinaryExpr +
+                Identifier kw_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_IDENT
+        Then
+          Assignment
+            Target
+              Identifier ident_count
+            Value
+              BinaryExpr +
+                Identifier ident_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_INT
+        Then
+          Assignment
+            Target
+              Identifier int_count
+            Value
+              BinaryExpr +
+                Identifier int_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_STRING
+        Then
+          Assignment
+            Target
+              Identifier string_count
+            Value
+              BinaryExpr +
+                Identifier string_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_OP
+        Then
+          Assignment
+            Target
+              Identifier op_count
+            Value
+              BinaryExpr +
+                Identifier op_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_NEWLINE
+        Then
+          Assignment
+            Target
+              Identifier newline_count
+            Value
+              BinaryExpr +
+                Identifier newline_count
+                IntLiteral 1
+      IfStatement
+        Condition
+          BinaryExpr ==
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_ERROR
+        Then
+          Assignment
+            Target
+              Identifier error_count
+            Value
+              BinaryExpr +
+                Identifier error_count
+                IntLiteral 1
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  keywords:    "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier kw_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  identifiers: "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier ident_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  integers:    "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier int_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  strings:     "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier string_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  operators:   "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier op_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  newlines:    "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier newline_count
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  errors:      "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier error_count
+    ReturnStatement
+      BinaryExpr +
+        BinaryExpr +
+          BinaryExpr +
+            BinaryExpr +
+              BinaryExpr +
+                BinaryExpr +
+                  Identifier kw_count
+                  Identifier ident_count
+                Identifier int_count
+              Identifier string_count
+            Identifier op_count
+          Identifier newline_count
+        Identifier error_count
+  FunctionDecl check_delimiters
+    Param tokens: Vector<Token>
+    Param source: string
+    ReturnType: bool
+    LetStatement paren_depth: i32
+      IntLiteral 0
+    LetStatement bracket_depth: i32
+      IntLiteral 0
+    LetStatement balanced: bool
+      BoolLiteral true
+    ForStatement tok
+      Iterable
+        CallExpr
+          Callee
+            FieldExpr .iter
+              Identifier tokens
+      IfStatement
+        Condition
+          BinaryExpr and
+            BinaryExpr ==
+              FieldExpr .kind
+                Identifier tok
+              CallExpr
+                Callee
+                  Identifier TK_OP
+            BinaryExpr ==
+              FieldExpr .len
+                Identifier tok
+              CallExpr
+                Callee
+                  Identifier to_i64
+                Args
+                  IntLiteral 1
+        Then
+          LetStatement ch: i32
+            CallExpr
+              Callee
+                Identifier char_at
+              Args
+                Identifier source
+                FieldExpr .offset
+                  Identifier tok
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 40
+            Then
+              Assignment
+                Target
+                  Identifier paren_depth
+                Value
+                  BinaryExpr +
+                    Identifier paren_depth
+                    IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 41
+            Then
+              Assignment
+                Target
+                  Identifier paren_depth
+                Value
+                  BinaryExpr -
+                    Identifier paren_depth
+                    IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 91
+            Then
+              Assignment
+                Target
+                  Identifier bracket_depth
+                Value
+                  BinaryExpr +
+                    Identifier bracket_depth
+                    IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr ==
+                Identifier ch
+                IntLiteral 93
+            Then
+              Assignment
+                Target
+                  Identifier bracket_depth
+                Value
+                  BinaryExpr -
+                    Identifier bracket_depth
+                    IntLiteral 1
+          IfStatement
+            Condition
+              BinaryExpr <
+                Identifier paren_depth
+                IntLiteral 0
+            Then
+              Assignment
+                Target
+                  Identifier balanced
+                Value
+                  BoolLiteral false
+          IfStatement
+            Condition
+              BinaryExpr <
+                Identifier bracket_depth
+                IntLiteral 0
+            Then
+              Assignment
+                Target
+                  Identifier balanced
+                Value
+                  BoolLiteral false
+    IfStatement
+      Condition
+        BinaryExpr !=
+          Identifier paren_depth
+          IntLiteral 0
+      Then
+        Assignment
+          Target
+            Identifier balanced
+          Value
+            BoolLiteral false
+    IfStatement
+      Condition
+        BinaryExpr !=
+          Identifier bracket_depth
+          IntLiteral 0
+      Then
+        Assignment
+          Target
+            Identifier balanced
+          Value
+            BoolLiteral false
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  parens:   depth "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier paren_depth
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "  brackets: depth "
+            CallExpr
+              Callee
+                Identifier i32_to_string
+              Args
+                Identifier bracket_depth
+    ReturnStatement
+      Identifier balanced
+  FunctionDecl nontrivia_head
+    Param tokens: Vector<Token>
+    Param source: string
+    Param limit: i32
+    ReturnType: i32
+    LetStatement printed: i32
+      IntLiteral 0
+    LetStatement i: i64
+      IntLiteral 0
+    WhileStatement
+      Condition
+        BinaryExpr and
+          BinaryExpr <
+            Identifier i
+            CallExpr
+              Callee
+                FieldExpr .length
+                  Identifier tokens
+          BinaryExpr <
+            Identifier printed
+            Identifier limit
+      LetStatement tok: Token
+        CallExpr
+          Callee
+            FieldExpr .get
+              Identifier tokens
+          Args
+            Identifier i
+      IfStatement
+        Condition
+          BinaryExpr !=
+            FieldExpr .kind
+              Identifier tok
+            CallExpr
+              Callee
+                Identifier TK_NEWLINE
+        Then
+          LetStatement lexeme: string
+            CallExpr
+              Callee
+                Identifier substring
+              Args
+                Identifier source
+                FieldExpr .offset
+                  Identifier tok
+                FieldExpr .len
+                  Identifier tok
+          ExpressionStatement
+            CallExpr
+              Callee
+                Identifier print
+              Args
+                BinaryExpr +
+                  BinaryExpr +
+                    BinaryExpr +
+                      StringLiteral "  "
+                      CallExpr
+                        Callee
+                          Identifier kind_name
+                        Args
+                          FieldExpr .kind
+                            Identifier tok
+                    StringLiteral " "
+                  Identifier lexeme
+          Assignment
+            Target
+              Identifier printed
+            Value
+              BinaryExpr +
+                Identifier printed
+                IntLiteral 1
+      Assignment
+        Target
+          Identifier i
+        Value
+          BinaryExpr +
+            Identifier i
+            IntLiteral 1
+    ReturnStatement
+      Identifier printed
+  FunctionDecl main
+    ReturnType: i32
+    LetStatement self_path: string
+      StringLiteral "examples/bootstrap_probe/vector_tokenizer.dao"
+    IfStatement
+      Condition
+        BinaryExpr ==
+          CallExpr
+            Callee
+              Identifier file_exists
+            Args
+              Identifier self_path
+          BoolLiteral false
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier eprint
+            Args
+              BinaryExpr +
+                StringLiteral "file not found: "
+                Identifier self_path
+        ReturnStatement
+          IntLiteral 1
+    LetStatement source: string
+      CallExpr
+        Callee
+          Identifier read_file
+        Args
+          Identifier self_path
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "=== vector_tokenizer: self-lex ==="
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "source bytes: "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    Identifier length
+                  Args
+                    Identifier source
+    LetStatement tokens: Vector<Token>
+      CallExpr
+        Callee
+          Identifier lex
+        Args
+          Identifier source
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          BinaryExpr +
+            StringLiteral "total tokens: "
+            CallExpr
+              Callee
+                Identifier i64_to_string
+              Args
+                CallExpr
+                  Callee
+                    FieldExpr .length
+                      Identifier tokens
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "--- token distribution ---"
+    LetStatement total: i32
+      CallExpr
+        Callee
+          Identifier count_by_kind
+        Args
+          Identifier tokens
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "--- delimiter balance ---"
+    LetStatement balanced: bool
+      CallExpr
+        Callee
+          Identifier check_delimiters
+        Args
+          Identifier tokens
+          Identifier source
+    IfStatement
+      Condition
+        Identifier balanced
+      Then
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "  result: balanced"
+      Else
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "  result: UNBALANCED"
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral ""
+    ExpressionStatement
+      CallExpr
+        Callee
+          Identifier print
+        Args
+          StringLiteral "--- nontrivia head (first 20) ---"
+    LetStatement shown: i32
+      CallExpr
+        Callee
+          Identifier nontrivia_head
+        Args
+          Identifier tokens
+          Identifier source
+          IntLiteral 20
+    IfStatement
+      Condition
+        BinaryExpr >
+          CallExpr
+            Callee
+              FieldExpr .length
+                Identifier tokens
+          CallExpr
+            Callee
+              Identifier to_i64
+            Args
+              IntLiteral 0
+      Then
+        LetStatement last: Token
+          CallExpr
+            Callee
+              FieldExpr .get
+                Identifier tokens
+            Args
+              BinaryExpr -
+                CallExpr
+                  Callee
+                    FieldExpr .length
+                      Identifier tokens
+                IntLiteral 1
+        LetStatement last_lexeme: string
+          CallExpr
+            Callee
+              Identifier substring
+            Args
+              Identifier source
+              FieldExpr .offset
+                Identifier last
+              FieldExpr .len
+                Identifier last
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral ""
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  BinaryExpr +
+                    StringLiteral "last token: "
+                    CallExpr
+                      Callee
+                        Identifier kind_name
+                      Args
+                        FieldExpr .kind
+                          Identifier last
+                  StringLiteral " "
+                Identifier last_lexeme
+    ReturnStatement
+      IntLiteral 0

--- a/testdata/ast/examples_hashmap.ast
+++ b/testdata/ast/examples_hashmap.ast
@@ -2,6 +2,46 @@ File
   ClassDecl Entry
     Field name: string
     Field value: i32
+  FunctionDecl show_entry
+    Param label: string
+    Param result: Option<Entry>
+    ReturnType: i32
+    MatchStatement
+      Scrutinee
+        Identifier result
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                BinaryExpr +
+                  Identifier label
+                  StringLiteral " = "
+                CallExpr
+                  Callee
+                    Identifier i32_to_string
+                  Args
+                    FieldExpr .value
+                      Identifier e
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              BinaryExpr +
+                Identifier label
+                StringLiteral " not found"
+    ReturnStatement
+      IntLiteral 0
   FunctionDecl main
     ReturnType: i32
     ExpressionStatement
@@ -79,64 +119,42 @@ File
                   Callee
                     FieldExpr .length
                       Identifier m
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier m
-          Args
-            StringLiteral "x"
-      Then
-        LetStatement e: Entry
+    LetStatement unused1: i32
+      CallExpr
+        Callee
+          Identifier show_entry
+        Args
+          StringLiteral "x"
           CallExpr
             Callee
               FieldExpr .get
                 Identifier m
             Args
               StringLiteral "x"
-        ExpressionStatement
-          CallExpr
-            Callee
-              Identifier print
-            Args
-              BinaryExpr +
-                StringLiteral "x = "
-                CallExpr
-                  Callee
-                    Identifier i32_to_string
-                  Args
-                    FieldExpr .value
-                      Identifier e
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier m
-          Args
-            StringLiteral "y"
-      Then
-        LetStatement e: Entry
+    LetStatement unused2: i32
+      CallExpr
+        Callee
+          Identifier show_entry
+        Args
+          StringLiteral "y"
           CallExpr
             Callee
               FieldExpr .get
                 Identifier m
             Args
               StringLiteral "y"
-        ExpressionStatement
+    LetStatement unused3: i32
+      CallExpr
+        Callee
+          Identifier show_entry
+        Args
+          StringLiteral "w"
           CallExpr
             Callee
-              Identifier print
+              FieldExpr .get
+                Identifier m
             Args
-              BinaryExpr +
-                StringLiteral "y = "
-                CallExpr
-                  Callee
-                    Identifier i32_to_string
-                  Args
-                    FieldExpr .value
-                      Identifier e
+              StringLiteral "w"
     Assignment
       Target
         Identifier m
@@ -153,57 +171,18 @@ File
               Args
                 StringLiteral "x"
                 IntLiteral 99
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier m
-          Args
-            StringLiteral "x"
-      Then
-        LetStatement e: Entry
+    LetStatement unused4: i32
+      CallExpr
+        Callee
+          Identifier show_entry
+        Args
+          StringLiteral "x (updated)"
           CallExpr
             Callee
               FieldExpr .get
                 Identifier m
             Args
               StringLiteral "x"
-        ExpressionStatement
-          CallExpr
-            Callee
-              Identifier print
-            Args
-              BinaryExpr +
-                StringLiteral "x (updated) = "
-                CallExpr
-                  Callee
-                    Identifier i32_to_string
-                  Args
-                    FieldExpr .value
-                      Identifier e
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier m
-          Args
-            StringLiteral "w"
-      Then
-        ExpressionStatement
-          CallExpr
-            Callee
-              Identifier print
-            Args
-              StringLiteral "w found (unexpected)"
-      Else
-        ExpressionStatement
-          CallExpr
-            Callee
-              Identifier print
-            Args
-              StringLiteral "w not found (correct)"
     LetStatement big
       CallExpr
         Callee
@@ -335,15 +314,20 @@ File
                   Callee
                     FieldExpr .length
                       Identifier big
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier big
-          Args
-            StringLiteral "j"
-      Then
+    LetStatement rj: Option<i32>
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier big
+        Args
+          StringLiteral "j"
+    MatchStatement
+      Scrutinee
+        Identifier rj
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
         ExpressionStatement
           CallExpr
             Callee
@@ -355,21 +339,31 @@ File
                   Callee
                     Identifier i32_to_string
                   Args
-                    CallExpr
-                      Callee
-                        FieldExpr .get
-                          Identifier big
-                      Args
-                        StringLiteral "j"
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier big
-          Args
-            StringLiteral "a"
-      Then
+                    Identifier v
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "j not found"
+    LetStatement ra: Option<i32>
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier big
+        Args
+          StringLiteral "a"
+    MatchStatement
+      Scrutinee
+        Identifier ra
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
         ExpressionStatement
           CallExpr
             Callee
@@ -381,85 +375,46 @@ File
                   Callee
                     Identifier i32_to_string
                   Args
-                    CallExpr
-                      Callee
-                        FieldExpr .get
-                          Identifier big
-                      Args
-                        StringLiteral "a"
-    LetStatement all_ok: bool
-      BoolLiteral true
-    IfStatement
-      Condition
-        BinaryExpr ==
-          CallExpr
-            Callee
-              FieldExpr .contains
-                Identifier big
-            Args
-              StringLiteral "a"
-          BoolLiteral false
-      Then
-        Assignment
-          Target
-            Identifier all_ok
-          Value
-            BoolLiteral false
-    IfStatement
-      Condition
-        BinaryExpr ==
-          CallExpr
-            Callee
-              FieldExpr .contains
-                Identifier big
-            Args
-              StringLiteral "e"
-          BoolLiteral false
-      Then
-        Assignment
-          Target
-            Identifier all_ok
-          Value
-            BoolLiteral false
-    IfStatement
-      Condition
-        BinaryExpr ==
-          CallExpr
-            Callee
-              FieldExpr .contains
-                Identifier big
-            Args
-              StringLiteral "j"
-          BoolLiteral false
-      Then
-        Assignment
-          Target
-            Identifier all_ok
-          Value
-            BoolLiteral false
-    IfStatement
-      Condition
-        CallExpr
-          Callee
-            FieldExpr .contains
-              Identifier big
-          Args
-            StringLiteral "missing"
-      Then
-        Assignment
-          Target
-            Identifier all_ok
-          Value
-            BoolLiteral false
-    IfStatement
-      Condition
-        Identifier all_ok
-      Then
+                    Identifier v
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
         ExpressionStatement
           CallExpr
             Callee
               Identifier print
             Args
-              StringLiteral "all keys correct after resize"
+              StringLiteral "a not found"
+    LetStatement rm: Option<i32>
+      CallExpr
+        Callee
+          FieldExpr .get
+            Identifier big
+        Args
+          StringLiteral "missing"
+    MatchStatement
+      Scrutinee
+        Identifier rm
+      Arm
+        Pattern
+          FieldExpr .Some
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "missing found (unexpected)"
+      Arm
+        Pattern
+          FieldExpr .None
+            Identifier Option
+        ExpressionStatement
+          CallExpr
+            Callee
+              Identifier print
+            Args
+              StringLiteral "missing = None (correct)"
     ReturnStatement
       IntLiteral 0

--- a/testdata/ast/stdlib_core_hashmap.ast
+++ b/testdata/ast/stdlib_core_hashmap.ast
@@ -82,7 +82,7 @@ File
     FunctionDecl get
       Param self
       Param key: string
-      ReturnType: V
+      ReturnType: Option<V>
       IfStatement
         Condition
           BinaryExpr ==
@@ -94,12 +94,9 @@ File
               Args
                 IntLiteral 0
         Then
-          ExpressionStatement
-            CallExpr
-              Callee
-                Identifier panic
-              Args
-                StringLiteral "HashMap.get: key not found"
+          ReturnStatement
+            FieldExpr .None
+              Identifier Option
       LetStatement idx: i64
         CallExpr
           Callee
@@ -136,12 +133,9 @@ File
                 Identifier st
                 IntLiteral 0
             Then
-              ExpressionStatement
-                CallExpr
-                  Callee
-                    Identifier panic
-                  Args
-                    StringLiteral "HashMap.get: key not found"
+              ReturnStatement
+                FieldExpr .None
+                  Identifier Option
           IfStatement
             Condition
               BinaryExpr ==
@@ -162,14 +156,19 @@ File
                     Identifier key
                 Then
                   ReturnStatement
-                    UnaryExpr *
-                      CallExpr
-                        Callee
-                          Identifier ptr_offset
-                        Args
-                          FieldExpr .val_data
-                            Identifier self
-                          Identifier idx
+                    CallExpr
+                      Callee
+                        FieldExpr .Some
+                          Identifier Option
+                      Args
+                        UnaryExpr *
+                          CallExpr
+                            Callee
+                              Identifier ptr_offset
+                            Args
+                              FieldExpr .val_data
+                                Identifier self
+                              Identifier idx
           Assignment
             Target
               Identifier idx
@@ -200,12 +199,9 @@ File
               BinaryExpr +
                 Identifier probes
                 IntLiteral 1
-      ExpressionStatement
-        CallExpr
-          Callee
-            Identifier panic
-          Args
-            StringLiteral "HashMap.get: key not found"
+      ReturnStatement
+        FieldExpr .None
+          Identifier Option
     FunctionDecl contains
       Param self
       Param key: string


### PR DESCRIPTION
## Summary

Fix two compiler bugs that prevented class methods from returning generic enum types like `Option<V>`. This unblocks `HashMap.get() → Option<V>` and makes the type-checker probe use honest fallible lookup.

## Highlights

- **Type registration ordering**: `register_declarations` now runs three passes — aliases, then type shells (enums/structs), then function/method signatures — so return types like `Option<V>` in hashmap.dao can reference `Option<T>` from option.dao regardless of source order
- **Monomorphization payload substitution**: `clone_function` now substitutes `MirEnumConstruct::enum_type` and `MirConstruct::struct_type` in instruction payloads, not just instruction types — fixes "cannot lower unresolved generic parameter" errors
- **HashMap.get() → Option<V>**: replaces the panicking `get()` with honest `Option.Some(value)` / `Option.None` returns
- **Probe updated**: type-checker probe uses `Option<Symbol>` from `table.get(name)` with match destructuring

## Test plan

- [x] 12/12 compiler tests pass
- [x] 28/28 type-checker probe tests pass
- [x] All 22 examples + 7 bootstrap probes compile
- [x] HashMap smoke test: Option-based get, match on Some/None, missing key returns None
- [x] Minimal repro (`class Box<V>` with `fn get_some(): Option<V>`) compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)