### PR TITLE
feat(lang): ✨ add ? (try) operator for Result<T,E> and Option<T>

### DIFF
--- a/compiler/analysis/semantic_tokens.cpp
+++ b/compiler/analysis/semantic_tokens.cpp
@@ -146,6 +146,7 @@ auto lexical_category(TokenKind kind) -> std::string_view {
   case TokenKind::Bang:
   case TokenKind::Dot:
   case TokenKind::Pipe:
+  case TokenKind::Question:
     return ""; // General operators — no frozen taxonomy category.
 
   // Punctuation
@@ -455,6 +456,11 @@ private:
       const auto& pipe = expr.as<PipeExpr>();
       visit_expr(*pipe.left);
       visit_expr(*pipe.right);
+      break;
+    }
+    case NodeKind::TryExpr: {
+      const auto& try_expr = expr.as<TryExpr>();
+      visit_expr(*try_expr.operand);
       break;
     }
     case NodeKind::Lambda: {

--- a/compiler/frontend/ast/ast.cpp
+++ b/compiler/frontend/ast/ast.cpp
@@ -44,6 +44,7 @@ auto Expr::kind() const -> NodeKind {
       [](const IndexExpr&) { return NodeKind::IndexExpr; },
       [](const FieldExpr&) { return NodeKind::FieldExpr; },
       [](const PipeExpr&) { return NodeKind::PipeExpr; },
+      [](const TryExpr&) { return NodeKind::TryExpr; },
       [](const LambdaExpr&) { return NodeKind::Lambda; },
       [](const IntLiteral&) { return NodeKind::IntLiteral; },
       [](const FloatLiteral&) { return NodeKind::FloatLiteral; },
@@ -125,6 +126,8 @@ auto node_kind_name(NodeKind kind) -> const char* {
     return "FieldExpr";
   case NodeKind::PipeExpr:
     return "PipeExpr";
+  case NodeKind::TryExpr:
+    return "TryExpr";
   case NodeKind::Lambda:
     return "Lambda";
   case NodeKind::IntLiteral:

--- a/compiler/frontend/ast/ast.h
+++ b/compiler/frontend/ast/ast.h
@@ -76,6 +76,7 @@ enum class NodeKind : std::uint8_t {
   IndexExpr,
   FieldExpr,
   PipeExpr,
+  TryExpr,
   Lambda,
   IntLiteral,
   FloatLiteral,
@@ -389,6 +390,10 @@ struct PipeExpr {
   Expr* right;
 };
 
+struct TryExpr {
+  Expr* operand;
+};
+
 struct LambdaExpr {
   std::vector<std::pair<std::string_view, Span>> params;
   Expr* body;
@@ -413,8 +418,9 @@ struct QualifiedName {
 
 using ExprPayload = std::variant<
     BinaryExpr, UnaryExpr, CallExpr, IndexExpr, FieldExpr, PipeExpr,
-    LambdaExpr, IntLiteral, FloatLiteral, StringLiteral, BoolLiteral,
-    ListLiteral, IdentifierExpr, QualifiedName, ErrorExprNode>;
+    TryExpr, LambdaExpr, IntLiteral, FloatLiteral, StringLiteral,
+    BoolLiteral, ListLiteral, IdentifierExpr, QualifiedName,
+    ErrorExprNode>;
 
 // ---------------------------------------------------------------------------
 // Type node payloads

--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -532,6 +532,12 @@ private:
           print_expr(*node.left);
           print_expr(*node.right);
         },
+        [&](const TryExpr& node) {
+          indent();
+          out_ << "TryExpr\n";
+          Scope scope(depth_);
+          print_expr(*node.operand);
+        },
         [&](const LambdaExpr& node) {
           indent();
           out_ << "Lambda";

--- a/compiler/frontend/lexer/lexer.cpp
+++ b/compiler/frontend/lexer/lexer.cpp
@@ -108,6 +108,8 @@ auto token_kind_name(TokenKind kind) -> const char* {
     return "Pipe";
   case TokenKind::PipeGt:
     return "PipeGt";
+  case TokenKind::Question:
+    return "Question";
   case TokenKind::LParen:
     return "LParen";
   case TokenKind::RParen:
@@ -345,6 +347,9 @@ private:
       return;
     case ',':
       emit(TokenKind::Comma, start, 1);
+      return;
+    case '?':
+      emit(TokenKind::Question, start, 1);
       return;
 
     case '(':

--- a/compiler/frontend/lexer/token.h
+++ b/compiler/frontend/lexer/token.h
@@ -74,6 +74,7 @@ enum class TokenKind : std::uint8_t {
   Comma,      // ,
   Pipe,       // |
   PipeGt,     // |>
+  Question,   // ?
 
   // Delimiters
   LParen,   // (

--- a/compiler/frontend/parser/parser.cpp
+++ b/compiler/frontend/parser/parser.cpp
@@ -1311,6 +1311,12 @@ private:
         expr = ctx_.alloc<Expr>(span, FieldExpr{.object = expr,
                                                   .field = field_tok.text,
                                                   .field_span = field_tok.span});
+      } else if (peek_kind() == TokenKind::Question) {
+        // Try/propagate: expr?
+        const auto& q_tok = advance(); // ?
+        Span span = {.offset = expr->span.offset,
+                     .length = (q_tok.span.offset + q_tok.span.length) - expr->span.offset};
+        expr = ctx_.alloc<Expr>(span, TryExpr{.operand = expr});
       } else if (peek_kind() == TokenKind::LBracket) {
         // Index or type-parameter application: expr[args]
         advance(); // [

--- a/compiler/frontend/resolve/resolve.cpp
+++ b/compiler/frontend/resolve/resolve.cpp
@@ -850,6 +850,11 @@ private:
       }
       break;
     }
+    case NodeKind::TryExpr: {
+      const auto& try_expr = expr.as<TryExpr>();
+      resolve_expr(*try_expr.operand, scope);
+      break;
+    }
     case NodeKind::Lambda: {
       const auto& lam = expr.as<LambdaExpr>();
 

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -1302,6 +1302,9 @@ auto TypeChecker::check_expr(const Expr* expr, const Type* expected)
   case NodeKind::PipeExpr:
     result = check_pipe(expr);
     break;
+  case NodeKind::TryExpr:
+    result = check_try(expr);
+    break;
   case NodeKind::FieldExpr:
     result = check_field(expr);
     break;
@@ -2148,6 +2151,106 @@ auto TypeChecker::check_pipe(const Expr* expr) -> const Type* {
 
   // Substitute generic params in the return type.
   return substitute_generics(fn_type->return_type(), type_bindings);
+}
+
+// ---------------------------------------------------------------------------
+// Try/propagate expressions
+// ---------------------------------------------------------------------------
+
+auto TypeChecker::check_try(const Expr* expr) -> const Type* {
+  const auto& try_expr = expr->as<TryExpr>();
+  const auto* operand_type = check_expr(try_expr.operand);
+  if (operand_type == nullptr) {
+    return nullptr;
+  }
+
+  if (operand_type->kind() != TypeKind::Enum) {
+    error(expr->span,
+          "'?' operator requires an Option or Result type, got '" +
+              print_type(operand_type) + "'");
+    return nullptr;
+  }
+
+  const auto* enum_type = static_cast<const TypeEnum*>(operand_type);
+  auto name = enum_type->name();
+
+  if (name != "Option" && name != "Result") {
+    error(expr->span,
+          "'?' operator requires an Option or Result type, got '" +
+              print_type(operand_type) + "'");
+    return nullptr;
+  }
+
+  // Validate enclosing function return type compatibility.
+  if (ctx_.return_type == nullptr) {
+    error(expr->span,
+          "'?' operator can only be used inside a function with a return type");
+    return nullptr;
+  }
+
+  const auto& variants = enum_type->variants();
+
+  if (name == "Result") {
+    // Result<T, E>: Ok(T) at variant 0, Err(E) at variant 1.
+    // The expression type is T. The enclosing function must return Result<_, E>.
+    if (variants.size() < 2 || variants[0].payload_types.empty() ||
+        variants[1].payload_types.empty()) {
+      error(expr->span, "Result type has unexpected variant structure");
+      return nullptr;
+    }
+    const auto* ok_type = variants[0].payload_types[0];
+    const auto* err_type = variants[1].payload_types[0];
+
+    // Check that the enclosing function returns Result<_, E>.
+    if (ctx_.return_type->kind() != TypeKind::Enum) {
+      error(expr->span,
+            "enclosing function must return Result to use '?' on Result, "
+            "but returns '" + print_type(ctx_.return_type) + "'");
+      return nullptr;
+    }
+    const auto* ret_enum = static_cast<const TypeEnum*>(ctx_.return_type);
+    if (ret_enum->name() != "Result") {
+      error(expr->span,
+            "enclosing function must return Result to use '?' on Result, "
+            "but returns '" + print_type(ctx_.return_type) + "'");
+      return nullptr;
+    }
+    // Check that the error types match.
+    if (ret_enum->variants().size() >= 2 &&
+        !ret_enum->variants()[1].payload_types.empty()) {
+      const auto* fn_err_type = ret_enum->variants()[1].payload_types[0];
+      if (!is_assignable(err_type, fn_err_type)) {
+        error(expr->span,
+              "error type '" + print_type(err_type) +
+                  "' is not assignable to function return error type '" +
+                  print_type(fn_err_type) + "'");
+      }
+    }
+    return ok_type;
+  }
+
+  // Option<T>: Some(T) at variant 0, None at variant 1.
+  // The expression type is T. The enclosing function must return Option<_>.
+  if (variants.empty() || variants[0].payload_types.empty()) {
+    error(expr->span, "Option type has unexpected variant structure");
+    return nullptr;
+  }
+  const auto* some_type = variants[0].payload_types[0];
+
+  if (ctx_.return_type->kind() != TypeKind::Enum) {
+    error(expr->span,
+          "enclosing function must return Option to use '?' on Option, "
+          "but returns '" + print_type(ctx_.return_type) + "'");
+    return nullptr;
+  }
+  const auto* ret_enum = static_cast<const TypeEnum*>(ctx_.return_type);
+  if (ret_enum->name() != "Option") {
+    error(expr->span,
+          "enclosing function must return Option to use '?' on Option, "
+          "but returns '" + print_type(ctx_.return_type) + "'");
+    return nullptr;
+  }
+  return some_type;
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -192,6 +192,7 @@ private:
   auto check_construct(const Expr* expr, const TypeStruct* struct_type)
       -> const Type*;
   auto check_pipe(const Expr* expr) -> const Type*;
+  auto check_try(const Expr* expr) -> const Type*;
   auto check_field(const Expr* expr) -> const Type*;
   auto lookup_method(const Type* obj_type, std::string_view name,
                      const Decl** resolved_decl = nullptr)

--- a/compiler/ir/hir/hir.cpp
+++ b/compiler/ir/hir/hir.cpp
@@ -47,6 +47,7 @@ auto HirExpr::kind() const -> HirKind {
       [](const HirField&) { return HirKind::Field; },
       [](const HirIndex&) { return HirKind::Index; },
       [](const HirPipe&) { return HirKind::Pipe; },
+      [](const HirTry&) { return HirKind::Try; },
       [](const HirLambda&) { return HirKind::Lambda; },
   }, payload);
 }
@@ -86,6 +87,7 @@ auto hir_kind_name(HirKind kind) -> const char* {
   case HirKind::Field:         return "Field";
   case HirKind::Index:         return "Index";
   case HirKind::Pipe:          return "Pipe";
+  case HirKind::Try:           return "Try";
   case HirKind::Lambda:        return "Lambda";
   }
   return "<unknown>";

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -184,6 +184,11 @@ struct HirPipe {
   HirExpr* right;
 };
 
+struct HirTry {
+  HirExpr* operand;
+  const TypeEnum* enum_type; // the Option/Result type of the operand
+};
+
 struct HirLambda {
   std::vector<HirParam> params;
   HirExpr* body;
@@ -193,7 +198,7 @@ using HirExprPayload = std::variant<
     HirIntLiteral, HirFloatLiteral, HirStringLiteral, HirBoolLiteral,
     HirSymbolRef, HirUnary, HirBinary, HirCall, HirConstruct,
     HirEnumConstruct, HirEnumDiscriminant, HirEnumPayload,
-    HirField, HirIndex, HirPipe, HirLambda>;
+    HirField, HirIndex, HirPipe, HirTry, HirLambda>;
 
 // ---------------------------------------------------------------------------
 // Container nodes — arena-allocated.

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -562,6 +562,17 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
     return ctx_.alloc<HirExpr>(span, type, HirPipe{left, right});
   }
 
+  case NodeKind::TryExpr: {
+    const auto& try_expr = expr->as<TryExpr>();
+    auto* operand = lower_expr(try_expr.operand);
+    const TypeEnum* enum_type = nullptr;
+    if (operand != nullptr && operand->type != nullptr &&
+        operand->type->kind() == TypeKind::Enum) {
+      enum_type = static_cast<const TypeEnum*>(operand->type);
+    }
+    return ctx_.alloc<HirExpr>(span, type, HirTry{operand, enum_type});
+  }
+
   case NodeKind::FieldExpr: {
     const auto& field = expr->as<FieldExpr>();
     // Enum variant access: lower to integer constant with enum type.

--- a/compiler/ir/hir/hir_kind.h
+++ b/compiler/ir/hir/hir_kind.h
@@ -46,6 +46,7 @@ enum class HirKind : std::uint8_t {
   Field,
   Index,
   Pipe,
+  Try,
   Lambda,
 };
 

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -424,6 +424,14 @@ private:
           print_expr(*node.left);
           print_expr(*node.right);
         },
+        [&](const HirTry& node) {
+          indent();
+          out_ << "Try";
+          print_type_annotation(expr.type);
+          out_ << "\n";
+          Scope scope(depth_);
+          print_expr(*node.operand);
+        },
         [&](const HirLambda& node) {
           indent();
           out_ << "Lambda";

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -441,6 +441,69 @@ auto MirBuilder::lower_expr_value(const HirExpr& expr) -> MirValueId {
         return emit_value(expr, MirEnumPayload{
             val, pay.variant_index, pay.field_index});
       },
+      [&](const HirTry& try_node) -> MirValueId {
+        // Lower operand (the Result/Option value).
+        auto operand_val = lower_expr_value(*try_node.operand);
+        const auto* enum_type = try_node.enum_type;
+        bool is_result = enum_type != nullptr && enum_type->name() == "Result";
+
+        // Extract discriminant (i32 — matches LLVM enum layout).
+        auto discr = emit_value(types_.builtin(BuiltinKind::I32), expr.span,
+                                MirEnumDiscriminant{operand_val});
+
+        // Compare discriminant to 0 (the success variant: Ok/Some).
+        auto zero = emit_value(types_.builtin(BuiltinKind::I32), expr.span,
+                               MirConstInt{0});
+        auto cmp = emit_value(types_.bool_type(), expr.span,
+                              MirBinary{BinaryOp::EqEq, discr, zero});
+
+        // Create basic blocks.
+        auto* ok_bb = fresh_block();
+        auto* err_bb = fresh_block();
+        auto* merge_bb = fresh_block();
+
+        emit_terminator(expr.span, MirCondBr{cmp, ok_bb->id, err_bb->id});
+
+        // Error/None block: propagate the error or None.
+        switch_to_block(err_bb);
+        if (is_result) {
+          // Extract Err payload from variant 1, field 0.
+          auto err_payload = emit_value(
+              enum_type->variants()[1].payload_types[0], expr.span,
+              MirEnumPayload{operand_val, 1, 0});
+          // Construct Result.Err(err_payload) with the function's return type.
+          const auto* ret_enum_type = static_cast<const TypeEnum*>(
+              current_fn_->return_type);
+          auto* err_args = ctx_.alloc<std::vector<MirValueId>>();
+          err_args->push_back(err_payload);
+          auto err_result = emit_value(
+              current_fn_->return_type, expr.span,
+              MirEnumConstruct{ret_enum_type, 1, err_args});
+          emit_region_exits(expr.span);
+          emit_terminator(expr.span, MirReturn{err_result, true});
+        } else {
+          // Option: construct Option.None (variant 1, no payload).
+          const auto* ret_enum_type = static_cast<const TypeEnum*>(
+              current_fn_->return_type);
+          auto* empty_args = ctx_.alloc<std::vector<MirValueId>>();
+          auto none_result = emit_value(
+              current_fn_->return_type, expr.span,
+              MirEnumConstruct{ret_enum_type, 1, empty_args});
+          emit_region_exits(expr.span);
+          emit_terminator(expr.span, MirReturn{none_result, true});
+        }
+
+        // Ok/Some block: extract the success payload.
+        switch_to_block(ok_bb);
+        auto ok_payload = emit_value(
+            expr.type, expr.span,
+            MirEnumPayload{operand_val, 0, 0});
+        emit_terminator(expr.span, MirBr{merge_bb->id});
+
+        // Merge block: the value produced by ? is the ok payload.
+        switch_to_block(merge_bb);
+        return ok_payload;
+      },
       [&](const HirPipe& pipe) -> MirValueId {
         auto left_val = lower_expr_value(*pipe.left);
         auto callee_val = lower_expr_value(*pipe.right);

--- a/examples/bootstrap_probe/type_checker.dao
+++ b/examples/bootstrap_probe/type_checker.dao
@@ -5,9 +5,9 @@
 // resolve + typecheck pass over the arena.
 //
 // Tests: HashMap<V> for O(1) symbol lookup, Option<V> for fallible
-// map get, Result<T, E> for error-bearing analysis, multi-pass
-// compiler architecture (lex → parse → analyze), and match
-// destructuring for control flow.
+// map get, Result<T, E> with ? operator for error propagation,
+// multi-pass compiler architecture (lex → parse → analyze), and
+// match destructuring for control flow.
 //
 // Language surface:
 //   let x = 5; let y = x + 3; y > 0
@@ -495,33 +495,21 @@ fn check_expr(arena: Vector<Node>, idx: i64, table: HashMap<Symbol>, source: str
           return Result.Err("undefined variable '" + name + "'")
 
     Node.Binary(op, left, right):
-      let lt: Result<i32, string> = check_expr(arena, left, table, source)
-      match lt:
-        Result.Err(msg):
-          return Result.Err(msg)
-        Result.Ok(left_ty):
-          let rt: Result<i32, string> = check_expr(arena, right, table, source)
-          match rt:
-            Result.Err(msg):
-              return Result.Err(msg)
-            Result.Ok(right_ty):
-              return check_binary_op(op, left_ty, right_ty)
+      let left_ty: i32 = check_expr(arena, left, table, source)?
+      let right_ty: i32 = check_expr(arena, right, table, source)?
+      return check_binary_op(op, left_ty, right_ty)
 
     Node.Unary(op, operand):
-      let ot: Result<i32, string> = check_expr(arena, operand, table, source)
-      match ot:
-        Result.Err(msg):
-          return Result.Err(msg)
-        Result.Ok(operand_ty):
-          if op == TK.Minus:
-            if operand_ty == TY_INT():
-              return Result.Ok(TY_INT())
-            return Result.Err("unary '-' requires Int, got " + type_name(operand_ty))
-          if op == TK.KwNot:
-            if operand_ty == TY_BOOL():
-              return Result.Ok(TY_BOOL())
-            return Result.Err("'not' requires Bool, got " + type_name(operand_ty))
-          return Result.Err("unknown unary operator")
+      let operand_ty: i32 = check_expr(arena, operand, table, source)?
+      if op == TK.Minus:
+        if operand_ty == TY_INT():
+          return Result.Ok(TY_INT())
+        return Result.Err("unary '-' requires Int, got " + type_name(operand_ty))
+      if op == TK.KwNot:
+        if operand_ty == TY_BOOL():
+          return Result.Ok(TY_BOOL())
+        return Result.Err("'not' requires Bool, got " + type_name(operand_ty))
+      return Result.Err("unknown unary operator")
 
   return Result.Err("unknown node kind")
 
@@ -535,21 +523,12 @@ fn analyze(arena: Vector<Node>, stmts: Vector<Stmt>, source: string): Result<i32
     let stmt: Stmt = stmts.get(i)
     match stmt:
       Stmt.Let(name_off, name_len, expr_idx):
-        let result: Result<i32, string> = check_expr(arena, expr_idx, table, source)
-        match result:
-          Result.Ok(ty):
-            let name: string = substring(source, name_off, name_len)
-            table = table.set(name, Symbol(name, ty))
-            last_ty = ty
-          Result.Err(msg):
-            return Result.Err(msg)
+        let ty: i32 = check_expr(arena, expr_idx, table, source)?
+        let name: string = substring(source, name_off, name_len)
+        table = table.set(name, Symbol(name, ty))
+        last_ty = ty
       Stmt.Expr(expr_idx):
-        let result: Result<i32, string> = check_expr(arena, expr_idx, table, source)
-        match result:
-          Result.Ok(ty):
-            last_ty = ty
-          Result.Err(msg):
-            return Result.Err(msg)
+        last_ty = check_expr(arena, expr_idx, table, source)?
     i = i + 1
   return Result.Ok(last_ty)
 

--- a/testdata/ast/examples_bootstrap_probe_type_checker.ast
+++ b/testdata/ast/examples_bootstrap_probe_type_checker.ast
@@ -2612,180 +2612,129 @@ File
         Pattern
           FieldExpr .Binary
             Identifier Node
-        LetStatement lt: Result<i32, string>
+        LetStatement left_ty: i32
+          TryExpr
+            CallExpr
+              Callee
+                Identifier check_expr
+              Args
+                Identifier arena
+                Identifier left
+                Identifier table
+                Identifier source
+        LetStatement right_ty: i32
+          TryExpr
+            CallExpr
+              Callee
+                Identifier check_expr
+              Args
+                Identifier arena
+                Identifier right
+                Identifier table
+                Identifier source
+        ReturnStatement
           CallExpr
             Callee
-              Identifier check_expr
+              Identifier check_binary_op
             Args
-              Identifier arena
-              Identifier left
-              Identifier table
-              Identifier source
-        MatchStatement
-          Scrutinee
-            Identifier lt
-          Arm
-            Pattern
-              FieldExpr .Err
-                Identifier Result
-            ReturnStatement
-              CallExpr
-                Callee
-                  FieldExpr .Err
-                    Identifier Result
-                Args
-                  Identifier msg
-          Arm
-            Pattern
-              FieldExpr .Ok
-                Identifier Result
-            LetStatement rt: Result<i32, string>
-              CallExpr
-                Callee
-                  Identifier check_expr
-                Args
-                  Identifier arena
-                  Identifier right
-                  Identifier table
-                  Identifier source
-            MatchStatement
-              Scrutinee
-                Identifier rt
-              Arm
-                Pattern
-                  FieldExpr .Err
-                    Identifier Result
-                ReturnStatement
-                  CallExpr
-                    Callee
-                      FieldExpr .Err
-                        Identifier Result
-                    Args
-                      Identifier msg
-              Arm
-                Pattern
-                  FieldExpr .Ok
-                    Identifier Result
-                ReturnStatement
-                  CallExpr
-                    Callee
-                      Identifier check_binary_op
-                    Args
-                      Identifier op
-                      Identifier left_ty
-                      Identifier right_ty
+              Identifier op
+              Identifier left_ty
+              Identifier right_ty
       Arm
         Pattern
           FieldExpr .Unary
             Identifier Node
-        LetStatement ot: Result<i32, string>
-          CallExpr
-            Callee
-              Identifier check_expr
-            Args
-              Identifier arena
-              Identifier operand
-              Identifier table
-              Identifier source
-        MatchStatement
-          Scrutinee
-            Identifier ot
-          Arm
-            Pattern
-              FieldExpr .Err
-                Identifier Result
-            ReturnStatement
-              CallExpr
-                Callee
-                  FieldExpr .Err
-                    Identifier Result
-                Args
-                  Identifier msg
-          Arm
-            Pattern
-              FieldExpr .Ok
-                Identifier Result
+        LetStatement operand_ty: i32
+          TryExpr
+            CallExpr
+              Callee
+                Identifier check_expr
+              Args
+                Identifier arena
+                Identifier operand
+                Identifier table
+                Identifier source
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .Minus
+                Identifier TK
+          Then
             IfStatement
               Condition
                 BinaryExpr ==
-                  Identifier op
-                  FieldExpr .Minus
-                    Identifier TK
+                  Identifier operand_ty
+                  CallExpr
+                    Callee
+                      Identifier TY_INT
               Then
-                IfStatement
-                  Condition
-                    BinaryExpr ==
-                      Identifier operand_ty
+                ReturnStatement
+                  CallExpr
+                    Callee
+                      FieldExpr .Ok
+                        Identifier Result
+                    Args
                       CallExpr
                         Callee
                           Identifier TY_INT
-                  Then
-                    ReturnStatement
-                      CallExpr
-                        Callee
-                          FieldExpr .Ok
-                            Identifier Result
-                        Args
-                          CallExpr
-                            Callee
-                              Identifier TY_INT
-                ReturnStatement
-                  CallExpr
-                    Callee
-                      FieldExpr .Err
-                        Identifier Result
-                    Args
-                      BinaryExpr +
-                        StringLiteral "unary '-' requires Int, got "
-                        CallExpr
-                          Callee
-                            Identifier type_name
-                          Args
-                            Identifier operand_ty
-            IfStatement
-              Condition
-                BinaryExpr ==
-                  Identifier op
-                  FieldExpr .KwNot
-                    Identifier TK
-              Then
-                IfStatement
-                  Condition
-                    BinaryExpr ==
-                      Identifier operand_ty
-                      CallExpr
-                        Callee
-                          Identifier TY_BOOL
-                  Then
-                    ReturnStatement
-                      CallExpr
-                        Callee
-                          FieldExpr .Ok
-                            Identifier Result
-                        Args
-                          CallExpr
-                            Callee
-                              Identifier TY_BOOL
-                ReturnStatement
-                  CallExpr
-                    Callee
-                      FieldExpr .Err
-                        Identifier Result
-                    Args
-                      BinaryExpr +
-                        StringLiteral "'not' requires Bool, got "
-                        CallExpr
-                          Callee
-                            Identifier type_name
-                          Args
-                            Identifier operand_ty
             ReturnStatement
               CallExpr
                 Callee
                   FieldExpr .Err
                     Identifier Result
                 Args
-                  StringLiteral "unknown unary operator"
+                  BinaryExpr +
+                    StringLiteral "unary '-' requires Int, got "
+                    CallExpr
+                      Callee
+                        Identifier type_name
+                      Args
+                        Identifier operand_ty
+        IfStatement
+          Condition
+            BinaryExpr ==
+              Identifier op
+              FieldExpr .KwNot
+                Identifier TK
+          Then
+            IfStatement
+              Condition
+                BinaryExpr ==
+                  Identifier operand_ty
+                  CallExpr
+                    Callee
+                      Identifier TY_BOOL
+              Then
+                ReturnStatement
+                  CallExpr
+                    Callee
+                      FieldExpr .Ok
+                        Identifier Result
+                    Args
+                      CallExpr
+                        Callee
+                          Identifier TY_BOOL
+            ReturnStatement
+              CallExpr
+                Callee
+                  FieldExpr .Err
+                    Identifier Result
+                Args
+                  BinaryExpr +
+                    StringLiteral "'not' requires Bool, got "
+                    CallExpr
+                      Callee
+                        Identifier type_name
+                      Args
+                        Identifier operand_ty
+        ReturnStatement
+          CallExpr
+            Callee
+              FieldExpr .Err
+                Identifier Result
+            Args
+              StringLiteral "unknown unary operator"
     ReturnStatement
       CallExpr
         Callee
@@ -2830,98 +2779,62 @@ File
           Pattern
             FieldExpr .Let
               Identifier Stmt
-          LetStatement result: Result<i32, string>
+          LetStatement ty: i32
+            TryExpr
+              CallExpr
+                Callee
+                  Identifier check_expr
+                Args
+                  Identifier arena
+                  Identifier expr_idx
+                  Identifier table
+                  Identifier source
+          LetStatement name: string
             CallExpr
               Callee
-                Identifier check_expr
+                Identifier substring
               Args
-                Identifier arena
-                Identifier expr_idx
-                Identifier table
                 Identifier source
-          MatchStatement
-            Scrutinee
-              Identifier result
-            Arm
-              Pattern
-                FieldExpr .Ok
-                  Identifier Result
-              LetStatement name: string
-                CallExpr
-                  Callee
-                    Identifier substring
-                  Args
-                    Identifier source
-                    Identifier name_off
-                    Identifier name_len
-              Assignment
-                Target
-                  Identifier table
-                Value
+                Identifier name_off
+                Identifier name_len
+          Assignment
+            Target
+              Identifier table
+            Value
+              CallExpr
+                Callee
+                  FieldExpr .set
+                    Identifier table
+                Args
+                  Identifier name
                   CallExpr
                     Callee
-                      FieldExpr .set
-                        Identifier table
+                      Identifier Symbol
                     Args
                       Identifier name
-                      CallExpr
-                        Callee
-                          Identifier Symbol
-                        Args
-                          Identifier name
-                          Identifier ty
-              Assignment
-                Target
-                  Identifier last_ty
-                Value
-                  Identifier ty
-            Arm
-              Pattern
-                FieldExpr .Err
-                  Identifier Result
-              ReturnStatement
-                CallExpr
-                  Callee
-                    FieldExpr .Err
-                      Identifier Result
-                  Args
-                    Identifier msg
+                      Identifier ty
+          Assignment
+            Target
+              Identifier last_ty
+            Value
+              Identifier ty
         Arm
           Pattern
             FieldExpr .Expr
               Identifier Stmt
-          LetStatement result: Result<i32, string>
-            CallExpr
-              Callee
-                Identifier check_expr
-              Args
-                Identifier arena
-                Identifier expr_idx
-                Identifier table
-                Identifier source
-          MatchStatement
-            Scrutinee
-              Identifier result
-            Arm
-              Pattern
-                FieldExpr .Ok
-                  Identifier Result
-              Assignment
-                Target
-                  Identifier last_ty
-                Value
-                  Identifier ty
-            Arm
-              Pattern
-                FieldExpr .Err
-                  Identifier Result
-              ReturnStatement
+          Assignment
+            Target
+              Identifier last_ty
+            Value
+              TryExpr
                 CallExpr
                   Callee
-                    FieldExpr .Err
-                      Identifier Result
+                    Identifier check_expr
                   Args
-                    Identifier msg
+                    Identifier arena
+                    Identifier expr_idx
+                    Identifier table
+                    Identifier source
       Assignment
         Target
           Identifier i

--- a/tools/playground/compiler_service/token_category.h
+++ b/tools/playground/compiler_service/token_category.h
@@ -76,6 +76,7 @@ inline auto token_category(TokenKind kind) -> std::string_view {
   case TokenKind::Comma:
   case TokenKind::Pipe:
   case TokenKind::PipeGt:
+  case TokenKind::Question:
     return "operator";
 
   // Delimiters


### PR DESCRIPTION
## Summary

Add the `?` postfix operator for early-return error/none propagation. \`expr?\` unwraps the success value from a Result or Option, or early-returns the error/none from the enclosing function.

## Highlights

- Full compiler pipeline: lexer (`Question` token) → parser (postfix in `parse_postfix()`) → AST (`TryExpr`) → type checker (validates operand type + return type compatibility) → HIR (`HirTry`) → MIR (desugared into basic blocks)
- Works for both `Result<T, E>` and `Option<T>`
- Type checker validates: operand must be Result/Option, enclosing function must return compatible Result/Option, error types must match
- MIR desugaring: discriminant check → err block (wrap + return) / ok block (extract payload) — no new MIR instructions
- Bootstrap probe rewritten with `?`: `check_expr` and `analyze` drop from 4-level nesting to 1, eliminating 6 nested match blocks (28/28 tests pass)

### Before
```dao
let lt: Result<i32, string> = check_expr(arena, left, table, source)
match lt:
  Result.Err(msg):
    return Result.Err(msg)
  Result.Ok(left_ty):
    let rt: Result<i32, string> = check_expr(arena, right, table, source)
    match rt:
      Result.Err(msg):
        return Result.Err(msg)
      Result.Ok(right_ty):
        return check_binary_op(op, left_ty, right_ty)
```

### After
```dao
let left_ty: i32 = check_expr(arena, left, table, source)?
let right_ty: i32 = check_expr(arena, right, table, source)?
return check_binary_op(op, left_ty, right_ty)
```

## Test plan

- [x] 12/12 compiler tests pass
- [x] 28/28 type-checker probe tests pass (with `?`)
- [x] All 22 examples + 7 bootstrap probes compile
- [x] Result `?`: propagates `Err`, unwraps `Ok`
- [x] Option `?`: propagates `None`, unwraps `Some`
- [x] Golden AST files regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)