### PR TITLE
docs(phase7): 📝 add Task 19 diagnostic formatter spec and fix stale Tier B status

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -290,8 +290,11 @@ Exit criteria:
 
 Tasks 6–13 (resolve, types, typecheck, HIR, MIR, LLVM backend,
 generics, coroutines) are complete or substantially complete.
+Task 18 (enum payloads and match destructuring) is complete.
 
-The next implementation tasks are sequenced below.
+The next implementation tasks are sequenced below. Task 19
+(diagnostic formatter) is the Phase 7 entry leaf — see
+`docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md`.
 
 ### Task 14 — Numeric Type Expansion
 
@@ -331,14 +334,16 @@ Status: **complete**
 
 #### Tier B — Phase 6 prerequisite
 
-Priority: **high** — C ABI interop cannot function without 64-bit
-integers.
+Status: **complete**
 
-- `i64` surface exposure: type system, parser literal support,
-  codegen, runtime hooks (`__dao_eq_i64`, `__dao_conv_i64_to_string`)
-- explicit `i32 → f64` and `f64 → i32` conversion functions with
-  the trapping semantics defined in the contract
-- widen `__dao_str_length` from i32 to i64 once i64 is surfaced
+- ✓ `i64` surface exposure: type system (`BuiltinKind::I64`,
+  `type_context.i64()`), parser recognition, LLVM backend lowering
+  (`llvm::Type::getInt64Ty`), runtime hooks (`__dao_eq_i64`,
+  `__dao_conv_i64_to_string`), stdlib extensions (`extend i64 as
+  Numeric`), working example (`examples/i64.dao`)
+- ✓ explicit numeric conversions between i32/i64 and f32/f64 with
+  trapping semantics (27-function conversion matrix)
+- ✓ `__dao_str_length` returns `int64_t`
 
 #### Tier C — Phase 6+ dedicated task
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -207,6 +207,9 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
+Status: **entry leaf selected** — diagnostic formatter as first real
+subsystem extraction (Task 19)
+
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself
 - establish a bootstrap chain from host implementation → mixed
@@ -214,10 +217,22 @@ Goals:
 - keep test parity between the host compiler and the Dao-implemented
   compiler as the handoff proceeds
 
+Entry decision:
+- six bootstrap probes (mini_lexer through type_checker) proved language
+  viability but are architecturally too simplified to extract from
+  directly (flat scope, integer type constants, string-only diagnostics)
+- the diagnostic formatter is the correct entry leaf because it is a
+  genuine compiler subsystem, is fully isolated, and forces the shared
+  substrate (Span, SourceBuffer, line/col mapping, string formatting)
+  that every subsequent extraction depends on
+- see `docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md` for the full
+  task spec
+
 Recommended bootstrap sequence:
 1. keep the initial compiler in an implementation language suited to
    rapid frontend/backend construction
-2. implement leaf or utility components in Dao first
+2. implement leaf or utility components in Dao first — starting with
+   diagnostic formatting (Task 19)
 3. migrate increasingly central compiler phases only when Dao can
    express them ergonomically and compile them reliably
 4. reach stage-2 self-hosting before claiming the compiler is truly

--- a/docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md
+++ b/docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md
@@ -93,8 +93,13 @@ Constructor helpers:
 
 ### 4. `examples/bootstrap_probe/diagnostic_formatter.dao` — formatter
 
-The formatter consumes a `SourceBuffer` and a `Vector<Diagnostic>` and
-produces formatted output. Target output format:
+The formatter consumes a `SourceBuffer`, a `Vector<Diagnostic>`, and an
+optional prelude line offset (`i64`, defaulting to 0) and produces
+formatted output. The prelude offset adjusts displayed line numbers so
+that diagnostics from user code prepended after a stdlib prelude show
+correct user-facing line numbers (matching the existing C++ driver's
+`line_offset` parameter in `print_error_diagnostics` /
+`print_diagnostics`). Target output format:
 
 ```
 test.dao:3:5: error: undefined variable 'x'
@@ -110,8 +115,8 @@ Required capabilities:
 - render context line with line number gutter
 - render caret/underline marker at the error column
 - handle multiple diagnostics sequentially
-- handle prelude line offset (diagnostics from user code that follows
-  a prepended stdlib prelude)
+- apply prelude line offset to displayed line numbers (subtract offset
+  from raw line, matching the C++ driver convention)
 
 ### 5. Test harness
 
@@ -121,8 +126,12 @@ The probe must include a self-test harness (same pattern as
 - constructs a SourceBuffer from an inline source string
 - creates diagnostics at known offsets
 - formats them and verifies the output contains expected substrings
-- tests edge cases: first line, last line, empty source, multi-byte
-  offsets, multiple diagnostics on the same line
+- tests edge cases: first line, last line, empty source, multiple
+  diagnostics on the same line, prelude line offset adjustment
+- note: all offsets and columns are byte-based, matching the existing
+  C++ `SourceBuffer` and runtime string primitives (`char_at`,
+  `substring`, `index_of` all operate on byte indices). Display-width
+  correctness for multi-byte UTF-8 sequences is explicitly deferred
 
 ## Stdlib dependencies
 

--- a/docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md
+++ b/docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md
@@ -1,0 +1,206 @@
+# Task 19 — Diagnostic Formatter (Phase 7 Entry Leaf)
+
+## Objective
+
+Implement a diagnostic formatter in pure Dao as the first real Phase 7
+self-hosting leaf extraction. This forces foundational stdlib
+infrastructure (`Span`, `SourceBuffer`, line/column mapping, snippet
+extraction) that every subsequent self-hosting subsystem will depend on.
+
+## Motivation
+
+The bootstrap probes (especially `type_checker.dao`) proved that Dao can
+express compiler-shaped logic. But they used string-only error messages
+with no source location, no context snippets, and no structured
+formatting. The diagnostic formatter is the right Phase 7 entry point
+because:
+
+- it is a genuine compiler subsystem (not a synthetic probe)
+- it is a true leaf — no dependency on scope chains, type universes, or
+  module resolution
+- it forces exactly the shared substrate needed downstream: spans, source
+  buffers, line indexing, string formatting
+- it is small enough to finish without dragging in the full frontend
+
+## What already exists in C++
+
+The C++ diagnostic subsystem is minimal and well-understood:
+
+| File | Contents |
+|------|----------|
+| `compiler/frontend/diagnostics/source.h` | `Span` (offset + length), `LineCol` (line + col), `SourceBuffer` (filename, contents, line index, `text(span)`, `line_col(offset)`) |
+| `compiler/frontend/diagnostics/diagnostic.h` | `Severity` enum (Error, Warning, Note), `Diagnostic` struct (severity + span + message) |
+| `compiler/driver/main.cpp` lines 51–82 | `print_error_diagnostics` and `print_diagnostics` — iterate diagnostics, resolve span → line:col, format `filename:line:col: severity: message` |
+
+The formatting is currently inlined in the driver as ~30 lines of C++.
+There is no context-line extraction, no underline/caret rendering, and no
+multi-diagnostic aggregation beyond sequential printing.
+
+## Deliverables
+
+### 1. `stdlib/core/span.dao` — source span types
+
+```dao
+struct Span:
+  offset: i64
+  length: i64
+
+struct LineCol:
+  line: i64
+  col: i64
+```
+
+These are value types. No methods needed initially beyond construction.
+
+### 2. `stdlib/core/source_buffer.dao` — source buffer with line index
+
+```dao
+class SourceBuffer:
+  filename: string
+  contents: string
+  line_offsets: Vector<i64>
+```
+
+Required methods:
+
+- `make_source_buffer(filename: string, contents: string): SourceBuffer`
+  — constructor that builds the line offset index
+- `text(buf: SourceBuffer, span: Span): string` — extract span text
+- `line_col(buf: SourceBuffer, offset: i64): LineCol` — binary search
+  for line containing offset, compute column
+- `line_text(buf: SourceBuffer, line: i64): string` — extract full
+  source line by 1-based line number
+- `line_count(buf: SourceBuffer): i64` — total line count
+
+### 3. `stdlib/core/diagnostic.dao` — diagnostic types
+
+```dao
+enum Severity:
+  Error
+  Warning
+  Note
+
+struct Diagnostic:
+  severity: Severity
+  span: Span
+  message: string
+```
+
+Constructor helpers:
+
+- `make_error(span: Span, message: string): Diagnostic`
+- `make_warning(span: Span, message: string): Diagnostic`
+
+### 4. `examples/bootstrap_probe/diagnostic_formatter.dao` — formatter
+
+The formatter consumes a `SourceBuffer` and a `Vector<Diagnostic>` and
+produces formatted output. Target output format:
+
+```
+test.dao:3:5: error: undefined variable 'x'
+  3 | let y = x + 1
+      ^
+```
+
+Required capabilities:
+
+- resolve span → line:col via `SourceBuffer`
+- extract context line from source
+- render `filename:line:col: severity: message`
+- render context line with line number gutter
+- render caret/underline marker at the error column
+- handle multiple diagnostics sequentially
+- handle prelude line offset (diagnostics from user code that follows
+  a prepended stdlib prelude)
+
+### 5. Test harness
+
+The probe must include a self-test harness (same pattern as
+`type_checker.dao`) that:
+
+- constructs a SourceBuffer from an inline source string
+- creates diagnostics at known offsets
+- formats them and verifies the output contains expected substrings
+- tests edge cases: first line, last line, empty source, multi-byte
+  offsets, multiple diagnostics on the same line
+
+## Stdlib dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| `Vector<T>` | ✅ exists | for line_offsets and diagnostic lists |
+| `string` ops | ✅ exists | concat, length, char_at, substring |
+| `i64` | ✅ exists | all offsets and indices |
+| `Span` / `LineCol` | ❌ new | deliverable of this task |
+| `SourceBuffer` | ❌ new | deliverable of this task |
+| `Diagnostic` / `Severity` | ❌ new | deliverable of this task |
+| `i64_to_string` | ✅ exists | for line number rendering |
+| `HashMap<V>` | not needed | — |
+| `Option<T>` | maybe | for bounds-checked access |
+
+## Language features exercised
+
+This task stress-tests:
+
+- **struct construction and field access** — Span, LineCol, Diagnostic
+- **class with methods** — SourceBuffer
+- **enum matching** — Severity dispatch
+- **Vector iteration** — line offset scanning
+- **string building** — concat chains for formatted output
+- **binary search** — line_col implementation
+- **i64 arithmetic** — offset/length computation
+
+## What this task deliberately avoids
+
+- No scope chains or symbol tables
+- No type universe or type checking logic
+- No parsing or AST construction
+- No module/import system
+- No mutable references or unsafe memory
+- No generic type parameters beyond existing Vector<T>
+
+## Expected learnings
+
+This task will surface real answers to:
+
+1. **Are string concat chains sufficient for formatting, or do we need a
+   string builder?** — If concat-per-segment is too slow or ergonomically
+   painful, that's a concrete stdlib gap to fix.
+2. **Is char_at + substring sufficient for source text slicing?** — The
+   line index builder needs character-level scanning. If the current
+   string API is awkward for this, that identifies the next string
+   primitive to add.
+3. **Does the struct/class split work for value-vs-entity types?** —
+   Span and LineCol are pure values; SourceBuffer holds state. This
+   exercises both patterns.
+4. **What is the next real extraction candidate?** — After diagnostics,
+   the next leaf should be whatever this task reveals as painful.
+
+## Exit criteria
+
+- `daoc build examples/bootstrap_probe/diagnostic_formatter.dao`
+  compiles and runs successfully
+- formatter produces correct `filename:line:col: severity: message`
+  output with context lines and caret markers
+- self-test harness passes all cases
+- `Span`, `LineCol`, `SourceBuffer`, `Diagnostic`, `Severity` are
+  usable as stdlib types for future subsystem extractions
+- learnings documented: string builder needed? new string primitives?
+  struct/class friction?
+
+## Sequencing
+
+This is the **first** Phase 7 task. It must complete before attempting
+extraction of resolver, parser, or type-checker subsystems, because
+those all depend on the diagnostic infrastructure this task establishes.
+
+Prerequisites:
+- None beyond current main. All required language features and stdlib
+  types already exist.
+
+Unlocks:
+- Phase 7 resolver leaf extraction (needs Span + Diagnostic for error
+  reporting)
+- Phase 7 parser leaf extraction (needs SourceBuffer for source
+  management)
+- Future diagnostic improvements (multi-span notes, fix suggestions)


### PR DESCRIPTION
## Summary

Adds the Phase 7 entry leaf task spec (Task 19 — diagnostic formatter) and fixes the stale Task 14 Tier B status line that listed i64 surface exposure as not-yet-started despite being fully implemented.

## Highlights

- **Task 19 spec** (`docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md`): defines the diagnostic formatter as the first real Phase 7 self-hosting leaf extraction — delivers `Span`, `SourceBuffer`, `LineCol`, `Diagnostic`, `Severity` as stdlib types plus a formatter probe with self-test harness
- **Task 14 Tier B doc fix**: marked complete — i64 is fully surfaced across type system, parser, LLVM backend, runtime hooks, stdlib, and examples
- **ROADMAP Phase 7 update**: records entry leaf decision and rationale (diagnostic formatter chosen over direct type_checker probe promotion)
- **IMPLEMENTATION_PLAN update**: "What Comes After" section references Task 19 as the next sequenced task

## Test plan

- [ ] Verify Task 19 spec is internally consistent with existing stdlib surface and C++ diagnostic subsystem
- [ ] Confirm Task 14 Tier B completion claims match codebase (i64 end-to-end: type system, parser, backend, runtime, stdlib, examples)
- [ ] Verify ROADMAP Phase 7 section is consistent with task spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)