### PR TITLE
feat(bootstrap): ✨ add diagnostic formatter — Phase 7 entry leaf (Task 19)

### DIFF
--- a/compiler/backend/llvm/llvm_backend.cpp
+++ b/compiler/backend/llvm/llvm_backend.cpp
@@ -680,7 +680,24 @@ auto LlvmBackend::lower_const_string(const MirConstString& p, const MirInst& ins
   if (raw.size() >= 2 && raw.front() == '"' && raw.back() == '"') {
     raw = raw.substr(1, raw.size() - 2);
   }
-  auto str = std::string(raw);
+  // Process escape sequences: \n, \t, \\, \", \r, \0.
+  std::string str;
+  str.reserve(raw.size());
+  for (size_t i = 0; i < raw.size(); ++i) {
+    if (raw[i] == '\\' && i + 1 < raw.size()) {
+      switch (raw[i + 1]) {
+        case 'n':  str += '\n'; ++i; break;
+        case 't':  str += '\t'; ++i; break;
+        case 'r':  str += '\r'; ++i; break;
+        case '\\': str += '\\'; ++i; break;
+        case '"':  str += '"';  ++i; break;
+        case '0':  str += '\0'; ++i; break;
+        default:   str += raw[i]; break;
+      }
+    } else {
+      str += raw[i];
+    }
+  }
   auto* str_constant = llvm::ConstantDataArray::getString(ctx_, str, /*AddNull=*/true);
   auto* global = new llvm::GlobalVariable(
       *module_, str_constant->getType(), /*isConstant=*/true,

--- a/examples/bootstrap_probe/diagnostic_formatter.dao
+++ b/examples/bootstrap_probe/diagnostic_formatter.dao
@@ -1,0 +1,341 @@
+// diagnostic_formatter.dao — Phase 7 entry leaf: diagnostic formatter.
+//
+// This is the first real compiler subsystem extracted into pure Dao.
+// It consumes a SourceBuffer and Vector<Diagnostic>, resolves source
+// spans to line:col locations, and produces human-readable diagnostic
+// output with context lines and caret markers.
+//
+// Span, LineCol, Severity, and Diagnostic are stdlib types (from
+// stdlib/core/diagnostic.dao). SourceBuffer is defined here because
+// it requires Vector<i64> as a field, and Vector loads after all
+// potential stdlib file names alphabetically.
+//
+// Target output format:
+//   test.dao:3:5: error: undefined variable 'x'
+//     3 | let y = x + 1
+//         ^
+
+// ---------------------------------------------------------------------------
+// SourceBuffer — source text with line index for span resolution
+// ---------------------------------------------------------------------------
+
+class SourceBuffer:
+  filename: string
+  contents: string
+  line_offsets: Vector<i64>
+
+fn make_source_buffer(filename: string, contents: string): SourceBuffer
+  let offsets: Vector<i64> = Vector<i64>::new()
+  let zero: i64 = 0
+  offsets = offsets.push(zero)
+  let i: i64 = 0
+  let len: i64 = length(contents)
+  while i < len:
+    if char_at(contents, i) == 10:
+      offsets = offsets.push(i + 1)
+    i = i + 1
+  return SourceBuffer(filename, contents, offsets)
+
+fn sb_text(buf: SourceBuffer, span: Span): string
+  return substring(buf.contents, span.offset, span.length)
+
+fn sb_line_col(buf: SourceBuffer, offset: i64): LineCol
+  let low: i64 = 0
+  let high: i64 = buf.line_offsets.length()
+  while low + 1 < high:
+    let mid: i64 = low + (high - low) / 2
+    if buf.line_offsets.get(mid) <= offset:
+      low = mid
+    else:
+      high = mid
+  return LineCol(low + 1, offset - buf.line_offsets.get(low) + 1)
+
+fn sb_line_text(buf: SourceBuffer, line: i64): string
+  let idx: i64 = line - 1
+  if idx < 0:
+    return ""
+  if idx >= buf.line_offsets.length():
+    return ""
+  let start: i64 = buf.line_offsets.get(idx)
+  let end: i64 = length(buf.contents)
+  if idx + 1 < buf.line_offsets.length():
+    end = buf.line_offsets.get(idx + 1)
+  // Strip trailing newline if present.
+  if end > start:
+    if char_at(buf.contents, end - 1) == 10:
+      end = end - 1
+  return substring(buf.contents, start, end - start)
+
+fn sb_line_count(buf: SourceBuffer): i64
+  return buf.line_offsets.length()
+
+// ---------------------------------------------------------------------------
+// Severity formatting
+// ---------------------------------------------------------------------------
+
+fn severity_label(sev: Severity): string
+  match sev:
+    Severity.Error:
+      return "error"
+    Severity.Warning:
+      return "warning"
+    Severity.Note:
+      return "note"
+  return "unknown"
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+// Repeat a character (given as string) n times.
+fn repeat_char(ch: string, n: i64): string
+  let result: string = ""
+  let i: i64 = 0
+  while i < n:
+    result = result + ch
+    i = i + 1
+  return result
+
+// Compute the display width of a decimal number (for gutter alignment).
+fn digit_width(n: i64): i64
+  if n <= 0:
+    return 1
+  let w: i64 = 0
+  let v: i64 = n
+  while v > 0:
+    w = w + 1
+    v = v / 10
+  return w
+
+// ---------------------------------------------------------------------------
+// Diagnostic formatter
+// ---------------------------------------------------------------------------
+
+// Format a single diagnostic into a human-readable string.
+// line_offset is subtracted from the displayed line number to adjust
+// for prepended prelude source (matching the C++ driver convention).
+fn format_diagnostic(buf: SourceBuffer, diag: Diagnostic, line_offset: i64): string
+  let loc: LineCol = sb_line_col(buf, diag.span.offset)
+  let display_line: i64 = loc.line - line_offset
+  if display_line < 1:
+    display_line = loc.line
+
+  // Header: filename:line:col: severity: message
+  let header: string = buf.filename + ":" + i64_to_string(display_line) + ":" + i64_to_string(loc.col) + ": " + severity_label(diag.severity) + ": " + diag.message
+
+  // Context line with gutter.
+  let context: string = sb_line_text(buf, loc.line)
+  let gutter_width: i64 = digit_width(display_line)
+  let gutter: string = repeat_char(" ", gutter_width) + " | "
+  let line_gutter: string = i64_to_string(display_line) + " | "
+
+  // Caret marker under the error column.
+  let caret_padding: string = repeat_char(" ", loc.col - 1)
+  let caret_len: i64 = diag.span.length
+  if caret_len < 1:
+    caret_len = 1
+  let caret: string = repeat_char("^", caret_len)
+
+  return header + "\n" + "  " + line_gutter + context + "\n" + "  " + gutter + caret_padding + caret
+
+// Format all diagnostics sequentially with the given prelude line offset.
+fn format_diagnostics(buf: SourceBuffer, diags: Vector<Diagnostic>, line_offset: i64): string
+  let result: string = ""
+  let i: i64 = 0
+  while i < diags.length():
+    if i > 0:
+      result = result + "\n"
+    result = result + format_diagnostic(buf, diags.get(i), line_offset)
+    i = i + 1
+  return result
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+fn test_contains(label: string, haystack: string, needle: string): bool
+  if index_of(haystack, needle) >= 0:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label + ": expected to find '" + needle + "'")
+  print("  got: " + haystack)
+  return false
+
+fn test_eq(label: string, actual: string, expected: string): bool
+  if actual == expected:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label)
+  print("  expected: " + expected)
+  print("  actual:   " + actual)
+  return false
+
+fn main(): i32
+  print("=== diagnostic_formatter: Phase 7 entry leaf ===")
+  print("")
+
+  let pass_count: i32 = 0
+
+  // --- SourceBuffer and line indexing ---
+
+  let src: string = "let x = 1\nlet y = x + 1\nlet z = y * 2\n"
+  let buf: SourceBuffer = make_source_buffer("test.dao", src)
+
+  // Test line count (3 newlines → 4 line offsets).
+  if test_eq("line_count", i64_to_string(sb_line_count(buf)), "4"):
+    pass_count = pass_count + 1
+
+  // Test line_col for offset 0 (first char, line 1 col 1).
+  let loc0: LineCol = sb_line_col(buf, 0)
+  if test_eq("line_col_0", i64_to_string(loc0.line) + ":" + i64_to_string(loc0.col), "1:1"):
+    pass_count = pass_count + 1
+
+  // Test line_col for offset 10 (start of second line, 'l' in 'let y').
+  let off10: i64 = 10
+  let loc10: LineCol = sb_line_col(buf, off10)
+  if test_eq("line_col_10", i64_to_string(loc10.line) + ":" + i64_to_string(loc10.col), "2:1"):
+    pass_count = pass_count + 1
+
+  // Test line_col for offset 18 (the 'x' in 'x + 1' on line 2, col 9).
+  let off18: i64 = 18
+  let loc18: LineCol = sb_line_col(buf, off18)
+  if test_eq("line_col_18", i64_to_string(loc18.line) + ":" + i64_to_string(loc18.col), "2:9"):
+    pass_count = pass_count + 1
+
+  // Test line text extraction.
+  let one: i64 = 1
+  let two: i64 = 2
+  let three: i64 = 3
+  if test_eq("line_text_1", sb_line_text(buf, one), "let x = 1"):
+    pass_count = pass_count + 1
+  if test_eq("line_text_2", sb_line_text(buf, two), "let y = x + 1"):
+    pass_count = pass_count + 1
+  if test_eq("line_text_3", sb_line_text(buf, three), "let z = y * 2"):
+    pass_count = pass_count + 1
+
+  // Test span text extraction.
+  let span_x: Span = Span(off18, one)
+  if test_eq("sb_text", sb_text(buf, span_x), "x"):
+    pass_count = pass_count + 1
+
+  // --- Diagnostic formatting ---
+
+  // Single error diagnostic.
+  let diag1: Diagnostic = make_error(Span(off18, one), "undefined variable 'x'")
+  let fmt1: string = format_diagnostic(buf, diag1, 0)
+
+  // Header line.
+  if test_contains("fmt_header", fmt1, "test.dao:2:9: error: undefined variable 'x'"):
+    pass_count = pass_count + 1
+
+  // Context line with gutter.
+  if test_contains("fmt_context", fmt1, "2 | let y = x + 1"):
+    pass_count = pass_count + 1
+
+  // Caret marker.
+  if test_contains("fmt_caret", fmt1, "^"):
+    pass_count = pass_count + 1
+
+  // --- Warning diagnostic ---
+
+  let zero: i64 = 0
+  let diag_warn: Diagnostic = make_warning(Span(zero, three), "unused variable")
+  let fmt_warn: string = format_diagnostic(buf, diag_warn, 0)
+  if test_contains("warn_severity", fmt_warn, "warning: unused variable"):
+    pass_count = pass_count + 1
+  if test_contains("warn_location", fmt_warn, "test.dao:1:1"):
+    pass_count = pass_count + 1
+  // 'let' is 3 chars, so caret should be '^^^'.
+  if test_contains("warn_caret_width", fmt_warn, "^^^"):
+    pass_count = pass_count + 1
+
+  // --- Multi-span caret ---
+
+  let off24: i64 = 24
+  let five: i64 = 5
+  let diag_wide: Diagnostic = make_error(Span(off24, five), "type mismatch")
+  let fmt_wide: string = format_diagnostic(buf, diag_wide, 0)
+  if test_contains("wide_caret", fmt_wide, "^^^^^"):
+    pass_count = pass_count + 1
+
+  // --- First line diagnostic ---
+
+  let four: i64 = 4
+  let diag_first: Diagnostic = make_error(Span(four, one), "unexpected token")
+  let fmt_first: string = format_diagnostic(buf, diag_first, 0)
+  if test_contains("first_line_loc", fmt_first, "test.dao:1:5"):
+    pass_count = pass_count + 1
+  if test_contains("first_line_ctx", fmt_first, "1 | let x = 1"):
+    pass_count = pass_count + 1
+
+  // --- Last line diagnostic ---
+
+  let diag_last: Diagnostic = make_error(Span(off24, one), "bad expression")
+  let fmt_last: string = format_diagnostic(buf, diag_last, 0)
+  if test_contains("last_line_loc", fmt_last, "test.dao:3:1"):
+    pass_count = pass_count + 1
+
+  // --- Multiple diagnostics ---
+
+  let diags: Vector<Diagnostic> = Vector<Diagnostic>::new()
+  diags = diags.push(make_error(Span(off18, one), "first error"))
+  diags = diags.push(make_warning(Span(zero, three), "second warning"))
+  let fmt_multi: string = format_diagnostics(buf, diags, 0)
+  if test_contains("multi_first", fmt_multi, "error: first error"):
+    pass_count = pass_count + 1
+  if test_contains("multi_second", fmt_multi, "warning: second warning"):
+    pass_count = pass_count + 1
+
+  // --- Prelude line offset ---
+
+  // With line_offset=1, line 2 in source displays as line 1.
+  let diag_offset: Diagnostic = make_error(Span(off18, one), "offset test")
+  let fmt_offset: string = format_diagnostic(buf, diag_offset, one)
+  if test_contains("prelude_offset", fmt_offset, "test.dao:1:9"):
+    pass_count = pass_count + 1
+
+  // --- Empty source ---
+
+  let empty_buf: SourceBuffer = make_source_buffer("empty.dao", "")
+  if test_eq("empty_line_count", i64_to_string(sb_line_count(empty_buf)), "1"):
+    pass_count = pass_count + 1
+
+  // --- Single line without trailing newline ---
+
+  let single_buf: SourceBuffer = make_source_buffer("single.dao", "hello")
+  if test_eq("single_line_count", i64_to_string(sb_line_count(single_buf)), "1"):
+    pass_count = pass_count + 1
+  if test_eq("single_line_text", sb_line_text(single_buf, one), "hello"):
+    pass_count = pass_count + 1
+
+  // --- Out of bounds line text ---
+
+  let hundred: i64 = 100
+  if test_eq("oob_line_text", sb_line_text(buf, hundred), ""):
+    pass_count = pass_count + 1
+  if test_eq("oob_line_zero", sb_line_text(buf, zero), ""):
+    pass_count = pass_count + 1
+
+  // --- Multiple diagnostics on same line ---
+
+  let off10b: i64 = 10
+  let diags_same: Vector<Diagnostic> = Vector<Diagnostic>::new()
+  diags_same = diags_same.push(make_error(Span(off10b, three), "first"))
+  diags_same = diags_same.push(make_error(Span(off18, one), "second"))
+  let fmt_same: string = format_diagnostics(buf, diags_same, 0)
+  if test_contains("same_line_first", fmt_same, "2:1: error: first"):
+    pass_count = pass_count + 1
+  if test_contains("same_line_second", fmt_same, "2:9: error: second"):
+    pass_count = pass_count + 1
+
+  // --- Summary ---
+
+  let total: i32 = 28
+  print("")
+  print("--- results ---")
+  print(i32_to_string(pass_count) + " / " + i32_to_string(total) + " passed")
+
+  if pass_count == total:
+    print("ALL TESTS PASSED")
+
+  return 0

--- a/stdlib/core/diagnostic.dao
+++ b/stdlib/core/diagnostic.dao
@@ -1,0 +1,37 @@
+// diagnostic.dao — Source spans, locations, and diagnostic types.
+//
+// Span represents a byte range in source text (offset + length).
+// LineCol represents a human-readable 1-based line and column.
+// Severity classifies diagnostic importance.
+// Diagnostic pairs a source span with a severity and human-readable message.
+//
+// All offsets and columns are byte-based, matching the C++ SourceBuffer
+// and runtime string primitives. Display-width correctness for multi-byte
+// UTF-8 sequences is explicitly deferred.
+
+class Span:
+  offset: i64
+  length: i64
+
+class LineCol:
+  line: i64
+  col: i64
+
+enum Severity:
+  Error
+  Warning
+  Note
+
+class Diagnostic:
+  severity: Severity
+  span: Span
+  message: string
+
+fn make_error(span: Span, message: string): Diagnostic
+  return Diagnostic(Severity.Error, span, message)
+
+fn make_warning(span: Span, message: string): Diagnostic
+  return Diagnostic(Severity.Warning, span, message)
+
+fn make_note(span: Span, message: string): Diagnostic
+  return Diagnostic(Severity.Note, span, message)

--- a/testdata/ast/stdlib_core_diagnostic.ast
+++ b/testdata/ast/stdlib_core_diagnostic.ast
@@ -1,0 +1,54 @@
+File
+  ClassDecl Span
+    Field offset: i64
+    Field length: i64
+  ClassDecl LineCol
+    Field line: i64
+    Field col: i64
+  EnumDecl Severity
+    Variant Error
+    Variant Warning
+    Variant Note
+  ClassDecl Diagnostic
+    Field severity: Severity
+    Field span: Span
+    Field message: string
+  FunctionDecl make_error
+    Param span: Span
+    Param message: string
+    ReturnType: Diagnostic
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Diagnostic
+        Args
+          FieldExpr .Error
+            Identifier Severity
+          Identifier span
+          Identifier message
+  FunctionDecl make_warning
+    Param span: Span
+    Param message: string
+    ReturnType: Diagnostic
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Diagnostic
+        Args
+          FieldExpr .Warning
+            Identifier Severity
+          Identifier span
+          Identifier message
+  FunctionDecl make_note
+    Param span: Span
+    Param message: string
+    ReturnType: Diagnostic
+    ReturnStatement
+      CallExpr
+        Callee
+          Identifier Diagnostic
+        Args
+          FieldExpr .Note
+            Identifier Severity
+          Identifier span
+          Identifier message


### PR DESCRIPTION
## Summary

First real compiler subsystem extracted into pure Dao as the Phase 7 entry leaf. Implements source span resolution, line/column mapping, context-line extraction, and human-readable diagnostic formatting with caret markers. Also fixes a missing basic compiler feature: string escape sequence processing in the LLVM backend.

## Highlights

- **`stdlib/core/diagnostic.dao`**: adds `Span`, `LineCol`, `Severity` enum, `Diagnostic` class, and constructor helpers (`make_error`, `make_warning`, `make_note`) as reusable stdlib types
- **`examples/bootstrap_probe/diagnostic_formatter.dao`**: `SourceBuffer` with precomputed line index, binary-search `line_col`, formatter producing `filename:line:col: severity: message` with context lines and caret markers, prelude line offset support, 28/28 self-test harness
- **String escape sequences**: `\n`, `\t`, `\r`, `\\`, `\"`, `\0` are now processed in string literals (was missing — backend emitted them literally)
- **Stdlib load order finding**: class-typed fields require the referenced class to be defined earlier in the alphabetically-concatenated prelude; `SourceBuffer` (needs `Vector<i64>` field) cannot live in stdlib until this constraint is addressed
- **Golden AST file** added for new stdlib type; all 12 unit tests, 22 examples, and 8 bootstrap probes pass

## Test plan

- [x] 28/28 diagnostic formatter self-tests pass
- [x] 12/12 compiler unit tests pass (including new golden file)
- [x] 22/22 examples compile
- [x] 8/8 bootstrap probes compile (including new diagnostic_formatter)
- [ ] Verify string escape sequences don't break existing string usage in examples
- [ ] Verify playground still renders correctly with new stdlib types in prelude

🤖 Generated with [Claude Code](https://claude.com/claude-code)