### PR TITLE
fix(typecheck): 🐛 enable forward references for class-typed fields

### DIFF
--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -493,13 +493,16 @@ void TypeChecker::register_declarations(const FileNode& file) {
 
   // Sub-pass 1b-ii: resolve class field types now that all type
   // shells (classes and enums) are registered in symbol_types_.
+  // Unresolved types are kept as nullptr to preserve arity — same
+  // rationale as enum variant payloads: dropping the slot silently
+  // mutates the struct shape and produces misleading secondary
+  // constructor-arity errors instead of the real type-resolution
+  // failure.
   for (auto& pending : pending_classes) {
     std::vector<StructField> fields;
     for (const auto* field : pending.class_decl->fields) {
       const auto* field_type = resolve_type_node(field->type);
-      if (field_type != nullptr) {
-        fields.push_back({field->name, field_type});
-      }
+      fields.push_back({field->name, field_type});
     }
     pending.shell->set_fields(std::move(fields));
   }
@@ -772,7 +775,8 @@ void TypeChecker::compute_derived_conformances(const FileNode& file) {
         const auto* stype = static_cast<const TypeStruct*>(entry.struct_type);
         bool all_fields_conform = true;
         for (const auto& field : stype->fields()) {
-          if (!type_conforms_to(field.type, concept_decl)) {
+          if (field.type == nullptr ||
+              !type_conforms_to(field.type, concept_decl)) {
             all_fields_conform = false;
             break;
           }

--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -421,6 +421,19 @@ void TypeChecker::register_declarations(const FileNode& file) {
   // Pass 1b: register type shells (enums and class structs) so that
   // function signatures processed in pass 1c can reference them
   // regardless of source order.
+  //
+  // Sub-pass 1b-i: register class struct shells with empty fields.
+  // This ensures all class names are available in symbol_types_
+  // before any field types are resolved, enabling forward references
+  // between classes (e.g. class Diagnostic with a Span field where
+  // Span is defined later in the source).
+  struct PendingClass {
+    const ClassDecl* class_decl;
+    const Decl* decl;
+    TypeStruct* shell;
+  };
+  std::vector<PendingClass> pending_classes;
+
   for (const auto* decl : file.declarations) {
     if (decl->kind() == NodeKind::ClassDecl) {
       const auto& st = decl->as<ClassDecl>();
@@ -430,17 +443,10 @@ void TypeChecker::register_declarations(const FileNode& file) {
       }
       const auto* sym = decl_it->second;
 
-      std::vector<StructField> fields;
-      for (const auto* field : st.fields) {
-        const auto* field_type = resolve_type_node(field->type);
-        if (field_type != nullptr) {
-          fields.push_back({field->name, field_type});
-        }
-      }
-      const auto* struct_type =
-          types_.make_struct(sym, st.name, std::move(fields));
-      symbol_types_[sym] = struct_type;
-      typed_.set_decl_type(decl, struct_type);
+      auto* shell = types_.make_struct_shell(sym, st.name);
+      symbol_types_[sym] = shell;
+      typed_.set_decl_type(decl, shell);
+      pending_classes.push_back({&st, decl, shell});
     } else if (decl->kind() == NodeKind::EnumDecl) {
       const auto& en = decl->as<EnumDeclNode>();
       auto decl_it = decl_symbols_.find(en.name_span.offset);
@@ -483,6 +489,19 @@ void TypeChecker::register_declarations(const FileNode& file) {
       symbol_types_[sym] = enum_type;
       typed_.set_decl_type(decl, enum_type);
     }
+  }
+
+  // Sub-pass 1b-ii: resolve class field types now that all type
+  // shells (classes and enums) are registered in symbol_types_.
+  for (auto& pending : pending_classes) {
+    std::vector<StructField> fields;
+    for (const auto* field : pending.class_decl->fields) {
+      const auto* field_type = resolve_type_node(field->type);
+      if (field_type != nullptr) {
+        fields.push_back({field->name, field_type});
+      }
+    }
+    pending.shell->set_fields(std::move(fields));
   }
 
   // Pass 1c: register function signatures, class method signatures,

--- a/compiler/frontend/types/type.h
+++ b/compiler/frontend/types/type.h
@@ -157,6 +157,13 @@ public:
     return fields_;
   }
 
+  // Set or replace fields. Used during type-checker initialization to
+  // support forward references: shells are registered with empty fields
+  // first, then fields are resolved once all type shells exist.
+  void set_fields(std::vector<StructField> fields) {
+    fields_ = std::move(fields);
+  }
+
   static auto classof(const Type* t) -> bool {
     return t->kind() == TypeKind::Struct;
   }

--- a/compiler/frontend/types/type_context.cpp
+++ b/compiler/frontend/types/type_context.cpp
@@ -137,6 +137,11 @@ auto TypeContext::make_struct(const void* decl_id, std::string_view name,
   return arena_.alloc<TypeStruct>(decl_id, name, std::move(fields));
 }
 
+auto TypeContext::make_struct_shell(const void* decl_id,
+                                    std::string_view name) -> TypeStruct* {
+  return arena_.alloc<TypeStruct>(decl_id, name, std::vector<StructField>{});
+}
+
 auto TypeContext::make_enum(const void* decl_id, std::string_view name,
                              std::vector<EnumVariant> variants)
     -> const TypeEnum* {

--- a/compiler/frontend/types/type_context.h
+++ b/compiler/frontend/types/type_context.h
@@ -66,6 +66,12 @@ public:
   auto make_struct(const void* decl_id, std::string_view name,
                    std::vector<StructField> fields) -> const TypeStruct*;
 
+  // Allocate a struct type shell with empty fields. Returns a mutable
+  // pointer so the caller can call set_fields() once all type shells
+  // are registered (enabling forward references between classes).
+  auto make_struct_shell(const void* decl_id,
+                         std::string_view name) -> TypeStruct*;
+
   auto make_enum(const void* decl_id, std::string_view name,
                  std::vector<EnumVariant> variants) -> const TypeEnum*;
 

--- a/stdlib/core/diagnostic.dao
+++ b/stdlib/core/diagnostic.dao
@@ -1,21 +1,9 @@
-// diagnostic.dao — Source spans, locations, and diagnostic types.
+// diagnostic.dao — Diagnostic types for compiler error reporting.
 //
-// Span represents a byte range in source text (offset + length).
-// LineCol represents a human-readable 1-based line and column.
-// Severity classifies diagnostic importance.
-// Diagnostic pairs a source span with a severity and human-readable message.
-//
-// All offsets and columns are byte-based, matching the C++ SourceBuffer
-// and runtime string primitives. Display-width correctness for multi-byte
-// UTF-8 sequences is explicitly deferred.
-
-class Span:
-  offset: i64
-  length: i64
-
-class LineCol:
-  line: i64
-  col: i64
+// Severity classifies diagnostic importance. Diagnostic pairs a
+// source span with a severity and human-readable message.
+// Depends on Span from span.dao (forward reference — loaded later
+// in alphabetical prelude order, resolved via class shell two-pass).
 
 enum Severity:
   Error

--- a/stdlib/core/span.dao
+++ b/stdlib/core/span.dao
@@ -1,0 +1,15 @@
+// span.dao — Source span and location types.
+//
+// Span represents a byte range in source text (offset + length).
+// LineCol represents a human-readable 1-based line and column.
+// Both use byte semantics matching the C++ SourceBuffer and runtime
+// string primitives. Display-width correctness for multi-byte UTF-8
+// is explicitly deferred.
+
+class Span:
+  offset: i64
+  length: i64
+
+class LineCol:
+  line: i64
+  col: i64

--- a/testdata/ast/stdlib_core_diagnostic.ast
+++ b/testdata/ast/stdlib_core_diagnostic.ast
@@ -1,10 +1,4 @@
 File
-  ClassDecl Span
-    Field offset: i64
-    Field length: i64
-  ClassDecl LineCol
-    Field line: i64
-    Field col: i64
   EnumDecl Severity
     Variant Error
     Variant Warning

--- a/testdata/ast/stdlib_core_span.ast
+++ b/testdata/ast/stdlib_core_span.ast
@@ -1,0 +1,7 @@
+File
+  ClassDecl Span
+    Field offset: i64
+    Field length: i64
+  ClassDecl LineCol
+    Field line: i64
+    Field col: i64


### PR DESCRIPTION
## Summary

Class fields referencing classes defined later in source order were silently dropped, causing constructor arity mismatches and blocking stdlib types from referencing each other. Fixed by splitting the type checker's Pass 1b into two sub-passes: register all class shells first, then resolve field types.

## Highlights

- **Root cause**: Pass 1b resolved class field types in source order; if a referenced class wasn't registered yet, `resolve_type_node` returned `nullptr` and the field was silently dropped (contrast with enum variant payloads which correctly preserve `nullptr`)
- **Fix**: split Pass 1b into sub-pass 1b-i (register all class struct shells with empty fields via `make_struct_shell`) and sub-pass 1b-ii (resolve field types now that all shells exist, then call `set_fields()`)
- **API additions**: `TypeStruct::set_fields()` for post-construction field initialization; `TypeContext::make_struct_shell()` returning mutable `TypeStruct*`
- **Stdlib proof**: split `Span`/`LineCol` into `span.dao` (s) separate from `diagnostic.dao` (d) — Diagnostic now forward-references Span across the alphabetical prelude boundary
- **Remaining limitation**: generic class types as fields (e.g. `Vector<i64>`) still require the generic class to be defined earlier, due to deeper ordering dependencies in generic instantiation and method resolution

## Test plan

- [x] Forward reference test: `class Outer { inner: Inner }` where Inner is defined after Outer — compiles and runs correctly (was a hard error before)
- [x] 12/12 compiler unit tests pass
- [x] 22/22 examples compile
- [x] 8/8 bootstrap probes compile (including diagnostic_formatter with 28/28 tests)
- [x] Diagnostic.span field resolves correctly with Span in a separate, later-loaded stdlib file

🤖 Generated with [Claude Code](https://claude.com/claude-code)