### PR TITLE
docs(roadmap): 📝 update Phase 6 to v2 complete, Phase 7 probe status

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -290,11 +290,15 @@ Exit criteria:
 
 Tasks 6–13 (resolve, types, typecheck, HIR, MIR, LLVM backend,
 generics, coroutines) are complete or substantially complete.
+Task 15 (C ABI interop) v1 and v2 are complete — struct-by-value,
+function pointer types, and named-function callbacks all landed.
 Task 18 (enum payloads and match destructuring) is complete.
+Task 19 (diagnostic formatter, Phase 7 entry leaf) is complete.
+The full lexer bootstrap probe (`dao_lexer_v2.dao`) has verified
+parity with the C++ lexer.
 
-The next implementation tasks are sequenced below. Task 19
-(diagnostic formatter) is the Phase 7 entry leaf — see
-`docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md`.
+The next implementation focus is Phase 7 bootstrap extraction —
+promoting the lexer probe into a real bootstrap compiler subsystem.
 
 ### Task 14 — Numeric Type Expansion
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -185,10 +185,13 @@ Exit criteria:
 
 ## Phase 6 — C ABI Interop and Host Integration
 
-Status: **v2 in progress** — v1 (scalar/pointer C ABI calls, driver
-link passthrough, extern fn type validation, E2E examples) complete.
-v2 adds struct-by-value arguments and returns with repr-C-compatible
-predicate. Callbacks and variadics deferred.
+Status: **v2 complete** — v1 (scalar/pointer C ABI calls, driver link
+passthrough, extern fn type validation, E2E examples) and v2
+(struct-by-value with repr-C predicate, x86-64 SysV eightbyte
+classification, byval/sret for >16 B structs, function pointer types
+at extern boundary with named-function callbacks) both landed.
+Variadics, C unions, and indirect calls through C-supplied function
+pointers with struct params/returns are deferred.
 
 Goals:
 - stable C ABI entry/exit surface for initial foreign function calls
@@ -207,8 +210,11 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
-Status: **entry leaf selected** — diagnostic formatter as first real
-subsystem extraction (Task 19)
+Status: **probes complete, extraction next** — diagnostic formatter
+(Task 19) landed as entry leaf. Full lexer probe (`dao_lexer_v2.dao`)
+landed with verified C++ parity (error-token emission, INDENT/DEDENT
+spans, self-tests). Next: promote the lexer probe into a real
+bootstrap compiler subsystem.
 
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself
@@ -227,6 +233,9 @@ Entry decision:
   that every subsequent extraction depends on
 - see `docs/task_specs/TASK_19_DIAGNOSTIC_FORMATTER.md` for the full
   task spec
+- the full lexer probe (`dao_lexer_v2.dao`) has verified parity with
+  the C++ lexer across token kinds, error tokens, and INDENT/DEDENT
+  source spans — ready for extraction into a real bootstrap subsystem
 
 Recommended bootstrap sequence:
 1. keep the initial compiler in an implementation language suited to


### PR DESCRIPTION
## Summary

Roadmap and implementation plan were stale — Phase 6 v2 (struct-by-value C ABI, function pointer types, callbacks) already landed but docs still said "v2 in progress". Phase 7 lexer probe now has verified C++ parity after the error-token/span fix in #186.

## Highlights

- **ROADMAP.md Phase 6**: updated from "v2 in progress" to "v2 complete" with specifics (repr-C predicate, x86-64 SysV eightbyte classification, byval/sret, function pointer types)
- **ROADMAP.md Phase 7**: updated from "entry leaf selected" to "probes complete, extraction next" — notes lexer probe parity and readiness for extraction
- **IMPLEMENTATION_PLAN.md**: updated "What Comes After" to reflect Task 15 v2, Task 19, and lexer probe completion; repoints next focus to Phase 7 bootstrap extraction

## Test plan

- [ ] Verify ROADMAP.md Phase 6/7 status lines are accurate against landed commits
- [ ] Verify IMPLEMENTATION_PLAN.md "What Comes After" reflects current task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)