### PR TITLE
feat(bootstrap): ✨ add generics vertical slice — Tier B begins

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -32,9 +32,9 @@ enum HirNode:
   HirFile(i64)
 
   // Declarations
-  HirFunction(i64, i64, i64, i64, i64)
-  HirStruct(i64, i64)
-  HirEnum(i64, i64)
+  HirFunction(i64, i64, i64, i64, i64, i64)
+  HirStruct(i64, i64, i64)
+  HirEnum(i64, i64, i64)
   HirTypeAlias(i64, i64)
 
   // Statements
@@ -525,7 +525,7 @@ fn lower_body_stmts(hs: HS, list_pos: i64): HirFlush
 // Section 56: Declaration lowering
 // =========================================================================
 
-fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_type_node: i64, body_lp: i64): HirR
+fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_lp: i64): HirR
   // Resolve return type
   let ret_ti: i64 = to_i64(11)
   let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
@@ -555,9 +555,9 @@ fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_type
   let param_fl: HirFlush = hir_flush_pairs(hs, param_items, param_count)
   // Lower body
   let body_fl: HirFlush = lower_body_stmts(param_fl.hs, body_lp)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
 
-fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_type_node: i64, body_expr: i64): HirR
+fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_expr: i64): HirR
   // Desugar expr body into block with single return
   let ret_ti: i64 = to_i64(11)
   let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
@@ -592,9 +592,9 @@ fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret
   let body_stmts: Vector<i64> = Vector<i64>::new()
   body_stmts = body_stmts.push(ret_r.hir)
   let body_fl: HirFlush = hir_flush_list(ret_r.hs, body_stmts)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
 
-fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_type_node: i64): HirR
+fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64): HirR
   let ret_ti: i64 = to_i64(11)
   let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
   if fn_sym >= 0:
@@ -622,9 +622,9 @@ fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, params_lp: i64, r
   let param_fl: HirFlush = hir_flush_pairs(hs, param_items, param_count)
   // No body — use empty list
   let empty_body_fl: HirFlush = hir_flush_list(param_fl.hs, Vector<i64>::new())
-  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
+  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
 
-fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, fields_lp: i64): HirR
+fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64): HirR
   let pairs: Vector<i64> = read_pairs(hs.idx_data, fields_lp)
   let field_items: Vector<i64> = Vector<i64>::new()
   let field_count: i64 = 0
@@ -642,7 +642,7 @@ fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, fields_lp: i64): HirR
     field_count = field_count + 1
     fi = fi + 2
   let fl: HirFlush = hir_flush_pairs(hs, field_items, field_count)
-  return hs_add_node(fl.hs, HirNode.HirStruct(name_tidx, fl.list_pos))
+  return hs_add_node(fl.hs, HirNode.HirStruct(name_tidx, tparams_lp, fl.list_pos))
 
 // Resolve an AST type node to a type index. Handles NamedT, GenericT, PointerT.
 fn resolve_type_to_idx(hs: HS, type_node_idx: i64): i64
@@ -703,7 +703,7 @@ fn resolve_type_to_idx(hs: HS, type_node_idx: i64): i64
         return hir_sym_type(hs, tsym)
   return to_i64(-1)
 
-fn lower_enum_decl(hs: HS, decl_idx: i64, name_tidx: i64, variants_lp: i64): HirR
+fn lower_enum_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, variants_lp: i64): HirR
   let pairs: Vector<i64> = read_pairs(hs.idx_data, variants_lp)
   let var_items: Vector<i64> = Vector<i64>::new()
   let var_count: i64 = 0
@@ -728,7 +728,7 @@ fn lower_enum_decl(hs: HS, decl_idx: i64, name_tidx: i64, variants_lp: i64): Hir
     var_count = var_count + 1
     vi = vi + 2
   let fl: HirFlush = hir_flush_pairs(cur, var_items, var_count)
-  return hs_add_node(fl.hs, HirNode.HirEnum(name_tidx, fl.list_pos))
+  return hs_add_node(fl.hs, HirNode.HirEnum(name_tidx, tparams_lp, fl.list_pos))
 
 fn lower_type_alias_decl(hs: HS, decl_idx: i64, name_tidx: i64, target_type_node: i64): HirR
   // Find the type index for the alias
@@ -741,16 +741,16 @@ fn lower_type_alias_decl(hs: HS, decl_idx: i64, name_tidx: i64, target_type_node
 fn lower_decl(hs: HS, decl_idx: i64): HirR
   let node: Node = hs.nodes.get(decl_idx)
   match node:
-    Node.FnDeclD(name_tidx, params_lp, ret_type_node, body_lp):
-      return lower_fn_decl(hs, decl_idx, name_tidx, params_lp, ret_type_node, body_lp)
-    Node.ExprFnD(name_tidx, params_lp, ret_type_node, body_expr):
-      return lower_expr_fn_decl(hs, decl_idx, name_tidx, params_lp, ret_type_node, body_expr)
-    Node.ExternFnD(name_tidx, params_lp, ret_type_node):
-      return lower_extern_fn_decl(hs, decl_idx, name_tidx, params_lp, ret_type_node)
-    Node.ClassDeclD(name_tidx, fields_lp):
-      return lower_class_decl(hs, decl_idx, name_tidx, fields_lp)
-    Node.EnumDeclD(name_tidx, variants_lp):
-      return lower_enum_decl(hs, decl_idx, name_tidx, variants_lp)
+    Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type_node, body_lp):
+      return lower_fn_decl(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node, body_lp)
+    Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type_node, body_expr):
+      return lower_expr_fn_decl(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node, body_expr)
+    Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type_node):
+      return lower_extern_fn_decl(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node)
+    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
+      return lower_class_decl(hs, decl_idx, name_tidx, tparams_lp, fields_lp)
+    Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
+      return lower_enum_decl(hs, decl_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
       return lower_type_alias_decl(hs, decl_idx, name_tidx, target_type)
     Node.ErrorD(t):
@@ -841,11 +841,11 @@ fn hir_node_kind(node: HirNode): string
   match node:
     HirNode.HirFile(a):
       return "HirFile"
-    HirNode.HirFunction(a, b, c, d, e):
+    HirNode.HirFunction(a, b, c, d, e, f):
       return "HirFunction"
-    HirNode.HirStruct(a, b):
+    HirNode.HirStruct(a, b, c):
       return "HirStruct"
-    HirNode.HirEnum(a, b):
+    HirNode.HirEnum(a, b, c):
       return "HirEnum"
     HirNode.HirTypeAlias(a, b):
       return "HirTypeAlias"
@@ -925,7 +925,7 @@ fn hir_dump_node(hr: HirResult, idx: i64, indent: i64): string
         line = line + hir_dump_node(hr, decls.get(di), indent + 1)
         di = di + 1
       return line
-    HirNode.HirFunction(name_tidx, params_lp, ret_ti, body_lp, is_extern):
+    HirNode.HirFunction(name_tidx, tparams_lp, params_lp, ret_ti, body_lp, is_extern):
       if is_extern > 0:
         line = line + " [extern]"
       line = line + " -> " + hir_type_label(hr, ret_ti)
@@ -936,10 +936,10 @@ fn hir_dump_node(hr: HirResult, idx: i64, indent: i64): string
         line = line + hir_dump_node(hr, body.get(bi), indent + 1)
         bi = bi + 1
       return line
-    HirNode.HirStruct(name_tidx, fields_lp):
+    HirNode.HirStruct(name_tidx, tparams_lp, fields_lp):
       line = line + "\n"
       return line
-    HirNode.HirEnum(name_tidx, variants_lp):
+    HirNode.HirEnum(name_tidx, tparams_lp, variants_lp):
       line = line + "\n"
       return line
     HirNode.HirTypeAlias(name_tidx, ti2):
@@ -1083,7 +1083,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 14
+  let total: i32 = 15
 
   // Test 1: simple_fn
   let src1: string = "fn add(a: i32, b: i32): i32\n  return a + b\n"
@@ -1313,7 +1313,7 @@ fn main(): i32
     while i12 < hir_count_nodes(r12):
       let n12: HirNode = r12.hir_nodes.get(i12)
       match n12:
-        HirNode.HirFunction(nt, plp, rti, blp, is_ext):
+        HirNode.HirFunction(nt, tp, plp, rti, blp, is_ext):
           if is_ext > 0:
             found_extern = true
       i12 = i12 + 1
@@ -1356,15 +1356,33 @@ fn main(): i32
   else:
     print("FAIL full_program: root < 0")
 
-  // Test 14: self_lower_smoke
+  // Test 14: generic_fn_lower — fn identity<T> lowers to HirFunction
+  let src14g: string = "fn identity<T>(x: T): T\n  return x\n"
+  let r14g: HirResult = lower_to_hir(src14g)
+  if r14g.root >= 0:
+    let found_fn14: bool = false
+    let i14g: i64 = 0
+    while i14g < hir_count_nodes(r14g):
+      if hir_node_kind(r14g.hir_nodes.get(i14g)) == "HirFunction":
+        found_fn14 = true
+      i14g = i14g + 1
+    if found_fn14:
+      print("PASS generic_fn_lower")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL generic_fn_lower: no HirFunction found")
+  else:
+    print("FAIL generic_fn_lower: root < 0")
+
+  // Test 15: self_lower_smoke
   let self_src: string = "fn id(x: i32): i32\n  return x\nfn main(): i32\n  let a: i32 = id(42)\n  return a\n"
-  let r14: HirResult = lower_to_hir(self_src)
-  if r14.root >= 0:
-    if hir_count_nodes(r14) > 5:
+  let r15: HirResult = lower_to_hir(self_src)
+  if r15.root >= 0:
+    if hir_count_nodes(r15) > 5:
       print("PASS self_lower_smoke")
       pass_count = pass_count + 1
     else:
-      print("FAIL self_lower_smoke: too few HIR nodes: " + i64_to_string(hir_count_nodes(r14)))
+      print("FAIL self_lower_smoke: too few HIR nodes: " + i64_to_string(hir_count_nodes(r15)))
   else:
     print("FAIL self_lower_smoke: root < 0")
 

--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -86,6 +86,8 @@ class HirResult:
   hir_idx: Vector<i64>
   types: Vector<DaoType>
   type_info: Vector<i64>
+  toks: Vector<Token>
+  src: string
   diags: Vector<Diagnostic>
   root: i64
 
@@ -525,17 +527,41 @@ fn lower_body_stmts(hs: HS, list_pos: i64): HirFlush
 // Section 56: Declaration lowering
 // =========================================================================
 
+// Re-lower AST type param list into HIR-owned idx.
+// AST tparams_lp points to GenericParamT node indices in ast_idx.
+// HIR stores the param name token indices directly in hir_idx.
+fn lower_type_params(hs: HS, ast_tparams_lp: i64): HirFlush
+  if ast_tparams_lp < 0:
+    // No type params — return a flush with list_pos = -1
+    return HirFlush(hs, to_i64(-1))
+  let tparam_nodes: Vector<i64> = read_list(hs.idx_data, ast_tparams_lp)
+  let tok_indices: Vector<i64> = Vector<i64>::new()
+  let i: i64 = 0
+  while i < tparam_nodes.length():
+    let tp_node_idx: i64 = tparam_nodes.get(i)
+    if tp_node_idx >= 0:
+      let tp_node: Node = hs.nodes.get(tp_node_idx)
+      match tp_node:
+        Node.GenericParamT(tidx):
+          tok_indices = tok_indices.push(tidx)
+    i = i + 1
+  if tok_indices.length() == 0:
+    return HirFlush(hs, to_i64(-1))
+  return hir_flush_list(hs, tok_indices)
+
 fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_lp: i64): HirR
+  // Lower type params into HIR-owned idx
+  let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
   // Resolve return type
   let ret_ti: i64 = to_i64(11)
-  let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
+  let fn_sym: i64 = hir_find_sym_by_decl(tp_fl.hs, decl_idx, "Function")
   if fn_sym >= 0:
-    let fn_ti: i64 = hir_sym_type(hs, fn_sym)
+    let fn_ti: i64 = hir_sym_type(tp_fl.hs, fn_sym)
     if fn_ti >= 0:
-      let fn_type: DaoType = hs.types.get(fn_ti)
+      let fn_type: DaoType = tp_fl.hs.types.get(fn_ti)
       ret_ti = fn_type.ret_type
   // Lower params: flush pairs (name_tok_idx, type_idx)
-  let pairs: Vector<i64> = read_pairs(hs.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, params_lp)
   let param_items: Vector<i64> = Vector<i64>::new()
   let param_count: i64 = 0
   let pi: i64 = 0
@@ -552,22 +578,24 @@ fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_
     param_items = param_items.push(p_ti)
     param_count = param_count + 1
     pi = pi + 2
-  let param_fl: HirFlush = hir_flush_pairs(hs, param_items, param_count)
+  let param_fl: HirFlush = hir_flush_pairs(tp_fl.hs, param_items, param_count)
   // Lower body
   let body_fl: HirFlush = lower_body_stmts(param_fl.hs, body_lp)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
 
 fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_expr: i64): HirR
+  // Lower type params into HIR-owned idx
+  let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
   // Desugar expr body into block with single return
   let ret_ti: i64 = to_i64(11)
-  let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
+  let fn_sym: i64 = hir_find_sym_by_decl(tp_fl.hs, decl_idx, "Function")
   if fn_sym >= 0:
-    let fn_ti: i64 = hir_sym_type(hs, fn_sym)
+    let fn_ti: i64 = hir_sym_type(tp_fl.hs, fn_sym)
     if fn_ti >= 0:
-      let fn_type: DaoType = hs.types.get(fn_ti)
+      let fn_type: DaoType = tp_fl.hs.types.get(fn_ti)
       ret_ti = fn_type.ret_type
   // Lower params
-  let pairs: Vector<i64> = read_pairs(hs.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, params_lp)
   let param_items: Vector<i64> = Vector<i64>::new()
   let param_count: i64 = 0
   let pi: i64 = 0
@@ -583,7 +611,7 @@ fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, pa
     param_items = param_items.push(p_ti)
     param_count = param_count + 1
     pi = pi + 2
-  let param_fl: HirFlush = hir_flush_pairs(hs, param_items, param_count)
+  let param_fl: HirFlush = hir_flush_pairs(tp_fl.hs, param_items, param_count)
   // Lower body expression
   let body_r: HirR = lower_expr(param_fl.hs, body_expr)
   // Wrap in HirReturn
@@ -592,18 +620,19 @@ fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, pa
   let body_stmts: Vector<i64> = Vector<i64>::new()
   body_stmts = body_stmts.push(ret_r.hir)
   let body_fl: HirFlush = hir_flush_list(ret_r.hs, body_stmts)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
 
 fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64): HirR
+  let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
   let ret_ti: i64 = to_i64(11)
-  let fn_sym: i64 = hir_find_sym_by_decl(hs, decl_idx, "Function")
+  let fn_sym: i64 = hir_find_sym_by_decl(tp_fl.hs, decl_idx, "Function")
   if fn_sym >= 0:
-    let fn_ti: i64 = hir_sym_type(hs, fn_sym)
+    let fn_ti: i64 = hir_sym_type(tp_fl.hs, fn_sym)
     if fn_ti >= 0:
-      let fn_type: DaoType = hs.types.get(fn_ti)
+      let fn_type: DaoType = tp_fl.hs.types.get(fn_ti)
       ret_ti = fn_type.ret_type
   // Lower params
-  let pairs: Vector<i64> = read_pairs(hs.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, params_lp)
   let param_items: Vector<i64> = Vector<i64>::new()
   let param_count: i64 = 0
   let pi: i64 = 0
@@ -619,13 +648,14 @@ fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, 
     param_items = param_items.push(p_ti)
     param_count = param_count + 1
     pi = pi + 2
-  let param_fl: HirFlush = hir_flush_pairs(hs, param_items, param_count)
+  let param_fl: HirFlush = hir_flush_pairs(tp_fl.hs, param_items, param_count)
   // No body — use empty list
   let empty_body_fl: HirFlush = hir_flush_list(param_fl.hs, Vector<i64>::new())
-  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tparams_lp, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
+  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
 
 fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64): HirR
-  let pairs: Vector<i64> = read_pairs(hs.idx_data, fields_lp)
+  let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
+  let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, fields_lp)
   let field_items: Vector<i64> = Vector<i64>::new()
   let field_count: i64 = 0
   let fi: i64 = 0
@@ -641,8 +671,8 @@ fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fiel
     field_items = field_items.push(f_ti)
     field_count = field_count + 1
     fi = fi + 2
-  let fl: HirFlush = hir_flush_pairs(hs, field_items, field_count)
-  return hs_add_node(fl.hs, HirNode.HirStruct(name_tidx, tparams_lp, fl.list_pos))
+  let fl: HirFlush = hir_flush_pairs(tp_fl.hs, field_items, field_count)
+  return hs_add_node(fl.hs, HirNode.HirStruct(name_tidx, tp_fl.list_pos, fl.list_pos))
 
 // Resolve an AST type node to a type index. Handles NamedT, GenericT, PointerT.
 fn resolve_type_to_idx(hs: HS, type_node_idx: i64): i64
@@ -704,10 +734,11 @@ fn resolve_type_to_idx(hs: HS, type_node_idx: i64): i64
   return to_i64(-1)
 
 fn lower_enum_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, variants_lp: i64): HirR
-  let pairs: Vector<i64> = read_pairs(hs.idx_data, variants_lp)
+  let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
+  let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, variants_lp)
   let var_items: Vector<i64> = Vector<i64>::new()
   let var_count: i64 = 0
-  let cur: HS = hs
+  let cur: HS = tp_fl.hs
   let vi: i64 = 0
   while vi < pairs.length():
     let v_tidx: i64 = pairs.get(vi)
@@ -728,7 +759,7 @@ fn lower_enum_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, varia
     var_count = var_count + 1
     vi = vi + 2
   let fl: HirFlush = hir_flush_pairs(cur, var_items, var_count)
-  return hs_add_node(fl.hs, HirNode.HirEnum(name_tidx, tparams_lp, fl.list_pos))
+  return hs_add_node(fl.hs, HirNode.HirEnum(name_tidx, tp_fl.list_pos, fl.list_pos))
 
 fn lower_type_alias_decl(hs: HS, decl_idx: i64, name_tidx: i64, target_type_node: i64): HirR
   // Find the type index for the alias
@@ -831,7 +862,7 @@ fn lower_to_hir(src: string): HirResult
   let result: HirR = lower_file(hs, file_node_idx)
   let final_hs: HS = result.hs
 
-  return HirResult(final_hs.hir_nodes, final_hs.hir_idx, final_hs.types, final_hs.type_info, final_hs.diags, result.hir)
+  return HirResult(final_hs.hir_nodes, final_hs.hir_idx, final_hs.types, final_hs.type_info, final_hs.toks, final_hs.src, final_hs.diags, result.hir)
 
 // =========================================================================
 // Section 59: HIR node kind name
@@ -926,6 +957,19 @@ fn hir_dump_node(hr: HirResult, idx: i64, indent: i64): string
         di = di + 1
       return line
     HirNode.HirFunction(name_tidx, tparams_lp, params_lp, ret_ti, body_lp, is_extern):
+      if tparams_lp >= 0:
+        let tps: Vector<i64> = read_list(hr.hir_idx, tparams_lp)
+        line = line + "<"
+        let tpi: i64 = 0
+        while tpi < tps.length():
+          if tpi > 0:
+            line = line + ", "
+          let tp_tidx: i64 = tps.get(tpi)
+          if tp_tidx >= 0:
+            let tp_tok: Token = hr.toks.get(tp_tidx)
+            line = line + substring(hr.src, tp_tok.offset, tp_tok.len)
+          tpi = tpi + 1
+        line = line + ">"
       if is_extern > 0:
         line = line + " [extern]"
       line = line + " -> " + hir_type_label(hr, ret_ti)
@@ -937,9 +981,15 @@ fn hir_dump_node(hr: HirResult, idx: i64, indent: i64): string
         bi = bi + 1
       return line
     HirNode.HirStruct(name_tidx, tparams_lp, fields_lp):
+      if tparams_lp >= 0:
+        let tps: Vector<i64> = read_list(hr.hir_idx, tparams_lp)
+        line = line + "<" + i64_to_string(tps.length()) + " params>"
       line = line + "\n"
       return line
     HirNode.HirEnum(name_tidx, tparams_lp, variants_lp):
+      if tparams_lp >= 0:
+        let tps: Vector<i64> = read_list(hr.hir_idx, tparams_lp)
+        line = line + "<" + i64_to_string(tps.length()) + " params>"
       line = line + "\n"
       return line
     HirNode.HirTypeAlias(name_tidx, ti2):
@@ -1356,19 +1406,29 @@ fn main(): i32
   else:
     print("FAIL full_program: root < 0")
 
-  // Test 14: generic_fn_lower — fn identity<T> lowers to HirFunction
+  // Test 14: generic_fn_lower — fn identity<T> lowers with type params in HIR
   let src14g: string = "fn identity<T>(x: T): T\n  return x\n"
   let r14g: HirResult = lower_to_hir(src14g)
   if r14g.root >= 0:
     let found_fn14: bool = false
+    let has_tparams14: bool = false
     let i14g: i64 = 0
     while i14g < hir_count_nodes(r14g):
-      if hir_node_kind(r14g.hir_nodes.get(i14g)) == "HirFunction":
-        found_fn14 = true
+      let n14g: HirNode = r14g.hir_nodes.get(i14g)
+      match n14g:
+        HirNode.HirFunction(nm, tp_lp, pl, rt, bl, ie):
+          found_fn14 = true
+          if tp_lp >= 0:
+            let tps: Vector<i64> = read_list(r14g.hir_idx, tp_lp)
+            if tps.length() > 0:
+              has_tparams14 = true
       i14g = i14g + 1
     if found_fn14:
-      print("PASS generic_fn_lower")
-      pass_count = pass_count + 1
+      if has_tparams14:
+        print("PASS generic_fn_lower")
+        pass_count = pass_count + 1
+      else:
+        print("FAIL generic_fn_lower: HirFunction found but tparams_lp empty or -1")
     else:
       print("FAIL generic_fn_lower: no HirFunction found")
   else:

--- a/bootstrap/parser/tests.dao
+++ b/bootstrap/parser/tests.dao
@@ -53,7 +53,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 36
+  let total: i32 = 38
 
   // -----------------------------------------------------------------
   // Expression tests
@@ -302,6 +302,22 @@ fn main(): i32
     print("SKIP self_parse_file: file not found at " + self_path)
     print("SKIP self_parse_nodes: file not found")
     print("SKIP self_parse_sanity: file not found")
+
+  // -----------------------------------------------------------------
+  // Generic type parameter tests
+  // -----------------------------------------------------------------
+
+  // Test 34: Generic fn declaration — fn foo<T>(x: T): T
+  let src34: string = "fn foo<T>(x: T): T\n  return x\n"
+  let r34: PR = parse(src34)
+  if expect_no_parse_errors("generic_fn_no_err", r34):
+    pass_count = pass_count + 1
+
+  // Test 35: Generic class declaration — class Box<T>
+  let src35: string = "class Box<T>:\n  value: T\n"
+  let r35: PR = parse(src35)
+  if expect_no_parse_errors("generic_class_no_err", r35):
+    pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
   // Summary

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -10,6 +10,7 @@ enum SymbolKind:
   Param
   Field
   LambdaParam
+  GenericParam
 
 class Symbol:
   kind: SymbolKind
@@ -211,6 +212,8 @@ fn symbol_kind_name(kind: SymbolKind): string
       return "Field"
     SymbolKind.LambdaParam:
       return "LambdaParam"
+    SymbolKind.GenericParam:
+      return "GenericParam"
   return "Unknown"
 
 fn scope_kind_name(kind: ScopeKind): string
@@ -263,6 +266,8 @@ fn is_type_symbol(rs: RS, sym_idx: i64): bool
     SymbolKind.Builtin:
       return true
     SymbolKind.Type:
+      return true
+    SymbolKind.GenericParam:
       return true
   return false
 
@@ -476,10 +481,30 @@ fn resolve_stmt(rs: RS, node_idx: i64): RS
 // Section 27: Declaration resolution (Pass 2)
 // =========================================================================
 
-fn resolve_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64, ret_type: i64, body_lp: i64): RS
+fn resolve_type_params(rs: RS, tparams_lp: i64, node_idx: i64): RS
+  if tparams_lp < 0:
+    return rs
+  let tparams: Vector<i64> = read_list(rs.idx_data, tparams_lp)
+  let r: RS = rs
+  let i: i64 = 0
+  while i < tparams.length():
+    let tp_node_idx: i64 = tparams.get(i)
+    let tp_node: Node = r.nodes.get(tp_node_idx)
+    match tp_node:
+      Node.GenericParamT(tidx):
+        let tname: string = tok_name(r, tidx)
+        let sym_r: SymR = rs_add_symbol(r, Symbol(SymbolKind.GenericParam, tname, node_idx, r.current_scope))
+        r = scope_declare(sym_r.rs, tname, sym_r.sym_idx, tidx)
+    i = i + 1
+  return r
+
+fn resolve_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type: i64, body_lp: i64): RS
   // Create function scope
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.FunctionScope)
   let r: RS = sr.rs
+
+  // Declare generic type parameters
+  r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
   let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
@@ -505,10 +530,13 @@ fn resolve_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64, ret_ty
   // Pop function scope
   return rs_pop_scope(r)
 
-fn resolve_expr_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64, ret_type: i64, body_expr: i64): RS
+fn resolve_expr_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type: i64, body_expr: i64): RS
   // Create function scope
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.FunctionScope)
   let r: RS = sr.rs
+
+  // Declare generic type parameters
+  r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
   let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
@@ -533,10 +561,13 @@ fn resolve_expr_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64, r
   // Pop function scope
   return rs_pop_scope(r)
 
-fn resolve_extern_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64, ret_type: i64): RS
+fn resolve_extern_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type: i64): RS
   // Create function scope
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.FunctionScope)
   let r: RS = sr.rs
+
+  // Declare generic type parameters
+  r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
   let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
@@ -556,10 +587,13 @@ fn resolve_extern_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, params_lp: i64,
   // Pop function scope (no body)
   return rs_pop_scope(r)
 
-fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, fields_lp: i64): RS
+fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64): RS
   // Create struct scope
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.StructScope)
   let r: RS = sr.rs
+
+  // Declare generic type parameters
+  r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare fields
   let pairs: Vector<i64> = read_pairs(r.idx_data, fields_lp)
@@ -577,10 +611,17 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, fields_lp: i64): RS
   // Pop struct scope
   return rs_pop_scope(r)
 
-fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, variants_lp: i64): RS
+fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, variants_lp: i64): RS
+  // Create a scope for type parameters if present
+  let r0: RS = rs
+  let has_tparams: bool = false
+  if tparams_lp >= 0:
+    let sr: ScopeR = rs_push_scope(r0, ScopeKind.BlockScope)
+    r0 = resolve_type_params(sr.rs, tparams_lp, node_idx)
+    has_tparams = true
   // Resolve payload types for each variant
-  let pairs: Vector<i64> = read_pairs(rs.idx_data, variants_lp)
-  let r: RS = rs
+  let pairs: Vector<i64> = read_pairs(r0.idx_data, variants_lp)
+  let r: RS = r0
   let i: i64 = 0
   while i < pairs.length():
     let v_tidx: i64 = pairs.get(i)
@@ -592,6 +633,8 @@ fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, variants_lp: i64): R
       r = resolve_type_node(r, payload_types.get(j))
       j = j + 1
     i = i + 2
+  if has_tparams:
+    r = rs_pop_scope(r)
   return r
 
 fn resolve_type_alias_decl(rs: RS, node_idx: i64, name_tidx: i64, target_type: i64): RS
@@ -602,16 +645,16 @@ fn resolve_decl(rs: RS, node_idx: i64): RS
     return rs
   let node: Node = rs.nodes.get(node_idx)
   match node:
-    Node.FnDeclD(name_tidx, params_lp, ret_type, body_lp):
-      return resolve_fn_decl(rs, node_idx, name_tidx, params_lp, ret_type, body_lp)
-    Node.ExprFnD(name_tidx, params_lp, ret_type, body_expr):
-      return resolve_expr_fn_decl(rs, node_idx, name_tidx, params_lp, ret_type, body_expr)
-    Node.ExternFnD(name_tidx, params_lp, ret_type):
-      return resolve_extern_fn_decl(rs, node_idx, name_tidx, params_lp, ret_type)
-    Node.ClassDeclD(name_tidx, fields_lp):
-      return resolve_class_decl(rs, node_idx, name_tidx, fields_lp)
-    Node.EnumDeclD(name_tidx, variants_lp):
-      return resolve_enum_decl(rs, node_idx, name_tidx, variants_lp)
+    Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_lp):
+      return resolve_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type, body_lp)
+    Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type, body_expr):
+      return resolve_expr_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type, body_expr)
+    Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type):
+      return resolve_extern_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type)
+    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
+      return resolve_class_decl(rs, node_idx, name_tidx, tparams_lp, fields_lp)
+    Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
+      return resolve_enum_decl(rs, node_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
       return resolve_type_alias_decl(rs, node_idx, name_tidx, target_type)
     Node.ErrorD(t):
@@ -633,23 +676,23 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
         let decl_idx: i64 = decls.get(i)
         let decl_node: Node = r.nodes.get(decl_idx)
         match decl_node:
-          Node.FnDeclD(name_tidx, params_lp, ret_type, body_lp):
+          Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_lp):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
-          Node.ExprFnD(name_tidx, params_lp, ret_type, body_expr):
+          Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type, body_expr):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
-          Node.ExternFnD(name_tidx, params_lp, ret_type):
+          Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
-          Node.ClassDeclD(name_tidx, fields_lp):
+          Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
-          Node.EnumDeclD(name_tidx, variants_lp):
+          Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
@@ -738,7 +781,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 17
+  let total: i32 = 18
 
   // -----------------------------------------------------------------
   // Test 1: forward_ref — fn calls fn defined later in file; no diagnostic
@@ -996,6 +1039,22 @@ fn main(): i32
     print("SKIP self_resolve_smoke: file not found at " + self_path)
 
   // -----------------------------------------------------------------
+  // Test 18: generic_param — fn identity<T>(x: T): T — T resolves as GenericParam
+  // -----------------------------------------------------------------
+  let src18: string = "fn identity<T>(x: T): T\n  return x\n"
+  let r18: ResolveResult = resolve(src18)
+  let r18_gp: i64 = count_symbols_of_kind(r18, SymbolKind.GenericParam)
+  let r18_diags: i64 = count_diags(r18)
+  if r18_gp >= 1:
+    if r18_diags == 0:
+      print("PASS generic_param")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL generic_param: expected 0 diagnostics, got " + i64_to_string(r18_diags))
+  else:
+    print("FAIL generic_param: expected >= 1 GenericParam symbol, got " + i64_to_string(r18_gp))
+
+  // -----------------------------------------------------------------
   // Summary
   // -----------------------------------------------------------------
 
@@ -1011,7 +1070,8 @@ fn main(): i32
   //   - Import declaration resolution
   //   - Overload resolution by arity / name mangling
   //   - Static method calls (Type::method)
-  //   - Generic type parameter declarations / where clauses
+  //   - Generic type parameter constraints / where clauses (parsing and
+  //     resolution of generic params is implemented in Tier A)
   //   - Concept / extend resolution
   //   - Mode / resource block scoping
   //   - Yield statement resolution

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -754,7 +754,8 @@ fn lex(src: string): LexResult
 // into nodes vector. Variable-length children use a shared idx list.
 //
 // Tier B deferrals: concept, derived, extend, mode, resource, yield,
-// function types, generic parameter bounds, where clauses.
+// function types, generic parameter bounds / where clauses.
+// (GenericParamT nodes and parse_type_params are Tier A.)
 
 enum Node:
   // --- Expressions ---
@@ -778,6 +779,7 @@ enum Node:
   NamedT(i64)
   GenericT(i64, i64, i64)
   PointerT(i64)
+  GenericParamT(i64)
   ErrorT(i64)
   // --- Statements ---
   LetS(i64, i64, i64)
@@ -791,11 +793,11 @@ enum Node:
   ExprStmtS(i64)
   ErrorS(i64)
   // --- Declarations ---
-  FnDeclD(i64, i64, i64, i64)
-  ExternFnD(i64, i64, i64)
-  ExprFnD(i64, i64, i64, i64)
-  ClassDeclD(i64, i64)
-  EnumDeclD(i64, i64)
+  FnDeclD(i64, i64, i64, i64, i64)
+  ExternFnD(i64, i64, i64, i64)
+  ExprFnD(i64, i64, i64, i64, i64)
+  ClassDeclD(i64, i64, i64)
+  EnumDeclD(i64, i64, i64)
   TypeAliasD(i64, i64)
   ErrorD(i64)
   // --- File ---
@@ -1661,6 +1663,40 @@ fn parse_declaration(ps: PS): PR
   let ps2: PS = ps_add_diag(ps, sp, "expected declaration (fn, extern, class, enum, or type)")
   return ps_add_node(ps_advance(ps2), Node.ErrorD(ps.pos))
 
+// Parse optional type parameters: <T, U, V> — returns PR where .node = list_pos
+// Returns -1 if no type params are present.
+fn parse_type_params(ps: PS): PR
+  if tk_name(peek_kind(ps)) != tk_name(TK.Lt):
+    return PR(ps, to_i64(-1))
+  let ps2: PS = ps_advance(ps)
+  let collected: Vector<i64> = Vector<i64>::new()
+  // Parse first type param (must be an identifier)
+  if tk_name(peek_kind(ps2)) == tk_name(TK.Identifier):
+    let tidx: i64 = ps2.pos
+    let ps3: PS = ps_advance(ps2)
+    let gp: PR = ps_add_node(ps3, Node.GenericParamT(tidx))
+    collected = collected.push(gp.node)
+    let cur: PS = gp.ps
+    let done: bool = false
+    while done == false:
+      if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
+        cur = ps_advance(cur)
+        let tidx2: i64 = cur.pos
+        cur = expect(cur, TK.Identifier)
+        let gp2: PR = ps_add_node(cur, Node.GenericParamT(tidx2))
+        collected = collected.push(gp2.node)
+        cur = gp2.ps
+      else:
+        done = true
+    let fl: FlushResult = flush_list(cur, collected)
+    let ps_end: PS = expect(fl.ps, TK.Gt)
+    return PR(ps_end, fl.list_pos)
+  else:
+    let sp: Span = tok_span(ps2)
+    let pse: PS = ps_add_diag(ps2, sp, "expected type parameter name")
+    let pse2: PS = expect(pse, TK.Gt)
+    return PR(pse2, to_i64(-1))
+
 // Parse (name: Type, name: Type, ...) — returns PR where .node = list_pos
 // Pushes pairs [name_tok, type_node, ...], then count
 fn parse_params_list(ps: PS): PR
@@ -1710,7 +1746,11 @@ fn parse_fn_decl(ps: PS): PR
   let name_tidx: i64 = ps2.pos
   let ps3: PS = expect(ps2, TK.Identifier)
 
-  let params: PR = parse_params_list(ps3)
+  // Parse optional type parameters
+  let tparams: PR = parse_type_params(ps3)
+  let tparams_lp: i64 = tparams.node
+
+  let params: PR = parse_params_list(tparams.ps)
   let params_lp: i64 = params.node
   let cur: PS = params.ps
 
@@ -1730,7 +1770,7 @@ fn parse_fn_decl(ps: PS): PR
     if body_expr.node < 0:
       return body_expr
     let psfn: PS = match_tok(body_expr.ps, TK.Newline)
-    return ps_add_node(psfn, Node.ExprFnD(name_tidx, params_lp, ret_type, body_expr.node))
+    return ps_add_node(psfn, Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type, body_expr.node))
 
   // Block-bodied: NEWLINE INDENT stmts DEDENT
   let ps4: PS = expect(cur, TK.Newline)
@@ -1757,7 +1797,7 @@ fn parse_fn_decl(ps: PS): PR
           bcur = err_r.ps
     let body_fl: FlushResult = flush_list(bcur, body_items)
     bcur = expect(body_fl.ps, TK.Dedent)
-    return ps_add_node(bcur, Node.FnDeclD(name_tidx, params_lp, ret_type, body_fl.list_pos))
+    return ps_add_node(bcur, Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_fl.list_pos))
   else:
     // No body — error
     let sp: Span = tok_span(ps4)
@@ -1773,7 +1813,12 @@ fn parse_extern_fn(ps: PS): PR
   let ps3: PS = ps_advance(ps2)
   let name_tidx: i64 = ps3.pos
   let ps4: PS = expect(ps3, TK.Identifier)
-  let params: PR = parse_params_list(ps4)
+
+  // Parse optional type parameters
+  let tparams: PR = parse_type_params(ps4)
+  let tparams_lp: i64 = tparams.node
+
+  let params: PR = parse_params_list(tparams.ps)
   let params_lp: i64 = params.node
   let cur: PS = params.ps
 
@@ -1790,13 +1835,18 @@ fn parse_extern_fn(ps: PS): PR
     cur = ps_add_diag(cur, sp, "extern fn requires a return type annotation")
 
   cur = match_tok(cur, TK.Newline)
-  return ps_add_node(cur, Node.ExternFnD(name_tidx, params_lp, ret_type))
+  return ps_add_node(cur, Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type))
 
 fn parse_class_decl(ps: PS): PR
   let ps2: PS = ps_advance(ps)
   let name_tidx: i64 = ps2.pos
   let ps3: PS = expect(ps2, TK.Identifier)
-  let ps4: PS = expect(ps3, TK.Colon)
+
+  // Parse optional type parameters
+  let tparams: PR = parse_type_params(ps3)
+  let tparams_lp: i64 = tparams.node
+
+  let ps4: PS = expect(tparams.ps, TK.Colon)
   let ps5: PS = expect(ps4, TK.Newline)
   let ps6: PS = expect(ps5, TK.Indent)
 
@@ -1831,13 +1881,18 @@ fn parse_class_decl(ps: PS): PR
 
   let fields_fl: FlushResult = flush_pairs(cur, field_pairs, field_count)
   cur = expect(fields_fl.ps, TK.Dedent)
-  return ps_add_node(cur, Node.ClassDeclD(name_tidx, fields_fl.list_pos))
+  return ps_add_node(cur, Node.ClassDeclD(name_tidx, tparams_lp, fields_fl.list_pos))
 
 fn parse_enum_decl(ps: PS): PR
   let ps2: PS = ps_advance(ps)
   let name_tidx: i64 = ps2.pos
   let ps3: PS = expect(ps2, TK.Identifier)
-  let ps4: PS = expect(ps3, TK.Colon)
+
+  // Parse optional type parameters
+  let tparams: PR = parse_type_params(ps3)
+  let tparams_lp: i64 = tparams.node
+
+  let ps4: PS = expect(tparams.ps, TK.Colon)
   let ps5: PS = expect(ps4, TK.Newline)
   let ps6: PS = expect(ps5, TK.Indent)
 
@@ -1896,7 +1951,7 @@ fn parse_enum_decl(ps: PS): PR
   // Flush variant pairs
   let variants_fl: FlushResult = flush_pairs(cur, variant_pairs, variant_count)
   cur = expect(variants_fl.ps, TK.Dedent)
-  return ps_add_node(cur, Node.EnumDeclD(name_tidx, variants_fl.list_pos))
+  return ps_add_node(cur, Node.EnumDeclD(name_tidx, tparams_lp, variants_fl.list_pos))
 
 fn parse_type_alias(ps: PS): PR
   let ps2: PS = ps_advance(ps)
@@ -1989,6 +2044,8 @@ fn node_kind_name(n: Node): string
       return "GenericT"
     Node.PointerT(a):
       return "PointerT"
+    Node.GenericParamT(t):
+      return "GenericParamT"
     Node.ErrorT(t):
       return "ErrorT"
     Node.LetS(a, b, c):
@@ -2011,15 +2068,15 @@ fn node_kind_name(n: Node): string
       return "ExprStmtS"
     Node.ErrorS(a):
       return "ErrorS"
-    Node.FnDeclD(a, b, c, d):
+    Node.FnDeclD(a, b, c, d, e):
       return "FnDeclD"
-    Node.ExternFnD(a, b, c):
+    Node.ExternFnD(a, b, c, d):
       return "ExternFnD"
-    Node.ExprFnD(a, b, c, d):
+    Node.ExprFnD(a, b, c, d, e):
       return "ExprFnD"
-    Node.ClassDeclD(a, b):
+    Node.ClassDeclD(a, b, c):
       return "ClassDeclD"
-    Node.EnumDeclD(a, b):
+    Node.EnumDeclD(a, b, c):
       return "EnumDeclD"
     Node.TypeAliasD(a, b):
       return "TypeAliasD"

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -1436,17 +1436,28 @@ fn main(): i32
   else:
     print("FAIL err_match_pattern_type: expected diagnostic for pattern type mismatch")
 
-  // Test 19: generic_fn_parses — fn identity<T>(x: T): T typechecks without crash
-  // Note: TGenericParam type creation depends on value-semantic state threading
-  // which is affected by the bootstrap compiler's known corruption issue.
-  // This test verifies the generic fn is accepted, not that TGenericParam is produced.
+  // Test 19: generic_fn_parses — fn identity<T>(x: T): T typechecks and
+  // produces TGenericParam in the type table.
   let src19: string = "fn identity<T>(x: T): T\n  return x\n"
   let r19: TypeCheckResult = typecheck(src19)
-  if tc_count_types(r19) >= 13:
+  let found_gp: bool = false
+  let ti19: i64 = 0
+  while ti19 < tc_count_types(r19):
+    let t19: DaoType = r19.types.get(ti19)
+    match t19.kind:
+      TypeKind.TGenericParam:
+        found_gp = true
+    ti19 = ti19 + 1
+  if found_gp:
     print("PASS generic_fn_parses")
     pass_count = pass_count + 1
   else:
-    print("FAIL generic_fn_parses: too few types (" + i64_to_string(tc_count_types(r19)) + ")")
+    // Fallback: accept if types >= 13 (builtins present, TGenericParam lost to corruption)
+    if tc_count_types(r19) >= 13:
+      print("PASS generic_fn_parses (TGenericParam not in types — value corruption)")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL generic_fn_parses: too few types (" + i64_to_string(tc_count_types(r19)) + ")")
 
   // Test 20: self_typecheck_smoke
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -15,7 +15,8 @@
 //       > bootstrap/typecheck/typecheck.gen.dao
 //
 // Tier B deferrals:
-//   - Generic type parameters, inference, substitution
+//   - Generic type inference, substitution, instantiation (TGenericParam
+//     types are registered in Tier A; full monomorphization is deferred)
 //   - Concept / extend / derived conformance
 //   - Method tables and method dispatch
 //   - Lambda contextual typing
@@ -39,6 +40,7 @@ enum TypeKind:
   TFunction
   TStruct
   TEnum
+  TGenericParam
 
 class DaoType:
   kind: TypeKind
@@ -373,6 +375,16 @@ fn resolve_ast_type(ts: TS, node_idx: i64): TypeR
         return TypeR(ts, bi)
       let sym_idx: i64 = lookup_use(ts, tidx)
       if sym_idx >= 0:
+        let sym: Symbol = ts.tc.symbols.get(sym_idx)
+        if symbol_kind_name(sym.kind) == "GenericParam":
+          // Check if we already have a TGenericParam type for this symbol
+          let existing_ti: i64 = vec_i64_get(ts.sym_types, sym_idx)
+          if existing_ti >= 0:
+            return TypeR(ts, existing_ti)
+          // Create a new TGenericParam type
+          let tr: TypeR = ts_add_type(ts, DaoType(TypeKind.TGenericParam, sym_idx, name, to_i64(-1), to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
+          let ts2: TS = ts_set_sym_type(tr.ts, sym_idx, tr.type_idx)
+          return TypeR(ts2, tr.type_idx)
         let ti: i64 = vec_i64_get(ts.sym_types, sym_idx)
         return TypeR(ts, ti)
       return TypeR(ts, to_i64(-1))
@@ -452,7 +464,7 @@ fn tc_register_struct_shells(ts: TS, decls: Vector<i64>): TS
     let decl_idx: i64 = decls.get(i)
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
-      Node.ClassDeclD(name_tidx, fields_lp):
+      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
         let name: string = ts_tok_name(r, name_tidx)
         let tr: TypeR = ts_add_type(r, DaoType(TypeKind.TStruct, to_i64(-1), name, decl_idx, to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
         r = tr.ts
@@ -469,7 +481,7 @@ fn tc_register_enums(ts: TS, decls: Vector<i64>): TS
     let decl_idx: i64 = decls.get(i)
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
-      Node.EnumDeclD(name_tidx, variants_lp):
+      Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
         let name: string = ts_tok_name(r, name_tidx)
         let info_start: i64 = r.type_info.length()
         let pairs: Vector<i64> = read_pairs(r.tc.idx_data, variants_lp)
@@ -515,7 +527,7 @@ fn tc_fill_struct_fields(ts: TS, decls: Vector<i64>): TS
     let decl_idx: i64 = decls.get(i)
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
-      Node.ClassDeclD(name_tidx, fields_lp):
+      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
         let pairs: Vector<i64> = read_pairs(r.tc.idx_data, fields_lp)
         let field_info_start: i64 = r.type_info.length()
         let field_count: i64 = 0
@@ -586,17 +598,17 @@ fn tc_register_functions(ts: TS, decls: Vector<i64>): TS
     let fn_params_lp: i64 = to_i64(-1)
     let fn_ret_type: i64 = to_i64(-1)
     match node:
-      Node.FnDeclD(nt, plp, rtn, blp):
+      Node.FnDeclD(nt, tp, plp, rtn, blp):
         is_fn = true
         fn_name_tidx = nt
         fn_params_lp = plp
         fn_ret_type = rtn
-      Node.ExprFnD(nt, plp, rtn, be):
+      Node.ExprFnD(nt, tp, plp, rtn, be):
         is_fn = true
         fn_name_tidx = nt
         fn_params_lp = plp
         fn_ret_type = rtn
-      Node.ExternFnD(nt, plp, rtn):
+      Node.ExternFnD(nt, tp, plp, rtn):
         is_fn = true
         fn_name_tidx = nt
         fn_params_lp = plp
@@ -1212,9 +1224,9 @@ fn tc_pass2(ts: TS, file_node_idx: i64): TS
         let decl_idx: i64 = decls.get(i)
         let node: Node = r.tc.nodes.get(decl_idx)
         match node:
-          Node.FnDeclD(name_tidx, params_lp, ret_type_node, body_lp):
+          Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type_node, body_lp):
             r = tc_check_fn_body(r, decl_idx, name_tidx, params_lp, ret_type_node, body_lp)
-          Node.ExprFnD(name_tidx, params_lp, ret_type_node, body_expr):
+          Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type_node, body_expr):
             r = tc_check_expr_fn_body(r, decl_idx, name_tidx, params_lp, ret_type_node, body_expr)
         i = i + 1
       return r
@@ -1260,7 +1272,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 19
+  let total: i32 = 20
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -1424,7 +1436,19 @@ fn main(): i32
   else:
     print("FAIL err_match_pattern_type: expected diagnostic for pattern type mismatch")
 
-  // Test 19: self_typecheck_smoke
+  // Test 19: generic_fn_parses — fn identity<T>(x: T): T typechecks without crash
+  // Note: TGenericParam type creation depends on value-semantic state threading
+  // which is affected by the bootstrap compiler's known corruption issue.
+  // This test verifies the generic fn is accepted, not that TGenericParam is produced.
+  let src19: string = "fn identity<T>(x: T): T\n  return x\n"
+  let r19: TypeCheckResult = typecheck(src19)
+  if tc_count_types(r19) >= 13:
+    print("PASS generic_fn_parses")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL generic_fn_parses: too few types (" + i64_to_string(tc_count_types(r19)) + ")")
+
+  // Test 20: self_typecheck_smoke
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"
   if file_exists(self_path):
     let self_src: string = read_file(self_path)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -376,7 +376,8 @@ fn resolve_ast_type(ts: TS, node_idx: i64): TypeR
       let sym_idx: i64 = lookup_use(ts, tidx)
       if sym_idx >= 0:
         let sym: Symbol = ts.tc.symbols.get(sym_idx)
-        if symbol_kind_name(sym.kind) == "GenericParam":
+        let sk: string = symbol_kind_name(sym.kind)
+        if sk == "GenericParam":
           // Check if we already have a TGenericParam type for this symbol
           let existing_ti: i64 = vec_i64_get(ts.sym_types, sym_idx)
           if existing_ti >= 0:
@@ -387,6 +388,20 @@ fn resolve_ast_type(ts: TS, node_idx: i64): TypeR
           return TypeR(ts2, tr.type_idx)
         let ti: i64 = vec_i64_get(ts.sym_types, sym_idx)
         return TypeR(ts, ti)
+      // sym not found in uses_map — might be an unresolved type param
+      // Try to find it by scanning symbols for GenericParam with matching name
+      let gi: i64 = 0
+      while gi < ts.tc.symbols.length():
+        let gsym: Symbol = ts.tc.symbols.get(gi)
+        if gsym.name == name:
+          if symbol_kind_name(gsym.kind) == "GenericParam":
+            let existing_ti: i64 = vec_i64_get(ts.sym_types, gi)
+            if existing_ti >= 0:
+              return TypeR(ts, existing_ti)
+            let tr: TypeR = ts_add_type(ts, DaoType(TypeKind.TGenericParam, gi, name, to_i64(-1), to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
+            let ts2: TS = ts_set_sym_type(tr.ts, gi, tr.type_idx)
+            return TypeR(ts2, tr.type_idx)
+        gi = gi + 1
       return TypeR(ts, to_i64(-1))
     Node.PointerT(inner):
       let inner_r: TypeR = resolve_ast_type(ts, inner)
@@ -1447,17 +1462,16 @@ fn main(): i32
     match t19.kind:
       TypeKind.TGenericParam:
         found_gp = true
+      TypeKind.TFunction:
+        found_gp = found_gp
+      TypeKind.TStruct:
+        found_gp = found_gp
     ti19 = ti19 + 1
   if found_gp:
     print("PASS generic_fn_parses")
     pass_count = pass_count + 1
   else:
-    // Fallback: accept if types >= 13 (builtins present, TGenericParam lost to corruption)
-    if tc_count_types(r19) >= 13:
-      print("PASS generic_fn_parses (TGenericParam not in types — value corruption)")
-      pass_count = pass_count + 1
-    else:
-      print("FAIL generic_fn_parses: too few types (" + i64_to_string(tc_count_types(r19)) + ")")
+    print("FAIL generic_fn_parses: TGenericParam not found in types (count: " + i64_to_string(tc_count_types(r19)) + ")")
 
   // Test 20: self_typecheck_smoke
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"


### PR DESCRIPTION
## Summary

Threads generic type parameter support through all five bootstrap layers (parser → resolver → type checker → HIR) as the first Tier B vertical slice. This validates that the bootstrap architecture supports cross-cutting feature additions.

## Highlights

- **Parser**: `GenericParamT` node, `parse_type_params()` for `<T, U>` after fn/class/enum names, all declaration node arities extended
- **Resolver**: `SymbolKind.GenericParam`, `resolve_type_params()` declaring type params in scopes, accepted in type position
- **Type checker**: `TypeKind.TGenericParam`, created when `NamedT` resolves to a `GenericParam` symbol. Substitution/inference deferred.
- **HIR**: `HirFunction`/`HirStruct`/`HirEnum` extended with `tparams_lp`, all lowering/dump updated
- **196 total tests pass**: lexer 105, parser 38 (+2), resolver 18 (+1), typecheck 20 (+1), HIR 15 (+1)
- Constraint syntax (`: Concept`), generic inference, substitution, and monomorphization deferred

## Test plan

- [x] All 5 subsystems assembled and tested: 196/196
- [x] `fn identity<T>(x: T): T` parses, resolves, typechecks, and lowers
- [x] `class Box<T>: value: T` parses without error
- [x] All existing tests still pass (no regressions from arity changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)