### PR TITLE
feat(bootstrap): ✨ add class methods vertical slice — Tier B

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -32,7 +32,7 @@ enum HirNode:
   HirFile(i64)
 
   // Declarations
-  HirFunction(i64, i64, i64, i64, i64, i64)
+  HirFunction(i64, i64, i64, i64, i64, i64, i64)  // name, tparams_lp, params_lp, ret_ti, body_lp, is_extern, class_owner_tidx (-1 for free fns)
   HirStruct(i64, i64, i64)
   HirEnum(i64, i64, i64)
   HirTypeAlias(i64, i64)
@@ -549,10 +549,8 @@ fn lower_type_params(hs: HS, ast_tparams_lp: i64): HirFlush
     return HirFlush(hs, to_i64(-1))
   return hir_flush_list(hs, tok_indices)
 
-fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_lp: i64): HirR
-  // Lower type params into HIR-owned idx
+fn lower_fn_decl_with_owner(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_lp: i64, class_owner_tidx: i64): HirR
   let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
-  // Resolve return type
   let ret_ti: i64 = to_i64(11)
   let fn_sym: i64 = hir_find_sym_by_decl(tp_fl.hs, decl_idx, "Function")
   if fn_sym >= 0:
@@ -560,7 +558,6 @@ fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_
     if fn_ti >= 0:
       let fn_type: DaoType = tp_fl.hs.types.get(fn_ti)
       ret_ti = fn_type.ret_type
-  // Lower params: flush pairs (name_tok_idx, type_idx)
   let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, params_lp)
   let param_items: Vector<i64> = Vector<i64>::new()
   let param_count: i64 = 0
@@ -568,7 +565,6 @@ fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_
   while pi < pairs.length():
     let p_tidx: i64 = pairs.get(pi)
     let p_type_node: i64 = pairs.get(pi + 1)
-    // Get param type from sym_types
     let p_name: string = hs_tok_name(hs, p_tidx)
     let p_sym: i64 = hir_find_param_sym(hs, decl_idx, p_name)
     let p_ti: i64 = to_i64(-1)
@@ -579,9 +575,11 @@ fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_
     param_count = param_count + 1
     pi = pi + 2
   let param_fl: HirFlush = hir_flush_pairs(tp_fl.hs, param_items, param_count)
-  // Lower body
   let body_fl: HirFlush = lower_body_stmts(param_fl.hs, body_lp)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0), class_owner_tidx))
+
+fn lower_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_lp: i64): HirR
+  return lower_fn_decl_with_owner(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node, body_lp, to_i64(-1))
 
 fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64, body_expr: i64): HirR
   // Lower type params into HIR-owned idx
@@ -620,7 +618,7 @@ fn lower_expr_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, pa
   let body_stmts: Vector<i64> = Vector<i64>::new()
   body_stmts = body_stmts.push(ret_r.hir)
   let body_fl: HirFlush = hir_flush_list(ret_r.hs, body_stmts)
-  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0)))
+  return hs_add_node(body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, body_fl.list_pos, to_i64(0), to_i64(-1)))
 
 fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, params_lp: i64, ret_type_node: i64): HirR
   let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
@@ -651,7 +649,7 @@ fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, 
   let param_fl: HirFlush = hir_flush_pairs(tp_fl.hs, param_items, param_count)
   // No body — use empty list
   let empty_body_fl: HirFlush = hir_flush_list(param_fl.hs, Vector<i64>::new())
-  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
+  return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1), to_i64(-1)))
 
 fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64, methods_lp: i64): HirR
   let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
@@ -840,7 +838,8 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
         let dr: HirR = lower_decl(cur, decls.get(i))
         cur = dr.hs
         hir_decls = hir_decls.push(dr.hir)
-        // Emit methods as flat top-level HirFunction nodes
+        // Emit methods as flat top-level HirFunction nodes with
+        // class_owner set to the class name token for mangled identity.
         let decl_node: Node = hs.nodes.get(decls.get(i))
         match decl_node:
           Node.ClassDeclD(cn_tidx, cn_tp, cn_fl, cn_ml):
@@ -852,7 +851,7 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
                 let meth_node: Node = cur.nodes.get(meth_idx)
                 match meth_node:
                   Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
-                    let mr: HirR = lower_fn_decl(cur, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
+                    let mr: HirR = lower_fn_decl_with_owner(cur, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp, cn_tidx)
                     cur = mr.hs
                     hir_decls = hir_decls.push(mr.hir)
                 mi = mi + 1
@@ -888,7 +887,7 @@ fn hir_node_kind(node: HirNode): string
   match node:
     HirNode.HirFile(a):
       return "HirFile"
-    HirNode.HirFunction(a, b, c, d, e, f):
+    HirNode.HirFunction(a, b, c, d, e, f, g):
       return "HirFunction"
     HirNode.HirStruct(a, b, c):
       return "HirStruct"
@@ -972,7 +971,10 @@ fn hir_dump_node(hr: HirResult, idx: i64, indent: i64): string
         line = line + hir_dump_node(hr, decls.get(di), indent + 1)
         di = di + 1
       return line
-    HirNode.HirFunction(name_tidx, tparams_lp, params_lp, ret_ti, body_lp, is_extern):
+    HirNode.HirFunction(name_tidx, tparams_lp, params_lp, ret_ti, body_lp, is_extern, class_owner):
+      if class_owner >= 0:
+        let co_tok: Token = hr.toks.get(class_owner)
+        line = line + " [" + substring(hr.src, co_tok.offset, co_tok.len) + ".]"
       if tparams_lp >= 0:
         let tps: Vector<i64> = read_list(hr.hir_idx, tparams_lp)
         line = line + "<"
@@ -1379,7 +1381,7 @@ fn main(): i32
     while i12 < hir_count_nodes(r12):
       let n12: HirNode = r12.hir_nodes.get(i12)
       match n12:
-        HirNode.HirFunction(nt, tp, plp, rti, blp, is_ext):
+        HirNode.HirFunction(nt, tp, plp, rti, blp, is_ext, co):
           if is_ext > 0:
             found_extern = true
       i12 = i12 + 1
@@ -1432,7 +1434,7 @@ fn main(): i32
     while i14g < hir_count_nodes(r14g):
       let n14g: HirNode = r14g.hir_nodes.get(i14g)
       match n14g:
-        HirNode.HirFunction(nm, tp_lp, pl, rt, bl, ie):
+        HirNode.HirFunction(nm, tp_lp, pl, rt, bl, ie, co2):
           found_fn14 = true
           if tp_lp >= 0:
             let tps: Vector<i64> = read_list(r14g.hir_idx, tp_lp)

--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -653,7 +653,7 @@ fn lower_extern_fn_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, 
   let empty_body_fl: HirFlush = hir_flush_list(param_fl.hs, Vector<i64>::new())
   return hs_add_node(empty_body_fl.hs, HirNode.HirFunction(name_tidx, tp_fl.list_pos, param_fl.list_pos, ret_ti, empty_body_fl.list_pos, to_i64(1)))
 
-fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64): HirR
+fn lower_class_decl(hs: HS, decl_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64, methods_lp: i64): HirR
   let tp_fl: HirFlush = lower_type_params(hs, tparams_lp)
   let pairs: Vector<i64> = read_pairs(tp_fl.hs.idx_data, fields_lp)
   let field_items: Vector<i64> = Vector<i64>::new()
@@ -778,8 +778,8 @@ fn lower_decl(hs: HS, decl_idx: i64): HirR
       return lower_expr_fn_decl(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node, body_expr)
     Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type_node):
       return lower_extern_fn_decl(hs, decl_idx, name_tidx, tparams_lp, params_lp, ret_type_node)
-    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
-      return lower_class_decl(hs, decl_idx, name_tidx, tparams_lp, fields_lp)
+    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
+      return lower_class_decl(hs, decl_idx, name_tidx, tparams_lp, fields_lp, methods_lp)
     Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
       return lower_enum_decl(hs, decl_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
@@ -840,6 +840,22 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
         let dr: HirR = lower_decl(cur, decls.get(i))
         cur = dr.hs
         hir_decls = hir_decls.push(dr.hir)
+        // Emit methods as flat top-level HirFunction nodes
+        let decl_node: Node = hs.nodes.get(decls.get(i))
+        match decl_node:
+          Node.ClassDeclD(cn_tidx, cn_tp, cn_fl, cn_ml):
+            if cn_ml >= 0:
+              let methods: Vector<i64> = read_list(cur.idx_data, cn_ml)
+              let mi: i64 = 0
+              while mi < methods.length():
+                let meth_idx: i64 = methods.get(mi)
+                let meth_node: Node = cur.nodes.get(meth_idx)
+                match meth_node:
+                  Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+                    let mr: HirR = lower_fn_decl(cur, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
+                    cur = mr.hs
+                    hir_decls = hir_decls.push(mr.hir)
+                mi = mi + 1
         i = i + 1
       let fl: HirFlush = hir_flush_list(cur, hir_decls)
       return hs_add_node(fl.hs, HirNode.HirFile(fl.list_pos))

--- a/bootstrap/parser/tests.dao
+++ b/bootstrap/parser/tests.dao
@@ -53,7 +53,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 38
+  let total: i32 = 40
 
   // -----------------------------------------------------------------
   // Expression tests
@@ -320,6 +320,22 @@ fn main(): i32
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
+  // Method tests
+  // -----------------------------------------------------------------
+
+  // Test 36: Class with method
+  let src36: string = "class Foo:\n  x: i32\n  fn get_x(self): i32\n    return self.x\n"
+  let r36: PR = parse(src36)
+  if expect_no_parse_errors("class_method_no_err", r36):
+    pass_count = pass_count + 1
+
+  // Test 37: Class with method and multiple params
+  let src37: string = "class Bar:\n  val: i64\n  fn add(self, n: i64): i64\n    return self.val + n\n"
+  let r37: PR = parse(src37)
+  if expect_no_parse_errors("class_method_multi_param_no_err", r37):
+    pass_count = pass_count + 1
+
+  // -----------------------------------------------------------------
   // Summary
   // -----------------------------------------------------------------
 
@@ -335,7 +351,7 @@ fn main(): i32
   //   - concept declarations
   //   - derived concept declarations
   //   - extend declarations
-  //   - class methods / conformance blocks (as / deny)
+  //   - conformance blocks (as / deny)
   //   - mode / resource blocks
   //   - yield statements
   //   - function types (fn(T): R as a type)

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -608,11 +608,8 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fi
     r = resolve_type_node(r, f_type)
     i = i + 2
 
-  // Pop struct scope
-  r = rs_pop_scope(r)
-
-  // Resolve methods (declared in file scope by collect_top_level)
-  let class_name: string = tok_name(r, name_tidx)
+  // Resolve methods BEFORE popping struct scope, so class type params
+  // (e.g. T in class Box<T>) are visible in method signatures/bodies.
   if methods_lp >= 0:
     let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
     let mi: i64 = 0
@@ -623,6 +620,9 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fi
         Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
           r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
       mi = mi + 1
+
+  // Pop struct scope after methods are resolved
+  r = rs_pop_scope(r)
   return r
 
 fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, variants_lp: i64): RS

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -587,7 +587,7 @@ fn resolve_extern_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64
   // Pop function scope (no body)
   return rs_pop_scope(r)
 
-fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64): RS
+fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fields_lp: i64, methods_lp: i64): RS
   // Create struct scope
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.StructScope)
   let r: RS = sr.rs
@@ -609,7 +609,21 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fi
     i = i + 2
 
   // Pop struct scope
-  return rs_pop_scope(r)
+  r = rs_pop_scope(r)
+
+  // Resolve methods (declared in file scope by collect_top_level)
+  let class_name: string = tok_name(r, name_tidx)
+  if methods_lp >= 0:
+    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let mi: i64 = 0
+    while mi < methods.length():
+      let meth_idx: i64 = methods.get(mi)
+      let meth_node: Node = r.nodes.get(meth_idx)
+      match meth_node:
+        Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+          r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
+      mi = mi + 1
+  return r
 
 fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, variants_lp: i64): RS
   // Create a scope for type parameters if present
@@ -651,8 +665,8 @@ fn resolve_decl(rs: RS, node_idx: i64): RS
       return resolve_expr_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type, body_expr)
     Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type):
       return resolve_extern_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type)
-    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
-      return resolve_class_decl(rs, node_idx, name_tidx, tparams_lp, fields_lp)
+    Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
+      return resolve_class_decl(rs, node_idx, name_tidx, tparams_lp, fields_lp, methods_lp)
     Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
       return resolve_enum_decl(rs, node_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
@@ -688,10 +702,24 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
-          Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
+          Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
+            // Register mangled method symbols in file scope
+            if methods_lp >= 0:
+              let meths: Vector<i64> = read_list(r.idx_data, methods_lp)
+              let mi: i64 = 0
+              while mi < meths.length():
+                let meth_idx: i64 = meths.get(mi)
+                let meth_node: Node = r.nodes.get(meth_idx)
+                match meth_node:
+                  Node.FnDeclD(m_name_tidx, m_tp, m_plp, m_rt, m_blp):
+                    let mname: string = tok_name(r, m_name_tidx)
+                    let mangled: string = name + "." + mname
+                    let msr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, mangled, meth_idx, r.current_scope))
+                    r = scope_declare(msr.rs, mangled, msr.sym_idx, m_name_tidx)
+                mi = mi + 1
           Node.EnumDeclD(name_tidx, tparams_lp, variants_lp):
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -796,7 +796,7 @@ enum Node:
   FnDeclD(i64, i64, i64, i64, i64)
   ExternFnD(i64, i64, i64, i64)
   ExprFnD(i64, i64, i64, i64, i64)
-  ClassDeclD(i64, i64, i64)
+  ClassDeclD(i64, i64, i64, i64)
   EnumDeclD(i64, i64, i64)
   TypeAliasD(i64, i64)
   ErrorD(i64)
@@ -1091,6 +1091,11 @@ fn parse_primary(ps: PS): PR
   // Identifier or qualified name
   if tk_name(k) == tk_name(TK.Identifier):
     return parse_ident_or_qual(ps)
+
+  // self keyword as expression (inside method bodies)
+  if tk_name(k) == tk_name(TK.KwSelf):
+    let self_tidx: i64 = ps.pos
+    return ps_add_node(ps_advance(ps), Node.IdentE(self_tidx))
 
   // Error
   let sp: Span = tok_span(ps)
@@ -1706,34 +1711,46 @@ fn parse_params_list(ps: PS): PR
   let cur: PS = ps2
 
   if tk_name(peek_kind(cur)) != tk_name(TK.RParen):
-    // Parse first param
+    // Parse first param — accept KwSelf as a parameter name (self param)
     let name_tidx: i64 = cur.pos
-    cur = expect(cur, TK.Identifier)
-    cur = expect(cur, TK.Colon)
-    let ty: PR = parse_type(cur)
-    cur = ty.ps
-    param_pairs = param_pairs.push(name_tidx)
-    if ty.node >= 0:
-      param_pairs = param_pairs.push(ty.node)
-    else:
+    if tk_name(peek_kind(cur)) == tk_name(TK.KwSelf):
+      cur = ps_advance(cur)
+      param_pairs = param_pairs.push(name_tidx)
       param_pairs = param_pairs.push(to_i64(-1))
-    count = count + 1
+      count = count + 1
+    else:
+      cur = expect(cur, TK.Identifier)
+      cur = expect(cur, TK.Colon)
+      let ty: PR = parse_type(cur)
+      cur = ty.ps
+      param_pairs = param_pairs.push(name_tidx)
+      if ty.node >= 0:
+        param_pairs = param_pairs.push(ty.node)
+      else:
+        param_pairs = param_pairs.push(to_i64(-1))
+      count = count + 1
 
     let done: bool = false
     while done == false:
       if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
         cur = ps_advance(cur)
         let name_tidx2: i64 = cur.pos
-        cur = expect(cur, TK.Identifier)
-        cur = expect(cur, TK.Colon)
-        let ty2: PR = parse_type(cur)
-        cur = ty2.ps
-        param_pairs = param_pairs.push(name_tidx2)
-        if ty2.node >= 0:
-          param_pairs = param_pairs.push(ty2.node)
-        else:
+        if tk_name(peek_kind(cur)) == tk_name(TK.KwSelf):
+          cur = ps_advance(cur)
+          param_pairs = param_pairs.push(name_tidx2)
           param_pairs = param_pairs.push(to_i64(-1))
-        count = count + 1
+          count = count + 1
+        else:
+          cur = expect(cur, TK.Identifier)
+          cur = expect(cur, TK.Colon)
+          let ty2: PR = parse_type(cur)
+          cur = ty2.ps
+          param_pairs = param_pairs.push(name_tidx2)
+          if ty2.node >= 0:
+            param_pairs = param_pairs.push(ty2.node)
+          else:
+            param_pairs = param_pairs.push(to_i64(-1))
+          count = count + 1
       else:
         done = true
 
@@ -1861,18 +1878,21 @@ fn parse_class_decl(ps: PS): PR
     if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
       done = true
     else:
-      let fname_tidx: i64 = cur.pos
-      cur = expect(cur, TK.Identifier)
-      cur = expect(cur, TK.Colon)
-      let fty: PR = parse_type(cur)
-      cur = fty.ps
-      field_pairs = field_pairs.push(fname_tidx)
-      if fty.node >= 0:
-        field_pairs = field_pairs.push(fty.node)
+      if tk_name(k) == tk_name(TK.KwFn):
+        done = true
       else:
-        field_pairs = field_pairs.push(to_i64(-1))
-      field_count = field_count + 1
-      cur = match_tok(cur, TK.Newline)
+        let fname_tidx: i64 = cur.pos
+        cur = expect(cur, TK.Identifier)
+        cur = expect(cur, TK.Colon)
+        let fty: PR = parse_type(cur)
+        cur = fty.ps
+        field_pairs = field_pairs.push(fname_tidx)
+        if fty.node >= 0:
+          field_pairs = field_pairs.push(fty.node)
+        else:
+          field_pairs = field_pairs.push(to_i64(-1))
+        field_count = field_count + 1
+        cur = match_tok(cur, TK.Newline)
 
   // Diagnose empty class body (contract: must have at least one field).
   if field_count == 0:
@@ -1880,8 +1900,30 @@ fn parse_class_decl(ps: PS): PR
     cur = ps_add_diag(cur, sp, "class body must contain at least one field")
 
   let fields_fl: FlushResult = flush_pairs(cur, field_pairs, field_count)
-  cur = expect(fields_fl.ps, TK.Dedent)
-  return ps_add_node(cur, Node.ClassDeclD(name_tidx, tparams_lp, fields_fl.list_pos))
+  cur = fields_fl.ps
+
+  // Parse methods: collect method node indices when we see KwFn
+  let method_items: Vector<i64> = Vector<i64>::new()
+  let mdone: bool = false
+  while mdone == false:
+    cur = skip_newlines(cur)
+    let mk: TK = peek_kind(cur)
+    if tk_name(mk) == tk_name(TK.KwFn):
+      let meth: PR = parse_fn_decl(cur)
+      if meth.node >= 0:
+        method_items = method_items.push(meth.node)
+      cur = meth.ps
+    else:
+      mdone = true
+
+  let methods_lp: i64 = to_i64(-1)
+  if method_items.length() > 0:
+    let mfl: FlushResult = flush_list(cur, method_items)
+    cur = mfl.ps
+    methods_lp = mfl.list_pos
+
+  cur = expect(cur, TK.Dedent)
+  return ps_add_node(cur, Node.ClassDeclD(name_tidx, tparams_lp, fields_fl.list_pos, methods_lp))
 
 fn parse_enum_decl(ps: PS): PR
   let ps2: PS = ps_advance(ps)
@@ -2074,7 +2116,7 @@ fn node_kind_name(n: Node): string
       return "ExternFnD"
     Node.ExprFnD(a, b, c, d, e):
       return "ExprFnD"
-    Node.ClassDeclD(a, b, c):
+    Node.ClassDeclD(a, b, c, d):
       return "ClassDeclD"
     Node.EnumDeclD(a, b, c):
       return "EnumDeclD"

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -1735,7 +1735,10 @@ fn parse_params_list(ps: PS): PR
       if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
         cur = ps_advance(cur)
         let name_tidx2: i64 = cur.pos
+        // self is only valid as the first parameter — reject here
         if tk_name(peek_kind(cur)) == tk_name(TK.KwSelf):
+          let sp: Span = tok_span(cur)
+          cur = ps_add_diag(cur, sp, "self must be the first parameter")
           cur = ps_advance(cur)
           param_pairs = param_pairs.push(name_tidx2)
           param_pairs = param_pairs.push(to_i64(-1))

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -479,7 +479,7 @@ fn tc_register_struct_shells(ts: TS, decls: Vector<i64>): TS
     let decl_idx: i64 = decls.get(i)
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
-      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
+      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
         let name: string = ts_tok_name(r, name_tidx)
         let tr: TypeR = ts_add_type(r, DaoType(TypeKind.TStruct, to_i64(-1), name, decl_idx, to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
         r = tr.ts
@@ -542,7 +542,7 @@ fn tc_fill_struct_fields(ts: TS, decls: Vector<i64>): TS
     let decl_idx: i64 = decls.get(i)
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
-      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp):
+      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
         let pairs: Vector<i64> = read_pairs(r.tc.idx_data, fields_lp)
         let field_info_start: i64 = r.type_info.length()
         let field_count: i64 = 0
@@ -647,6 +647,51 @@ fn tc_register_functions(ts: TS, decls: Vector<i64>): TS
     j = j + 1
   return TS(r.tc, r.types, r.type_info, st, r.diags, r.return_type, r.loop_depth, r.expr_types)
 
+fn tc_register_methods(ts: TS, decls: Vector<i64>): TS
+  let r: TS = ts
+  let i: i64 = 0
+  while i < decls.length():
+    let decl_idx: i64 = decls.get(i)
+    let node: Node = r.tc.nodes.get(decl_idx)
+    match node:
+      Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
+        if methods_lp >= 0:
+          let class_name: string = ts_tok_name(r, name_tidx)
+          let methods: Vector<i64> = read_list(r.tc.idx_data, methods_lp)
+          let mi: i64 = 0
+          while mi < methods.length():
+            let meth_idx: i64 = methods.get(mi)
+            let meth_node: Node = r.tc.nodes.get(meth_idx)
+            match meth_node:
+              Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+                // Register method function type (including self param)
+                let tr: TypeR = tc_register_fn_sig_core(r, meth_idx, m_name_tidx, m_params_lp, m_ret_type)
+                r = tr.ts
+                // Find the mangled symbol and set its type
+                let mname: string = ts_tok_name(r, m_name_tidx)
+                let mangled: string = class_name + "." + mname
+                let msym: i64 = to_i64(-1)
+                let si: i64 = 0
+                while si < r.tc.symbols.length():
+                  let sym: Symbol = r.tc.symbols.get(si)
+                  if sym.name == mangled:
+                    if symbol_kind_name(sym.kind) == "Function":
+                      msym = si
+                  si = si + 1
+                if msym >= 0:
+                  r = ts_set_sym_type(r, msym, tr.type_idx)
+                // Set self param type to the enclosing struct type
+                let struct_sym: i64 = find_sym_by_decl(r, decl_idx, "Type")
+                if struct_sym >= 0:
+                  let struct_ti: i64 = vec_i64_get(r.sym_types, struct_sym)
+                  if struct_ti >= 0:
+                    let self_sym: i64 = find_param_sym(r, meth_idx, "self")
+                    if self_sym >= 0:
+                      r = ts_set_sym_type(r, self_sym, struct_ti)
+            mi = mi + 1
+    i = i + 1
+  return r
+
 fn tc_pass1(ts: TS, file_node_idx: i64): TS
   let file_node: Node = ts.tc.nodes.get(file_node_idx)
   match file_node:
@@ -658,6 +703,7 @@ fn tc_pass1(ts: TS, file_node_idx: i64): TS
       r = tc_register_enums(r, decls)
       r = tc_fill_struct_fields(r, decls)
       r = tc_register_functions(r, decls)
+      r = tc_register_methods(r, decls)
       return r
   return ts
 
@@ -899,14 +945,26 @@ fn check_call_expr(ts: TS, node_idx: i64, callee: i64, args_lp: i64, arg_count: 
   let callee_type: DaoType = r.types.get(callee_ti)
   match callee_type.kind:
     TypeKind.TFunction:
-      if args.length() != callee_type.info_count:
+      // Detect method call: callee is a FieldE and first param is self
+      let is_method: bool = false
+      let callee_node2: Node = r.tc.nodes.get(callee)
+      match callee_node2:
+        Node.FieldE(mobj, mfield):
+          if callee_type.info_count > 0:
+            is_method = true
+      let param_offset: i64 = 0
+      let expected_args: i64 = callee_type.info_count
+      if is_method:
+        param_offset = 1
+        expected_args = callee_type.info_count - 1
+      if args.length() != expected_args:
         let sp: Span = ts_node_span(r, callee)
-        r = ts_add_diag(r, sp, "arity mismatch: expected " + i64_to_string(callee_type.info_count) + " arguments, got " + i64_to_string(args.length()))
+        r = ts_add_diag(r, sp, "arity mismatch: expected " + i64_to_string(expected_args) + " arguments, got " + i64_to_string(args.length()))
         return r
       let ci: i64 = 0
       while ci < args.length():
         let arg_ti: i64 = get_expr_type(r, args.get(ci))
-        let param_ti: i64 = r.type_info.get(callee_type.info_lp + ci)
+        let param_ti: i64 = r.type_info.get(callee_type.info_lp + param_offset + ci)
         if arg_ti >= 0:
           if param_ti >= 0:
             if types_equal(r, arg_ti, param_ti) == false:
@@ -943,6 +1001,7 @@ fn check_field_expr(ts: TS, node_idx: i64, obj: i64, field_tidx: i64): TS
   match obj_type.kind:
     TypeKind.TStruct:
       let field_name: string = ts_tok_name(r, field_tidx)
+      // Try field lookup first
       let fi: i64 = 0
       while fi < obj_type.info_count:
         let f_name_tidx: i64 = r.type_info.get(obj_type.info_lp + fi * 2)
@@ -951,6 +1010,20 @@ fn check_field_expr(ts: TS, node_idx: i64, obj: i64, field_tidx: i64): TS
         if f_name == field_name:
           return ts_set_expr_type(r, node_idx, f_type_idx)
         fi = fi + 1
+      // Try method lookup: look for mangled symbol "StructName.fieldName"
+      let mangled_name: string = obj_type.name + "." + field_name
+      let msym: i64 = to_i64(-1)
+      let si: i64 = 0
+      while si < r.tc.symbols.length():
+        let sym: Symbol = r.tc.symbols.get(si)
+        if sym.name == mangled_name:
+          if symbol_kind_name(sym.kind) == "Function":
+            msym = si
+        si = si + 1
+      if msym >= 0:
+        let meth_ti: i64 = vec_i64_get(r.sym_types, msym)
+        if meth_ti >= 0:
+          return ts_set_expr_type(r, node_idx, meth_ti)
       let sp: Span = ts_tok_span(r, field_tidx)
       r = ts_add_diag(r, sp, "no field '" + field_name + "' on type " + type_name(r, obj_ti))
       return r
@@ -1228,6 +1301,57 @@ fn tc_check_expr_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, 
   r = ts_set_return_type(r, old_return_type)
   return r
 
+fn tc_check_method_body(ts: TS, class_decl_idx: i64, meth_idx: i64, m_name_tidx: i64, m_params_lp: i64, m_ret_type: i64, m_body_lp: i64): TS
+  let r: TS = ts
+  let fn_ti: i64 = to_i64(-1)
+  // Find the mangled symbol for this method
+  let class_name: string = ""
+  let class_node: Node = r.tc.nodes.get(class_decl_idx)
+  match class_node:
+    Node.ClassDeclD(cn_tidx, cn_tp, cn_fl, cn_ml):
+      class_name = ts_tok_name(r, cn_tidx)
+  let mname: string = ts_tok_name(r, m_name_tidx)
+  let mangled: string = class_name + "." + mname
+  let msym: i64 = to_i64(-1)
+  let si: i64 = 0
+  while si < r.tc.symbols.length():
+    let sym: Symbol = r.tc.symbols.get(si)
+    if sym.name == mangled:
+      if symbol_kind_name(sym.kind) == "Function":
+        msym = si
+    si = si + 1
+  if msym >= 0:
+    fn_ti = vec_i64_get(r.sym_types, msym)
+  let old_return_type: i64 = r.return_type
+  if fn_ti >= 0:
+    let fn_type: DaoType = r.types.get(fn_ti)
+    r = ts_set_return_type(r, fn_type.ret_type)
+  // Declare param types — self gets the enclosing struct type
+  let pairs: Vector<i64> = read_pairs(r.tc.idx_data, m_params_lp)
+  let pi: i64 = 0
+  while pi < pairs.length():
+    let p_tidx: i64 = pairs.get(pi)
+    let p_type_node: i64 = pairs.get(pi + 1)
+    let p_name: string = ts_tok_name(r, p_tidx)
+    let p_sym: i64 = find_param_sym(r, meth_idx, p_name)
+    if p_sym >= 0:
+      if p_name == "self":
+        // Self type is the enclosing struct
+        let struct_sym: i64 = find_sym_by_decl(r, class_decl_idx, "Type")
+        if struct_sym >= 0:
+          let struct_ti: i64 = vec_i64_get(r.sym_types, struct_sym)
+          if struct_ti >= 0:
+            r = ts_set_sym_type(r, p_sym, struct_ti)
+      else:
+        let pt_r: TypeR = resolve_ast_type(r, p_type_node)
+        r = pt_r.ts
+        if pt_r.type_idx >= 0:
+          r = ts_set_sym_type(r, p_sym, pt_r.type_idx)
+    pi = pi + 2
+  r = check_body_stmts(r, m_body_lp)
+  r = ts_set_return_type(r, old_return_type)
+  return r
+
 fn tc_pass2(ts: TS, file_node_idx: i64): TS
   let file_node: Node = ts.tc.nodes.get(file_node_idx)
   match file_node:
@@ -1243,6 +1367,17 @@ fn tc_pass2(ts: TS, file_node_idx: i64): TS
             r = tc_check_fn_body(r, decl_idx, name_tidx, params_lp, ret_type_node, body_lp)
           Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type_node, body_expr):
             r = tc_check_expr_fn_body(r, decl_idx, name_tidx, params_lp, ret_type_node, body_expr)
+          Node.ClassDeclD(name_tidx, tparams_lp, fields_lp, methods_lp):
+            if methods_lp >= 0:
+              let meths: Vector<i64> = read_list(r.tc.idx_data, methods_lp)
+              let mi: i64 = 0
+              while mi < meths.length():
+                let meth_idx: i64 = meths.get(mi)
+                let meth_node: Node = r.tc.nodes.get(meth_idx)
+                match meth_node:
+                  Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+                    r = tc_check_method_body(r, decl_idx, meth_idx, m_name_tidx, m_params_lp, m_ret_type, m_body_lp)
+                mi = mi + 1
         i = i + 1
       return r
   return ts


### PR DESCRIPTION
## Summary

Threads class method support through all five bootstrap layers (parser → resolver → type checker → HIR) as the second Tier B vertical slice after generics.

## Highlights

- **Parser**: `ClassDeclD` 3→4 fields (methods_lp), class body parses fields then methods, `self` accepted as param name and primary expression
- **Resolver**: mangled method symbols (`ClassName.methodName`) registered in file scope, method bodies resolved with proper scoping
- **Type checker**: method table via mangled symbol scan, self param typed to enclosing struct, dot-call dispatch in `check_field_expr`, arity adjustment in `check_call_expr` to skip self
- **HIR**: methods emitted as standalone `HirFunction` nodes at file level (desugared to flat functions, matching C++ HIR builder)
- **198 total tests pass**: lexer 105, parser 40 (+2), resolver 18, typecheck 20, HIR 15

## Test plan

- [x] All 5 subsystems assembled and tested: 198/198
- [x] `class Foo: x: i32; fn get_x(self): i32` parses without error
- [x] `class Bar: val: i64; fn add(self, n: i64): i64` parses without error
- [x] All existing tests pass (no regressions from ClassDeclD arity change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)