### PR TITLE
docs(lang): 📝 add enum class ADR and contract amendments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ The current frozen surface assumptions are:
 - `mode <name> =>` enters an execution/safety mode
 - `resource <kind> <name> =>` binds a scoped resource domain
 - `|>` is a first-class pipeline operator
+- `enum` declares fieldless closed variants (classification only)
+- `enum class` declares closed structured variants with named fields
+  (see `docs/contracts/ADR_ENUM_CLASS.md`)
 
 Agents must not introduce alternate spellings for these without an
 explicit syntax revision task.

--- a/docs/contracts/ADR_ENUM_CLASS.md
+++ b/docs/contracts/ADR_ENUM_CLASS.md
@@ -1,0 +1,253 @@
+# ADR: `enum class` — Closed Structured Alternatives
+
+Status: **accepted**
+Date: 2026-03-26
+
+## Decision
+
+Add `enum class` as a compound declaration form for closed
+structured alternatives with named fields.
+
+## Context
+
+Dao has two foundational type-declaration keywords:
+
+- `enum` — closed set of atomic variants (classification)
+- `class` — open-ended nominal product type (composition)
+
+There is no way to declare a closed set of structured variants where
+each variant carries named fields.  This gap forces two bad patterns:
+
+1. **Payload-enum sludge**: `enum` variants with anonymous positional
+   fields that grow unbounded (`HirFunction(i64, i64, i64, i64, i64,
+   i64, i64)`).  Every match is a puzzle of positional guessing.
+   Adding a field breaks every match site.
+
+2. **Wrapper laundering**: a separate `class` for each variant's data,
+   wrapped in a 1-field enum variant.  Two declarations per variant,
+   two levels of indirection in every match.
+
+Both are structurally dishonest.  The missing construct is the
+synthesis of `enum` (closedness, exhaustive matching) with `class`
+(named fields, structural clarity).
+
+## The construct
+
+`enum class` is a compound declaration.  `enum` contributes closedness
+and exhaustive matching.  `class` contributes named fields and
+structural identity.
+
+```dao
+enum class Expr:
+  IntLit(value: i64)
+  Call(
+    callee: ExprId,
+    args: List[ExprId]
+  )
+  Function(
+    name: NameId,
+    tparams: ListId,
+    params: ListId,
+    ret: TypeId,
+    body: NodeId,
+    is_extern: bool,
+    class_owner: ClassId
+  )
+```
+
+### Syntax rules
+
+- `enum class Name:` introduces the declaration
+- Each variant is `VariantName(field: Type, field: Type, ...)`
+- Fields are always named — anonymous positional payloads are not
+  allowed in `enum class`
+- Multiline variants use parenthesized field lists (newlines inside
+  parens are suppressed, same as function parameters)
+- Fieldless variants are allowed: `None` (no parens needed)
+- Generic type parameters follow the name: `enum class Option<T>:`
+
+### Construction
+
+Named fields at construction site:
+
+```dao
+let e = Expr.Call(callee = f, args = my_args)
+```
+
+Fieldless variants:
+
+```dao
+let o = Option.None
+```
+
+### Match destructuring
+
+Named destructuring:
+
+```dao
+match expr:
+  Expr.IntLit(value):
+    print(value)
+  Expr.Call(callee, args):
+    dispatch(callee, args)
+  Expr.Function(name, ret, ..):
+    // .. ignores remaining fields
+```
+
+Rules:
+- Destructuring bindings follow field declaration order
+- `..` at the end ignores remaining fields (adding fields does not
+  break existing matches)
+- Exhaustive: the compiler requires all variants to be covered
+
+### Field access after match
+
+```dao
+match expr:
+  Expr.Call as c:
+    let callee = c.callee
+    let args = c.args
+```
+
+The `as` form binds the whole variant, enabling named field access
+without positional destructuring.
+
+## What changes about existing `enum`
+
+`enum` (without `class`) becomes fieldless only:
+
+```dao
+// This remains valid:
+enum Visibility:
+  Public
+  Private
+  Internal
+
+// This becomes ILLEGAL — use enum class instead:
+enum Option<T>:
+  Some(T)        // ERROR: enum variants cannot carry payloads
+  None
+```
+
+Payload-bearing variants move exclusively to `enum class`:
+
+```dao
+enum class Option<T>:
+  Some(value: T)
+  None
+```
+
+This is a **breaking change** to existing payload-bearing `enum`
+declarations.  All existing code using `enum` with payloads must
+migrate to `enum class`.
+
+## Design rationale
+
+### Why not a third keyword?
+
+Adding `family`, `choice`, `variant`, `case`, or any other third
+keyword creates a new ontological category that must be explained
+relative to both `enum` and `class`.  The compound form `enum class`
+communicates the semantics directly: it IS the synthesis of enum-ness
+and class-ness.
+
+### Why not extend `enum` with named fields?
+
+Because `enum` should stay clean.  Once `enum` can carry rich
+structured data, it becomes the junk drawer of the language — every
+distinction becomes a mega-sum, every mega-sum becomes a giant match,
+and basic structural decomposition dies.
+
+The hard rule: **enum classifies, class composes, enum class
+branches.**
+
+### Why not sealed class hierarchies?
+
+Sealed class hierarchies require inheritance machinery (subtyping,
+method resolution, potentially vtables).  Dao classes explicitly do
+not participate in inheritance hierarchies
+(CONTRACT_TYPE_SYSTEM_FOUNDATIONS §8.2).  `enum class` achieves
+closedness without introducing subtyping.
+
+### Why named fields only (no positional)?
+
+Positional fields are the root cause of the problem.
+`HirFunction(i64, i64, i64, i64, i64, i64, i64)` is the direct
+result of allowing anonymous positional payloads.  Named fields
+prevent this by construction.
+
+### Why `..` in match?
+
+Without `..`, adding a field to a variant breaks every match site —
+the same brittleness that positional payloads cause.  `..` allows
+matches that don't care about all fields to remain stable.
+
+## Semantic type category
+
+`enum class` occupies the fourth quadrant:
+
+|            | Atomic    | Structured    |
+|------------|-----------|---------------|
+| **Closed** | `enum`    | `enum class`  |
+| **Open**   | —         | `class`       |
+
+In the compiler's semantic type layer, `enum class` is represented
+as `TypeEnum` with named variant fields — the same representation as
+current payload enums, but with field name metadata attached.
+
+## Lowering
+
+The compiler controls the lowering strategy.  Valid options include:
+
+- Tagged union (tag + largest-variant payload)
+- Arena nodes with kind header
+- Per-variant compact storage
+
+No specific lowering strategy is mandated.  The language promises
+semantics, not representation.
+
+## Variants do not have methods
+
+`enum class` variants cannot declare methods.  Methods belong on the
+outer type:
+
+```dao
+enum class Expr:
+  IntLit(value: i64)
+  Call(callee: ExprId, args: List[ExprId])
+
+// Methods on the whole Expr type go in extend blocks:
+extend Expr:
+  fn is_literal(self): bool -> ...
+```
+
+This preserves the principle that variants are structured data, not
+behavioral objects.
+
+## Migration path
+
+1. All existing `enum` declarations with payload variants must be
+   rewritten as `enum class` with named fields.
+2. All existing `match` arms that destructure payloads positionally
+   must adopt named destructuring.
+3. All existing `Enum.Variant(value)` construction must adopt named
+   construction: `Enum.Variant(field = value)`.
+
+This affects:
+- stdlib (`Option<T>`, `Result<T, E>`)
+- examples
+- bootstrap probes and subsystems
+- test fixtures
+
+## Interaction with other features
+
+- **Generics**: `enum class Option<T>: Some(value: T) | None` works
+  naturally.
+- **Concepts**: `enum class` types can conform to concepts via
+  `extend` blocks.
+- **Pattern matching**: exhaustive matching is the primary dispatch
+  mechanism.  Future pattern matching extensions (guards, nested
+  patterns) apply to `enum class` variants.
+- **C ABI**: `enum class` types are not repr-C-compatible unless
+  all variants have identical layout.  Interop uses explicit
+  conversion.

--- a/docs/contracts/ADR_ENUM_CLASS.md
+++ b/docs/contracts/ADR_ENUM_CLASS.md
@@ -71,13 +71,13 @@ enum class Expr:
 Named fields at construction site:
 
 ```dao
-let e = Expr.Call(callee = f, args = my_args)
+let e = Expr::Call(callee = f, args = my_args)
 ```
 
 Fieldless variants:
 
 ```dao
-let o = Option.None
+let o = Option::None
 ```
 
 ### Match destructuring
@@ -86,11 +86,11 @@ Named destructuring:
 
 ```dao
 match expr:
-  Expr.IntLit(value):
+  Expr::IntLit(value):
     print(value)
-  Expr.Call(callee, args):
+  Expr::Call(callee, args):
     dispatch(callee, args)
-  Expr.Function(name, ret, ..):
+  Expr::Function(name, ret, ..):
     // .. ignores remaining fields
 ```
 
@@ -104,7 +104,7 @@ Rules:
 
 ```dao
 match expr:
-  Expr.Call as c:
+  Expr::Call as c:
     let callee = c.callee
     let args = c.args
 ```
@@ -211,18 +211,15 @@ semantics, not representation.
 `enum class` variants cannot declare methods.  Methods belong on the
 outer type:
 
-```dao
-enum class Expr:
-  IntLit(value: i64)
-  Call(callee: ExprId, args: List[ExprId])
-
-// Methods on the whole Expr type go in extend blocks:
-extend Expr:
-  fn is_literal(self): bool -> ...
-```
+Methods on the outer `enum class` type are attached through the same
+mechanism as class methods — either inside the declaration body after
+all variants, or through `extend` blocks once plain-extend syntax is
+frozen (currently only `extend Type as Concept:` is frozen in the
+syntax contract).
 
 This preserves the principle that variants are structured data, not
-behavioral objects.
+behavioral objects.  The exact method-attachment syntax for `enum
+class` is deferred until plain `extend` is frozen.
 
 ## Migration path
 
@@ -230,8 +227,8 @@ behavioral objects.
    rewritten as `enum class` with named fields.
 2. All existing `match` arms that destructure payloads positionally
    must adopt named destructuring.
-3. All existing `Enum.Variant(value)` construction must adopt named
-   construction: `Enum.Variant(field = value)`.
+3. All existing `Enum::Variant(value)` construction must adopt named
+   construction: `Enum::Variant(field = value)`.
 
 This affects:
 - stdlib (`Option<T>`, `Result<T, E>`)

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -86,6 +86,53 @@ Rules:
 - the uninitialized form requires an explicit type annotation
 - initialization semantics for the uninitialized form are not yet frozen
 
+## Enum Declarations
+
+```dao
+enum Visibility:
+  Public
+  Private
+  Internal
+```
+
+Rules:
+- `enum Name:` introduces a closed set of atomic variants
+- variants are fieldless — no payloads, no parenthesized data
+- enums are value types
+- for variants with structured data, use `enum class` instead
+
+## Enum Class Declarations
+
+```dao
+enum class Option<T>:
+  Some(value: T)
+  None
+
+enum class Expr:
+  IntLit(value: i64)
+  Call(
+    callee: ExprId,
+    args: List[ExprId]
+  )
+```
+
+Rules:
+- `enum class Name:` introduces a closed set of structured variants
+- each variant is `VariantName(field: Type, ...)` with named fields
+- fieldless variants use bare names (no parentheses needed)
+- field lists follow function-parameter conventions: parenthesized,
+  comma-separated, multiline when inside parens
+- anonymous positional payloads are not allowed — all fields must be
+  named
+- construction uses named fields: `Expr.Call(callee = f, args = a)`
+- match is exhaustive and uses named destructuring:
+  `Expr.Call(callee, args):` or `Expr.Call as c:` for field access
+- `..` in match ignores remaining fields (forward-compatible with
+  new fields)
+- variants cannot declare methods; methods go on the outer type via
+  `extend`
+- see `ADR_ENUM_CLASS.md` for full design rationale
+
 ## Class Declarations
 
 ```dao
@@ -290,12 +337,15 @@ This contract does not yet freeze:
 - receiver declaration syntax beyond `self`
 - mutable receiver syntax (`mut self`)
 - class construction syntax
-- pattern matching syntax
+- pattern matching syntax beyond named destructuring and `..` for
+  `enum class` (guards, nested patterns, or-patterns are not yet
+  frozen)
 - import alias syntax
 - concept object / dynamic dispatch syntax
 - operator overloading syntax
 - associated types inside concepts
-- `sealed` modifier for concepts and classes
+- `sealed` modifier for concepts (closedness for data types is
+  expressed via `enum class`, not a class modifier)
 - generator delegation (`yield from` or similar)
 - bidirectional coroutines (send values into a generator)
 - generator type inference from yield expressions without explicit

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -124,9 +124,9 @@ Rules:
   comma-separated, multiline when inside parens
 - anonymous positional payloads are not allowed — all fields must be
   named
-- construction uses named fields: `Expr.Call(callee = f, args = a)`
+- construction uses named fields: `Expr::Call(callee = f, args = a)`
 - match is exhaustive and uses named destructuring:
-  `Expr.Call(callee, args):` or `Expr.Call as c:` for field access
+  `Expr::Call(callee, args):` or `Expr::Call as c:` for field access
 - `..` in match ignores remaining fields (forward-compatible with
   new fields)
 - variants cannot declare methods; methods go on the outer type via

--- a/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
+++ b/docs/contracts/CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md
@@ -106,17 +106,54 @@ The semantic representation may use enums such as `I32`, `U64`, `F32`,
 
 ## 7. Enums and algebraic data
 
-Dao enums are true sum types.
+Dao has two closed-type declarations:
 
-This means the language direction assumes:
+- `enum` — closed set of fieldless atomic variants (classification)
+- `enum class` — closed set of structured variants with named fields
+  (branching with embodiment)
 
-- enums are not limited to C-style integer tags
-- payload-bearing variants are part of the intended model
-- later pattern matching and exhaustiveness checking are compatible
-  with the type model
+### 7.1 `enum` (fieldless)
 
-The exact surface syntax for payload-bearing variants may evolve, but
-the semantic direction is fixed.
+`enum` variants carry no data.  They are pure classifications.
+
+```dao
+enum Visibility:
+  Public
+  Private
+  Internal
+```
+
+Payload-bearing variants are not allowed in `enum`.  Use `enum class`
+instead.
+
+### 7.2 `enum class` (structured)
+
+`enum class` variants carry named fields.  Each variant is a
+structured alternative.
+
+```dao
+enum class Option<T>:
+  Some(value: T)
+  None
+```
+
+Rules:
+- fields are always named — no anonymous positional payloads
+- match is exhaustive with named destructuring
+- `..` in match ignores remaining fields
+- see `ADR_ENUM_CLASS.md` for full design rationale
+
+### 7.3 Semantic representation
+
+Both `enum` and `enum class` are represented as `TypeEnum` in the
+compiler's semantic type layer.  `enum class` variants additionally
+carry field name metadata.
+
+### 7.4 Migration
+
+Existing `enum` declarations with payload-bearing variants must
+migrate to `enum class` with named fields.  This is a breaking change.
+See `ADR_ENUM_CLASS.md` for the migration path.
 
 ## 8. Class semantics
 


### PR DESCRIPTION
## Summary

Freezes the `enum class` design: closed structured alternatives with named fields, filling the missing quadrant between fieldless `enum` (classification) and open `class` (composition).

## Highlights

- **`docs/contracts/ADR_ENUM_CLASS.md`**: full ADR with design rationale, syntax rules, construction, match destructuring (named fields + `..` + `as` binding), migration path from payload enums, lowering strategy, interaction with generics/concepts/extend
- **`CONTRACT_SYNTAX_SURFACE.md`**: new Enum Declarations (fieldless only) and Enum Class Declarations sections; Non-Laws updated
- **`CONTRACT_TYPE_SYSTEM_FOUNDATIONS.md`**: §7 rewritten to split enum (fieldless) and enum class (structured), with migration note
- **`AGENTS.md`**: frozen syntax assumptions updated

## The design in one sentence

```
enum classifies — class composes — enum class branches
```

## Breaking change

Existing `enum` declarations with payload variants must migrate to `enum class` with named fields. This affects stdlib (`Option<T>`, `Result<T,E>`), examples, and bootstrap subsystems.

## Test plan

- [ ] Review ADR for completeness and internal consistency
- [ ] Verify contract amendments don't contradict existing frozen decisions
- [ ] Implementation follows in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)