### PR TITLE
feat(bootstrap): ✨ add concept + extend vertical slice

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -27,40 +27,40 @@
 //   - Mode / resource blocks
 //   - Yield / generators
 
-enum HirNode:
+enum class HirNode:
   // File
-  HirFile(i64)
+  HirFile(decls_lp: i64)
 
   // Declarations
-  HirFunction(i64, i64, i64, i64, i64, i64, i64)  // name, tparams_lp, params_lp, ret_ti, body_lp, is_extern, class_owner_tidx (-1 for free fns)
-  HirStruct(i64, i64, i64)
-  HirEnum(i64, i64, i64)
-  HirTypeAlias(i64, i64)
+  HirFunction(name: i64, tparams: i64, params: i64, ret: i64, body: i64, is_extern: i64, class_owner: i64)
+  HirStruct(name: i64, tparams: i64, fields: i64)
+  HirEnum(name: i64, tparams: i64, variants: i64)
+  HirTypeAlias(name: i64, typ: i64)
 
   // Statements
-  HirLet(i64, i64, i64)
-  HirAssign(i64, i64)
-  HirIf(i64, i64, i64)
-  HirWhile(i64, i64)
-  HirFor(i64, i64, i64)
-  HirReturn(i64)
-  HirBreak(i64)
-  HirExprStmt(i64)
-  HirErrorStmt(i64)
+  HirLet(name: i64, typ: i64, init: i64)
+  HirAssign(target: i64, value: i64)
+  HirIf(cond: i64, then_lp: i64, else_lp: i64)
+  HirWhile(cond: i64, body_lp: i64)
+  HirFor(var_name: i64, iter: i64, body_lp: i64)
+  HirReturn(value: i64)
+  HirBreak(tok: i64)
+  HirExprStmt(expr: i64)
+  HirErrorStmt(tok: i64)
 
   // Expressions
-  HirIntLit(i64, i64)
-  HirFloatLit(i64, i64)
-  HirStringLit(i64, i64)
-  HirBoolLit(i64, i64)
-  HirIdent(i64, i64, i64)
-  HirBinary(i64, i64, i64, i64)
-  HirUnary(i64, i64, i64)
-  HirCall(i64, i64, i64, i64)
-  HirFieldAccess(i64, i64, i64)
-  HirPipe(i64, i64, i64)
-  HirQualName(i64, i64, i64)
-  HirErrorExpr(i64)
+  HirIntLit(tok: i64, typ: i64)
+  HirFloatLit(tok: i64, typ: i64)
+  HirStringLit(tok: i64, typ: i64)
+  HirBoolLit(tok: i64, typ: i64)
+  HirIdent(sym: i64, typ: i64, tok: i64)
+  HirBinary(op: i64, left: i64, right: i64, typ: i64)
+  HirUnary(op: i64, operand: i64, typ: i64)
+  HirCall(callee: i64, args_lp: i64, arg_count: i64, typ: i64)
+  HirFieldAccess(obj: i64, field: i64, typ: i64)
+  HirPipe(left: i64, right: i64, typ: i64)
+  HirQualName(segs_lp: i64, seg_count: i64, typ: i64)
+  HirErrorExpr(tok: i64)
 
 // =========================================================================
 // Section 50: HIR state and result types
@@ -782,6 +782,12 @@ fn lower_decl(hs: HS, decl_idx: i64): HirR
       return lower_enum_decl(hs, decl_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
       return lower_type_alias_decl(hs, decl_idx, name_tidx, target_type)
+    Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp):
+      // Concepts produce no runtime code — emit a no-op
+      return hs_add_node(hs, HirNode.HirErrorStmt(to_i64(0)))
+    Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+      // Extend methods are emitted in lower_file; return a no-op here
+      return hs_add_node(hs, HirNode.HirErrorStmt(to_i64(0)))
     Node.ErrorD(t):
       return hs_add_node(hs, HirNode.HirErrorStmt(to_i64(0)))
   return hs_add_node(hs, HirNode.HirErrorStmt(to_i64(0)))
@@ -855,6 +861,26 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
                     cur = mr.hs
                     hir_decls = hir_decls.push(mr.hir)
                 mi = mi + 1
+          Node.ExtendDeclD(ext_target, ext_cname, ext_ml):
+            if ext_ml >= 0:
+              // Get target type name token for owner
+              let ext_owner_tidx: i64 = to_i64(-1)
+              if ext_target >= 0:
+                let tnode: Node = cur.nodes.get(ext_target)
+                match tnode:
+                  Node.NamedT(t_tidx):
+                    ext_owner_tidx = t_tidx
+              let ext_methods: Vector<i64> = read_list(cur.idx_data, ext_ml)
+              let emi: i64 = 0
+              while emi < ext_methods.length():
+                let emeth_idx: i64 = ext_methods.get(emi)
+                let emeth_node: Node = cur.nodes.get(emeth_idx)
+                match emeth_node:
+                  Node.FnDeclD(em_name_tidx, em_tparams_lp, em_params_lp, em_ret_type, em_body_lp):
+                    let emr: HirR = lower_fn_decl_with_owner(cur, emeth_idx, em_name_tidx, em_tparams_lp, em_params_lp, em_ret_type, em_body_lp, ext_owner_tidx)
+                    cur = emr.hs
+                    hir_decls = hir_decls.push(emr.hir)
+                emi = emi + 1
         i = i + 1
       let fl: HirFlush = hir_flush_list(cur, hir_decls)
       return hs_add_node(fl.hs, HirNode.HirFile(fl.list_pos))
@@ -1151,7 +1177,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 15
+  let total: i32 = 16
 
   // Test 1: simple_fn
   let src1: string = "fn add(a: i32, b: i32): i32\n  return a + b\n"
@@ -1452,7 +1478,28 @@ fn main(): i32
   else:
     print("FAIL generic_fn_lower: root < 0")
 
-  // Test 15: self_lower_smoke
+  // Test 15: extend methods lower to HirFunction nodes
+  let src15e: string = "class Foo:\n  x: i32\n\nconcept Printable:\n  fn to_string(self): string\n\nextend Foo as Printable:\n  fn to_string(self): string\n    return \"Foo\"\n"
+  let r15e: HirResult = lower_to_hir(src15e)
+  if r15e.root >= 0:
+    // Count HirFunction nodes — should have at least one for the extend method
+    let fn_count_15e: i64 = 0
+    let i15e: i64 = 0
+    while i15e < hir_count_nodes(r15e):
+      let n15e: HirNode = r15e.hir_nodes.get(i15e)
+      match n15e:
+        HirNode.HirFunction(nm, tp_lp, pl, rt, bl, ie, co):
+          fn_count_15e = fn_count_15e + 1
+      i15e = i15e + 1
+    if fn_count_15e >= 1:
+      print("PASS extend_lower")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL extend_lower: expected >= 1 HirFunction, got " + i64_to_string(fn_count_15e))
+  else:
+    print("FAIL extend_lower: root < 0")
+
+  // Test 16: self_lower_smoke
   let self_src: string = "fn id(x: i32): i32\n  return x\nfn main(): i32\n  let a: i32 = id(42)\n  return a\n"
   let r15: HirResult = lower_to_hir(self_src)
   if r15.root >= 0:

--- a/bootstrap/parser/tests.dao
+++ b/bootstrap/parser/tests.dao
@@ -53,7 +53,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 40
+  let total: i32 = 43
 
   // -----------------------------------------------------------------
   // Expression tests
@@ -336,6 +336,28 @@ fn main(): i32
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
+  // Concept and extend tests
+  // -----------------------------------------------------------------
+
+  // Test 38: concept declaration parses without error
+  let src38: string = "concept Printable:\n  fn to_string(self): string\n"
+  let r38: PR = parse(src38)
+  if expect_no_parse_errors("concept_decl_no_err", r38):
+    pass_count = pass_count + 1
+
+  // Test 39: extend declaration parses without error
+  let src39: string = "class Foo:\n  x: i32\n\nconcept Printable:\n  fn to_string(self): string\n\nextend Foo as Printable:\n  fn to_string(self): string\n    return \"Foo\"\n"
+  let r39: PR = parse(src39)
+  if expect_no_parse_errors("extend_decl_no_err", r39):
+    pass_count = pass_count + 1
+
+  // Test 40: concept with multiple method signatures
+  let src40: string = "concept Showable:\n  fn show(self): string\n  fn size(self): i64\n"
+  let r40: PR = parse(src40)
+  if expect_no_parse_errors("concept_multi_sig_no_err", r40):
+    pass_count = pass_count + 1
+
+  // -----------------------------------------------------------------
   // Summary
   // -----------------------------------------------------------------
 
@@ -348,9 +370,7 @@ fn main(): i32
   // Tier B deferrals (documented, not silently omitted)
   // -----------------------------------------------------------------
   // The following syntax is explicitly deferred to Tier B:
-  //   - concept declarations
   //   - derived concept declarations
-  //   - extend declarations
   //   - conformance blocks (as / deny)
   //   - mode / resource blocks
   //   - yield statements

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -654,6 +654,46 @@ fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, var
 fn resolve_type_alias_decl(rs: RS, node_idx: i64, name_tidx: i64, target_type: i64): RS
   return resolve_type_node(rs, target_type)
 
+fn resolve_concept_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, methods_lp: i64): RS
+  // Create scope for type params
+  let sr: ScopeR = rs_push_scope(rs, ScopeKind.BlockScope)
+  let r: RS = sr.rs
+  r = resolve_type_params(r, tparams_lp, node_idx)
+  // Resolve method signature types (ExternFnD nodes — no body)
+  if methods_lp >= 0:
+    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let mi: i64 = 0
+    while mi < methods.length():
+      let meth_idx: i64 = methods.get(mi)
+      let meth_node: Node = r.nodes.get(meth_idx)
+      match meth_node:
+        Node.ExternFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type):
+          r = resolve_extern_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type)
+      mi = mi + 1
+  return rs_pop_scope(r)
+
+fn resolve_extend_decl(rs: RS, node_idx: i64, target_type_node: i64, concept_name_tidx: i64, methods_lp: i64): RS
+  let r: RS = rs
+  // Resolve target type
+  r = resolve_type_node(r, target_type_node)
+  // Resolve concept name as a symbol lookup
+  let concept_name: string = tok_name(r, concept_name_tidx)
+  let csym: i64 = scope_lookup(r, concept_name)
+  if csym >= 0:
+    r = rs_add_use(r, concept_name_tidx, csym)
+  // Resolve each method body
+  if methods_lp >= 0:
+    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let mi: i64 = 0
+    while mi < methods.length():
+      let meth_idx: i64 = methods.get(mi)
+      let meth_node: Node = r.nodes.get(meth_idx)
+      match meth_node:
+        Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+          r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
+      mi = mi + 1
+  return r
+
 fn resolve_decl(rs: RS, node_idx: i64): RS
   if node_idx < 0:
     return rs
@@ -671,6 +711,10 @@ fn resolve_decl(rs: RS, node_idx: i64): RS
       return resolve_enum_decl(rs, node_idx, name_tidx, tparams_lp, variants_lp)
     Node.TypeAliasD(name_tidx, target_type):
       return resolve_type_alias_decl(rs, node_idx, name_tidx, target_type)
+    Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp):
+      return resolve_concept_decl(rs, node_idx, name_tidx, tparams_lp, methods_lp)
+    Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+      return resolve_extend_decl(rs, node_idx, target_type_node, concept_name_tidx, methods_lp)
     Node.ErrorD(t):
       return rs
   return rs
@@ -728,6 +772,31 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
             let name: string = tok_name(r, name_tidx)
             let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
+          Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp):
+            let name: string = tok_name(r, name_tidx)
+            let sr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Type, name, decl_idx, r.current_scope))
+            r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
+          Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+            // Register mangled method symbols: TargetTypeName.methodName
+            if methods_lp >= 0:
+              let target_name: string = ""
+              if target_type_node >= 0:
+                let tnode: Node = r.nodes.get(target_type_node)
+                match tnode:
+                  Node.NamedT(t_tidx):
+                    target_name = tok_name(r, t_tidx)
+              let meths: Vector<i64> = read_list(r.idx_data, methods_lp)
+              let mi: i64 = 0
+              while mi < meths.length():
+                let meth_idx: i64 = meths.get(mi)
+                let meth_node: Node = r.nodes.get(meth_idx)
+                match meth_node:
+                  Node.FnDeclD(m_name_tidx, m_tp, m_plp, m_rt, m_blp):
+                    let mname: string = tok_name(r, m_name_tidx)
+                    let mangled: string = target_name + "." + mname
+                    let msr: SymR = rs_add_symbol(r, Symbol(SymbolKind.Function, mangled, meth_idx, r.current_scope))
+                    r = scope_declare(msr.rs, mangled, msr.sym_idx, m_name_tidx)
+                mi = mi + 1
           Node.ErrorD(t):
             r = r
         i = i + 1
@@ -809,7 +878,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 18
+  let total: i32 = 20
 
   // -----------------------------------------------------------------
   // Test 1: forward_ref — fn calls fn defined later in file; no diagnostic
@@ -1083,6 +1152,42 @@ fn main(): i32
     print("FAIL generic_param: expected >= 1 GenericParam symbol, got " + i64_to_string(r18_gp))
 
   // -----------------------------------------------------------------
+  // Test 19: extend creates mangled symbol — extend Foo as Printable creates Foo.to_string
+  // -----------------------------------------------------------------
+  let src19: string = "class Foo:\n  x: i32\n\nconcept Printable:\n  fn to_string(self): string\n\nextend Foo as Printable:\n  fn to_string(self): string\n    return \"Foo\"\n"
+  let r19: ResolveResult = resolve(src19)
+  let r19_diags: i64 = count_diags(r19)
+  let r19_found_mangled: bool = false
+  let r19_si: i64 = 0
+  while r19_si < r19.symbols.length():
+    let r19_sym: Symbol = r19.symbols.get(r19_si)
+    if r19_sym.name == "Foo.to_string":
+      if symbol_kind_name(r19_sym.kind) == "Function":
+        r19_found_mangled = true
+    r19_si = r19_si + 1
+  if r19_found_mangled:
+    print("PASS extend_mangled_symbol")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL extend_mangled_symbol: Foo.to_string symbol not found (diags: " + i64_to_string(r19_diags) + ")")
+
+  // -----------------------------------------------------------------
+  // Test 20: concept resolves without diagnostics
+  // -----------------------------------------------------------------
+  let src20: string = "concept Showable:\n  fn show(self): string\n"
+  let r20: ResolveResult = resolve(src20)
+  let r20_diags: i64 = count_diags(r20)
+  let r20_type_syms: i64 = count_symbols_of_kind(r20, SymbolKind.Type)
+  if r20_diags == 0:
+    if r20_type_syms >= 1:
+      print("PASS concept_resolve_no_err")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL concept_resolve_no_err: expected >= 1 Type symbol, got " + i64_to_string(r20_type_syms))
+  else:
+    print("FAIL concept_resolve_no_err: expected 0 diagnostics, got " + i64_to_string(r20_diags))
+
+  // -----------------------------------------------------------------
   // Summary
   // -----------------------------------------------------------------
 
@@ -1100,7 +1205,8 @@ fn main(): i32
   //   - Static method calls (Type::method)
   //   - Generic type parameter constraints / where clauses (parsing and
   //     resolution of generic params is implemented in Tier A)
-  //   - Concept / extend resolution
+  //   - Concept / extend conformance validation (parsing and symbol
+  //     registration is implemented; conformance checking is deferred)
   //   - Mode / resource block scoping
   //   - Yield statement resolution
   //   - Match arm destructuring bindings (patterns resolved as

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -757,51 +757,53 @@ fn lex(src: string): LexResult
 // function types, generic parameter bounds / where clauses.
 // (GenericParamT nodes and parse_type_params are Tier A.)
 
-enum Node:
+enum class Node:
   // --- Expressions ---
-  IntLitE(i64)
-  FloatLitE(i64)
-  StringLitE(i64)
-  BoolLitE(i64)
-  IdentE(i64)
-  QualNameE(i64, i64)
-  BinaryE(i64, i64, i64)
-  UnaryE(i64, i64)
-  CallE(i64, i64, i64)
-  IndexE(i64, i64)
-  FieldE(i64, i64)
-  PipeE(i64, i64)
-  TryE(i64)
-  LambdaE(i64, i64, i64)
-  ListLitE(i64, i64)
-  ErrorE(i64)
+  IntLitE(tok: i64)
+  FloatLitE(tok: i64)
+  StringLitE(tok: i64)
+  BoolLitE(tok: i64)
+  IdentE(tok: i64)
+  QualNameE(seg_lp: i64, seg_count: i64)
+  BinaryE(op: i64, left: i64, right: i64)
+  UnaryE(op: i64, operand: i64)
+  CallE(callee: i64, args_lp: i64, arg_count: i64)
+  IndexE(obj: i64, idx: i64)
+  FieldE(obj: i64, field: i64)
+  PipeE(left: i64, right: i64)
+  TryE(operand: i64)
+  LambdaE(params_lp: i64, param_count: i64, body: i64)
+  ListLitE(elems_lp: i64, elem_count: i64)
+  ErrorE(tok: i64)
   // --- Types ---
-  NamedT(i64)
-  GenericT(i64, i64, i64)
-  PointerT(i64)
-  GenericParamT(i64)
-  ErrorT(i64)
+  NamedT(tok: i64)
+  GenericT(name: i64, args_lp: i64, arg_count: i64)
+  PointerT(inner: i64)
+  GenericParamT(tok: i64)
+  ErrorT(tok: i64)
   // --- Statements ---
-  LetS(i64, i64, i64)
-  AssignS(i64, i64)
-  IfS(i64, i64, i64)
-  WhileS(i64, i64)
-  ForS(i64, i64, i64)
-  ReturnS(i64)
-  BreakS(i64)
-  MatchS(i64, i64)
-  ExprStmtS(i64)
-  ErrorS(i64)
+  LetS(name: i64, typ: i64, init: i64)
+  AssignS(target: i64, value: i64)
+  IfS(cond: i64, then_lp: i64, else_lp: i64)
+  WhileS(cond: i64, body_lp: i64)
+  ForS(var_tok: i64, iter: i64, body_lp: i64)
+  ReturnS(value: i64)
+  BreakS(tok: i64)
+  MatchS(scrutinee: i64, arms_lp: i64)
+  ExprStmtS(expr: i64)
+  ErrorS(tok: i64)
   // --- Declarations ---
-  FnDeclD(i64, i64, i64, i64, i64)
-  ExternFnD(i64, i64, i64, i64)
-  ExprFnD(i64, i64, i64, i64, i64)
-  ClassDeclD(i64, i64, i64, i64)
-  EnumDeclD(i64, i64, i64)
-  TypeAliasD(i64, i64)
-  ErrorD(i64)
+  FnDeclD(name: i64, tparams: i64, params: i64, ret: i64, body: i64)
+  ExternFnD(name: i64, tparams: i64, params: i64, ret: i64)
+  ExprFnD(name: i64, tparams: i64, params: i64, ret: i64, body: i64)
+  ClassDeclD(name: i64, tparams: i64, fields: i64, methods: i64)
+  EnumDeclD(name: i64, tparams: i64, variants: i64)
+  TypeAliasD(name: i64, typ: i64)
+  ConceptDeclD(name: i64, tparams: i64, methods: i64)
+  ExtendDeclD(target: i64, concept_name: i64, methods: i64)
+  ErrorD(tok: i64)
   // --- File ---
-  FileN(i64)
+  FileN(decls_lp: i64)
 
 // =========================================================================
 // Section 7: Parser state and result types
@@ -1663,9 +1665,13 @@ fn parse_declaration(ps: PS): PR
     return parse_enum_decl(ps)
   if tk_name(k) == tk_name(TK.KwType):
     return parse_type_alias(ps)
+  if tk_name(k) == tk_name(TK.KwConcept):
+    return parse_concept_decl(ps)
+  if tk_name(k) == tk_name(TK.KwExtend):
+    return parse_extend_decl(ps)
 
   let sp: Span = tok_span(ps)
-  let ps2: PS = ps_add_diag(ps, sp, "expected declaration (fn, extern, class, enum, or type)")
+  let ps2: PS = ps_add_diag(ps, sp, "expected declaration (fn, extern, class, enum, type, concept, or extend)")
   return ps_add_node(ps_advance(ps2), Node.ErrorD(ps.pos))
 
 // Parse optional type parameters: <T, U, V> — returns PR where .node = list_pos
@@ -2009,6 +2015,110 @@ fn parse_type_alias(ps: PS): PR
   let cur: PS = match_tok(ty.ps, TK.Newline)
   return ps_add_node(cur, Node.TypeAliasD(name_tidx, ty.node))
 
+fn parse_concept_decl(ps: PS): PR
+  let ps2: PS = ps_advance(ps)
+  let name_tidx: i64 = ps2.pos
+  let ps3: PS = expect(ps2, TK.Identifier)
+
+  // Parse optional type parameters
+  let tparams: PR = parse_type_params(ps3)
+  let tparams_lp: i64 = tparams.node
+
+  let ps4: PS = expect(tparams.ps, TK.Colon)
+  let ps5: PS = expect(ps4, TK.Newline)
+  let ps6: PS = expect(ps5, TK.Indent)
+
+  // Parse method signatures (fn without body)
+  let method_items: Vector<i64> = Vector<i64>::new()
+  let cur: PS = ps6
+  let done: bool = false
+  while done == false:
+    cur = skip_newlines(cur)
+    let k: TK = peek_kind(cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+      done = true
+    else:
+      if tk_name(k) == tk_name(TK.KwFn):
+        // Parse signature only: fn name(params): RetType NEWLINE (no body)
+        let ps_fn: PS = ps_advance(cur)
+        let sig_name_tidx: i64 = ps_fn.pos
+        let ps_fn2: PS = expect(ps_fn, TK.Identifier)
+        let sig_tparams: PR = parse_type_params(ps_fn2)
+        let sig_params: PR = parse_params_list(sig_tparams.ps)
+        let sig_cur: PS = sig_params.ps
+        let sig_ret_type: i64 = to_i64(-1)
+        if tk_name(peek_kind(sig_cur)) == tk_name(TK.Colon):
+          sig_cur = ps_advance(sig_cur)
+          let sig_ty: PR = parse_type(sig_cur)
+          if sig_ty.node >= 0:
+            sig_ret_type = sig_ty.node
+          sig_cur = sig_ty.ps
+        sig_cur = match_tok(sig_cur, TK.Newline)
+        let sig_r: PR = ps_add_node(sig_cur, Node.ExternFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type))
+        method_items = method_items.push(sig_r.node)
+        cur = sig_r.ps
+      else:
+        // Skip unexpected token
+        let sp: Span = tok_span(cur)
+        cur = ps_add_diag(cur, sp, "expected method signature in concept body")
+        cur = ps_advance(cur)
+
+  let methods_lp: i64 = to_i64(-1)
+  if method_items.length() > 0:
+    let mfl: FlushResult = flush_list(cur, method_items)
+    cur = mfl.ps
+    methods_lp = mfl.list_pos
+
+  cur = expect(cur, TK.Dedent)
+  return ps_add_node(cur, Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp))
+
+fn parse_extend_decl(ps: PS): PR
+  let ps2: PS = ps_advance(ps)
+
+  // Parse target type
+  let target_ty: PR = parse_type(ps2)
+  let target_type_node: i64 = target_ty.node
+  let cur: PS = target_ty.ps
+
+  // Consume 'as'
+  cur = expect(cur, TK.KwAs)
+
+  // Parse concept name (identifier token)
+  let concept_name_tidx: i64 = cur.pos
+  cur = expect(cur, TK.Identifier)
+
+  cur = expect(cur, TK.Colon)
+  cur = expect(cur, TK.Newline)
+  cur = expect(cur, TK.Indent)
+
+  // Parse method definitions (full fn with body)
+  let method_items: Vector<i64> = Vector<i64>::new()
+  let done: bool = false
+  while done == false:
+    cur = skip_newlines(cur)
+    let k: TK = peek_kind(cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+      done = true
+    else:
+      if tk_name(k) == tk_name(TK.KwFn):
+        let meth: PR = parse_fn_decl(cur)
+        if meth.node >= 0:
+          method_items = method_items.push(meth.node)
+        cur = meth.ps
+      else:
+        let sp: Span = tok_span(cur)
+        cur = ps_add_diag(cur, sp, "expected method definition in extend body")
+        cur = ps_advance(cur)
+
+  let methods_lp: i64 = to_i64(-1)
+  if method_items.length() > 0:
+    let mfl: FlushResult = flush_list(cur, method_items)
+    cur = mfl.ps
+    methods_lp = mfl.list_pos
+
+  cur = expect(cur, TK.Dedent)
+  return ps_add_node(cur, Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp))
+
 // =========================================================================
 // Section 14: File-level parsing
 // =========================================================================
@@ -2125,6 +2235,10 @@ fn node_kind_name(n: Node): string
       return "EnumDeclD"
     Node.TypeAliasD(a, b):
       return "TypeAliasD"
+    Node.ConceptDeclD(a, b, c):
+      return "ConceptDeclD"
+    Node.ExtendDeclD(a, b, c):
+      return "ExtendDeclD"
     Node.ErrorD(a):
       return "ErrorD"
     Node.FileN(a):

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -692,6 +692,83 @@ fn tc_register_methods(ts: TS, decls: Vector<i64>): TS
     i = i + 1
   return r
 
+fn tc_register_concepts(ts: TS, decls: Vector<i64>): TS
+  let r: TS = ts
+  let i: i64 = 0
+  while i < decls.length():
+    let decl_idx: i64 = decls.get(i)
+    let node: Node = r.tc.nodes.get(decl_idx)
+    match node:
+      Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp):
+        // Register concept as a Type in sym_types
+        let csym: i64 = find_sym_by_decl(r, decl_idx, "Type")
+        if csym >= 0:
+          let cname: string = ts_tok_name(r, name_tidx)
+          let tr: TypeR = ts_add_type(r, DaoType(TypeKind.TStruct, to_i64(-1), cname, decl_idx, to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
+          r = tr.ts
+          r = ts_set_sym_type(r, csym, tr.type_idx)
+    i = i + 1
+  return r
+
+fn tc_register_extend_methods(ts: TS, decls: Vector<i64>): TS
+  let r: TS = ts
+  let i: i64 = 0
+  while i < decls.length():
+    let decl_idx: i64 = decls.get(i)
+    let node: Node = r.tc.nodes.get(decl_idx)
+    match node:
+      Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+        if methods_lp >= 0:
+          // Get target type name from NamedT node
+          let target_name: string = ""
+          if target_type_node >= 0:
+            let tnode: Node = r.tc.nodes.get(target_type_node)
+            match tnode:
+              Node.NamedT(t_tidx):
+                target_name = ts_tok_name(r, t_tidx)
+          // Find the target type index
+          let target_ti: i64 = to_i64(-1)
+          let tsi: i64 = 0
+          while tsi < r.tc.symbols.length():
+            let tsym: Symbol = r.tc.symbols.get(tsi)
+            if tsym.name == target_name:
+              if symbol_kind_name(tsym.kind) == "Type":
+                target_ti = vec_i64_get(r.sym_types, tsi)
+              if symbol_kind_name(tsym.kind) == "Builtin":
+                target_ti = vec_i64_get(r.sym_types, tsi)
+            tsi = tsi + 1
+          let methods: Vector<i64> = read_list(r.tc.idx_data, methods_lp)
+          let mi: i64 = 0
+          while mi < methods.length():
+            let meth_idx: i64 = methods.get(mi)
+            let meth_node: Node = r.tc.nodes.get(meth_idx)
+            match meth_node:
+              Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+                // Register function type via tc_register_fn_sig_core
+                let tr: TypeR = tc_register_fn_sig_core(r, meth_idx, m_name_tidx, m_params_lp, m_ret_type)
+                r = tr.ts
+                // Find the mangled symbol and set its type
+                let mname: string = ts_tok_name(r, m_name_tidx)
+                let mangled: string = target_name + "." + mname
+                let msym: i64 = to_i64(-1)
+                let si: i64 = 0
+                while si < r.tc.symbols.length():
+                  let sym: Symbol = r.tc.symbols.get(si)
+                  if sym.name == mangled:
+                    if symbol_kind_name(sym.kind) == "Function":
+                      msym = si
+                  si = si + 1
+                if msym >= 0:
+                  r = ts_set_sym_type(r, msym, tr.type_idx)
+                // Set self param type to the target type
+                if target_ti >= 0:
+                  let self_sym: i64 = find_param_sym(r, meth_idx, "self")
+                  if self_sym >= 0:
+                    r = ts_set_sym_type(r, self_sym, target_ti)
+            mi = mi + 1
+    i = i + 1
+  return r
+
 fn tc_pass1(ts: TS, file_node_idx: i64): TS
   let file_node: Node = ts.tc.nodes.get(file_node_idx)
   match file_node:
@@ -704,6 +781,8 @@ fn tc_pass1(ts: TS, file_node_idx: i64): TS
       r = tc_fill_struct_fields(r, decls)
       r = tc_register_functions(r, decls)
       r = tc_register_methods(r, decls)
+      r = tc_register_concepts(r, decls)
+      r = tc_register_extend_methods(r, decls)
       return r
   return ts
 
@@ -1352,6 +1431,68 @@ fn tc_check_method_body(ts: TS, class_decl_idx: i64, meth_idx: i64, m_name_tidx:
   r = ts_set_return_type(r, old_return_type)
   return r
 
+fn tc_check_extend_method_body(ts: TS, extend_decl_idx: i64, meth_idx: i64, m_name_tidx: i64, m_params_lp: i64, m_ret_type: i64, m_body_lp: i64): TS
+  let r: TS = ts
+  // Get target type name from the extend decl
+  let target_name: string = ""
+  let extend_node: Node = r.tc.nodes.get(extend_decl_idx)
+  match extend_node:
+    Node.ExtendDeclD(target_type_node, cn_tidx, e_mlp):
+      if target_type_node >= 0:
+        let tnode: Node = r.tc.nodes.get(target_type_node)
+        match tnode:
+          Node.NamedT(t_tidx):
+            target_name = ts_tok_name(r, t_tidx)
+  let mname: string = ts_tok_name(r, m_name_tidx)
+  let mangled: string = target_name + "." + mname
+  let fn_ti: i64 = to_i64(-1)
+  let msym: i64 = to_i64(-1)
+  let si: i64 = 0
+  while si < r.tc.symbols.length():
+    let sym: Symbol = r.tc.symbols.get(si)
+    if sym.name == mangled:
+      if symbol_kind_name(sym.kind) == "Function":
+        msym = si
+    si = si + 1
+  if msym >= 0:
+    fn_ti = vec_i64_get(r.sym_types, msym)
+  let old_return_type: i64 = r.return_type
+  if fn_ti >= 0:
+    let fn_type: DaoType = r.types.get(fn_ti)
+    r = ts_set_return_type(r, fn_type.ret_type)
+  // Declare param types — self gets the target type
+  let pairs: Vector<i64> = read_pairs(r.tc.idx_data, m_params_lp)
+  let pi: i64 = 0
+  while pi < pairs.length():
+    let p_tidx: i64 = pairs.get(pi)
+    let p_type_node: i64 = pairs.get(pi + 1)
+    let p_name: string = ts_tok_name(r, p_tidx)
+    let p_sym: i64 = find_param_sym(r, meth_idx, p_name)
+    if p_sym >= 0:
+      if p_name == "self":
+        // Self type is the target type
+        let target_ti: i64 = to_i64(-1)
+        let tsi: i64 = 0
+        while tsi < r.tc.symbols.length():
+          let tsym: Symbol = r.tc.symbols.get(tsi)
+          if tsym.name == target_name:
+            if symbol_kind_name(tsym.kind) == "Type":
+              target_ti = vec_i64_get(r.sym_types, tsi)
+            if symbol_kind_name(tsym.kind) == "Builtin":
+              target_ti = vec_i64_get(r.sym_types, tsi)
+          tsi = tsi + 1
+        if target_ti >= 0:
+          r = ts_set_sym_type(r, p_sym, target_ti)
+      else:
+        let pt_r: TypeR = resolve_ast_type(r, p_type_node)
+        r = pt_r.ts
+        if pt_r.type_idx >= 0:
+          r = ts_set_sym_type(r, p_sym, pt_r.type_idx)
+    pi = pi + 2
+  r = check_body_stmts(r, m_body_lp)
+  r = ts_set_return_type(r, old_return_type)
+  return r
+
 fn tc_pass2(ts: TS, file_node_idx: i64): TS
   let file_node: Node = ts.tc.nodes.get(file_node_idx)
   match file_node:
@@ -1377,6 +1518,17 @@ fn tc_pass2(ts: TS, file_node_idx: i64): TS
                 match meth_node:
                   Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
                     r = tc_check_method_body(r, decl_idx, meth_idx, m_name_tidx, m_params_lp, m_ret_type, m_body_lp)
+                mi = mi + 1
+          Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+            if methods_lp >= 0:
+              let meths: Vector<i64> = read_list(r.tc.idx_data, methods_lp)
+              let mi: i64 = 0
+              while mi < meths.length():
+                let meth_idx: i64 = meths.get(mi)
+                let meth_node: Node = r.tc.nodes.get(meth_idx)
+                match meth_node:
+                  Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+                    r = tc_check_extend_method_body(r, decl_idx, meth_idx, m_name_tidx, m_params_lp, m_ret_type, m_body_lp)
                 mi = mi + 1
         i = i + 1
       return r
@@ -1422,7 +1574,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 20
+  let total: i32 = 21
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -1608,7 +1760,16 @@ fn main(): i32
   else:
     print("FAIL generic_fn_parses: TGenericParam not found in types (count: " + i64_to_string(tc_count_types(r19)) + ")")
 
-  // Test 20: self_typecheck_smoke
+  // Test 20: extend method body type-checks
+  let src20e: string = "class Foo:\n  x: i32\n\nconcept Printable:\n  fn to_string(self): string\n\nextend Foo as Printable:\n  fn to_string(self): string\n    return \"Foo\"\n"
+  let r20e: TypeCheckResult = typecheck(src20e)
+  if tc_count_diags(r20e) == 0:
+    print("PASS extend_method_typecheck")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL extend_method_typecheck: expected 0 diagnostics, got " + i64_to_string(tc_count_diags(r20e)))
+
+  // Test 21: self_typecheck_smoke (was test 20)
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"
   if file_exists(self_path):
     let self_src: string = read_file(self_path)


### PR DESCRIPTION
## Summary

Threads `concept` declarations and `extend Type as Concept:` through all five bootstrap layers. Also migrates Node and HirNode enums to `enum class` with named fields (required by the C++ compiler after PR #197).

## Highlights

- **Parser**: `ConceptDeclD` and `ExtendDeclD` node variants, `parse_concept_decl` (signature-only methods), `parse_extend_decl` (full method bodies)
- **Resolver**: concept as Type symbol, extend methods with mangled names (`TargetType.method`), `resolve_concept_decl` and `resolve_extend_decl`
- **Type checker**: `tc_register_concepts`, `tc_register_extend_methods` (self typed to target), extend body checking in pass 2
- **HIR**: extend methods emitted as standalone HirFunction nodes
- **enum class migration**: Node and HirNode enums converted to `enum class` with named fields per ADR
- **Lexer tests**: 105/105 pass

## Known limitation

Parser/resolver/typecheck/HIR test binaries OOM at runtime due to bootstrap compiler immutable-value memory scaling. This is a pre-existing issue unrelated to concept+extend. The lexer (smallest subsystem) passes fully.

## Test plan

- [x] Lexer: 105/105 ALL TESTS PASSED
- [x] C++ compiler: 12/12 tests pass (from #197)
- [x] Assembly: all 5 files assemble without error
- [ ] Parser/resolver/typecheck/HIR: OOM at runtime (pre-existing scaling issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)