### PR TITLE
fix(runtime): ⚡️ COW Vector + bootstrap state threading — fix OOM

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -888,8 +888,8 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
 
 fn lower_to_hir(src: string): HirResult
   // Run frontend pipeline
-  let pr: PR = parse(src)
-  let file_node_idx: i64 = pr.node
+  let po: ParseOutput = parse(src)
+  let file_node_idx: i64 = po.root
   let rr: ResolveResult = resolve(src)
   let tcr: TypeCheckResult = typecheck(src)
 
@@ -897,7 +897,7 @@ fn lower_to_hir(src: string): HirResult
   let um: HashMap<i64> = build_uses_map(rr.uses)
 
   // Construct HS
-  let hs: HS = HS(pr.ps.nodes, pr.ps.idx, pr.ps.toks, src, rr.symbols, tcr.types, tcr.type_info, tcr.expr_types, tcr.sym_types, um, Vector<HirNode>::new(), Vector<i64>::new(), tcr.diags)
+  let hs: HS = HS(po.nodes, po.idx, po.toks, src, rr.symbols, tcr.types, tcr.type_info, tcr.expr_types, tcr.sym_types, um, Vector<HirNode>::new(), Vector<i64>::new(), tcr.diags)
 
   // Lower
   let result: HirR = lower_file(hs, file_node_idx)

--- a/bootstrap/parser/tests.dao
+++ b/bootstrap/parser/tests.dao
@@ -2,6 +2,21 @@
 // Section 17: Test infrastructure
 // =========================================================================
 
+fn expect_node_kind_po(label: string, po: ParseOutput, node_idx: i64, expected: string): bool
+  if node_idx < 0:
+    print("FAIL " + label + ": node index is -1 (parse error)")
+    return false
+  if node_idx >= po.nodes.length():
+    print("FAIL " + label + ": node index " + i64_to_string(node_idx) + " out of bounds")
+    return false
+  let n: Node = po.nodes.get(node_idx)
+  let actual: string = node_kind_name(n)
+  if actual == expected:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label + ": expected " + expected + ", got " + actual)
+  return false
+
 fn expect_node_kind(label: string, pr: PR, node_idx: i64, expected: string): bool
   if node_idx < 0:
     print("FAIL " + label + ": node index is -1 (parse error)")
@@ -17,6 +32,13 @@ fn expect_node_kind(label: string, pr: PR, node_idx: i64, expected: string): boo
   print("FAIL " + label + ": expected " + expected + ", got " + actual)
   return false
 
+fn expect_no_parse_errors_po(label: string, po: ParseOutput): bool
+  if po.diags.length() == 0:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label + ": expected no errors, got " + i64_to_string(po.diags.length()))
+  return false
+
 fn expect_no_parse_errors(label: string, pr: PR): bool
   if pr.ps.diags.length() == 0:
     print("PASS " + label)
@@ -24,11 +46,25 @@ fn expect_no_parse_errors(label: string, pr: PR): bool
   print("FAIL " + label + ": expected no errors, got " + i64_to_string(pr.ps.diags.length()))
   return false
 
+fn expect_parse_errors_po(label: string, po: ParseOutput, min_errors: i64): bool
+  if po.diags.length() >= min_errors:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label + ": expected >= " + i64_to_string(min_errors) + " errors, got " + i64_to_string(po.diags.length()))
+  return false
+
 fn expect_parse_errors(label: string, pr: PR, min_errors: i64): bool
   if pr.ps.diags.length() >= min_errors:
     print("PASS " + label)
     return true
   print("FAIL " + label + ": expected >= " + i64_to_string(min_errors) + " errors, got " + i64_to_string(pr.ps.diags.length()))
+  return false
+
+fn expect_node_count_min_po(label: string, po: ParseOutput, min_count: i64): bool
+  if po.nodes.length() >= min_count:
+    print("PASS " + label)
+    return true
+  print("FAIL " + label + ": expected >= " + i64_to_string(min_count) + " nodes, got " + i64_to_string(po.nodes.length()))
   return false
 
 fn expect_node_count_min(label: string, pr: PR, min_count: i64): bool
@@ -41,8 +77,9 @@ fn expect_node_count_min(label: string, pr: PR, min_count: i64): bool
 // Helper to parse an expression snippet
 fn parse_expr_str(src: string): PR
   let lr: LexResult = lex(src)
-  let ps: PS = PS(lr.tokens, src, to_i64(0), Vector<Node>::new(), Vector<i64>::new(), lr.diagnostics)
-  return parse_expr(ps)
+  let pc: PC = PC(lr.tokens, src)
+  let ps: PS = PS(to_i64(0), Vector<Node>::new(), Vector<i64>::new(), lr.diagnostics)
+  return parse_expr(pc, ps)
 
 // =========================================================================
 // Section 18: Golden parse tests
@@ -141,44 +178,44 @@ fn main(): i32
 
   // Test 11: Simple fn declaration
   let src11: string = "fn foo(x: i32): i32\n  return x\n"
-  let r11: PR = parse(src11)
-  if expect_node_kind("decl_fn", r11, r11.node, "FileN"):
+  let r11: ParseOutput = parse(src11)
+  if expect_node_kind_po("decl_fn", r11, r11.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 12: Extern fn declaration
   let src12: string = "extern fn bar(s: string): i32\n"
-  let r12: PR = parse(src12)
-  if expect_node_kind("decl_extern_fn", r12, r12.node, "FileN"):
+  let r12: ParseOutput = parse(src12)
+  if expect_node_kind_po("decl_extern_fn", r12, r12.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 13: Expression-bodied fn
   let src13: string = "fn add(a: i64, b: i64): i64 -> a + b\n"
-  let r13: PR = parse(src13)
-  if expect_node_kind("decl_expr_fn", r13, r13.node, "FileN"):
+  let r13: ParseOutput = parse(src13)
+  if expect_node_kind_po("decl_expr_fn", r13, r13.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 14: Class with fields
   let src14: string = "class Point:\n  x: i64\n  y: i64\n"
-  let r14: PR = parse(src14)
-  if expect_node_kind("decl_class", r14, r14.node, "FileN"):
+  let r14: ParseOutput = parse(src14)
+  if expect_node_kind_po("decl_class", r14, r14.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 15: Enum with variants
   let src15: string = "enum Color:\n  Red\n  Green\n  Blue\n"
-  let r15: PR = parse(src15)
-  if expect_node_kind("decl_enum", r15, r15.node, "FileN"):
+  let r15: ParseOutput = parse(src15)
+  if expect_node_kind_po("decl_enum", r15, r15.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 16: Enum with payload variants
   let src16: string = "enum Expr:\n  IntLit(i64)\n  Binary(TK, i64, i64)\n"
-  let r16: PR = parse(src16)
-  if expect_node_kind("decl_enum_payload", r16, r16.node, "FileN"):
+  let r16: ParseOutput = parse(src16)
+  if expect_node_kind_po("decl_enum_payload", r16, r16.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 17: Type alias
   let src17: string = "type NodeId = i64\n"
-  let r17: PR = parse(src17)
-  if expect_node_kind("decl_type_alias", r17, r17.node, "FileN"):
+  let r17: ParseOutput = parse(src17)
+  if expect_node_kind_po("decl_type_alias", r17, r17.root, "FileN"):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -187,48 +224,48 @@ fn main(): i32
 
   // Test 18: Let statement
   let src18: string = "fn test(): i32\n  let x: i32 = 42\n  return x\n"
-  let r18: PR = parse(src18)
-  if expect_node_kind("stmt_let", r18, r18.node, "FileN"):
+  let r18: ParseOutput = parse(src18)
+  if expect_node_kind_po("stmt_let", r18, r18.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 19: If/else
   let src19: string = "fn test(): i32\n  if x > 0:\n    return 1\n  else:\n    return 0\n"
-  let r19: PR = parse(src19)
-  if expect_node_kind("stmt_if_else", r19, r19.node, "FileN"):
+  let r19: ParseOutput = parse(src19)
+  if expect_node_kind_po("stmt_if_else", r19, r19.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 20: While loop
   let src20: string = "fn test(): i32\n  while x > 0:\n    x = x - 1\n  return x\n"
-  let r20: PR = parse(src20)
-  if expect_node_kind("stmt_while", r20, r20.node, "FileN"):
+  let r20: ParseOutput = parse(src20)
+  if expect_node_kind_po("stmt_while", r20, r20.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 21: For loop
   let src21: string = "fn test(): i32\n  for i in items:\n    print(i)\n  return 0\n"
-  let r21: PR = parse(src21)
-  if expect_node_kind("stmt_for", r21, r21.node, "FileN"):
+  let r21: ParseOutput = parse(src21)
+  if expect_node_kind_po("stmt_for", r21, r21.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 22: Return
   let src22: string = "fn test(): i32\n  return 42\n"
-  let r22: PR = parse(src22)
-  if expect_no_parse_errors("stmt_return_no_err", r22):
+  let r22: ParseOutput = parse(src22)
+  if expect_no_parse_errors_po("stmt_return_no_err", r22):
     pass_count = pass_count + 1
 
   // Test 23: Match statement
   let src23: string = "fn test(): i32\n  match x:\n    TK.Plus:\n      return 1\n    TK.Minus:\n      return 2\n"
-  let r23: PR = parse(src23)
-  if expect_node_kind("stmt_match", r23, r23.node, "FileN"):
+  let r23: ParseOutput = parse(src23)
+  if expect_node_kind_po("stmt_match", r23, r23.root, "FileN"):
     pass_count = pass_count + 1
 
   // Test 24: Full program (enum + class + fn + main)
   let src24: string = "enum Color:\n  Red\n  Blue\n\nclass Point:\n  x: i64\n  y: i64\n\nfn add(a: i64, b: i64): i64 -> a + b\n\nfn main(): i32\n  let p: Point = Point(1, 2)\n  return 0\n"
-  let r24: PR = parse(src24)
+  let r24: ParseOutput = parse(src24)
   let r24_ok: bool = true
-  if expect_node_kind("full_program_file", r24, r24.node, "FileN") == false:
+  if expect_node_kind_po("full_program_file", r24, r24.root, "FileN") == false:
     r24_ok = false
   if r24_ok:
-    if expect_node_count_min("full_program_nodes", r24, to_i64(5)):
+    if expect_node_count_min_po("full_program_nodes", r24, to_i64(5)):
       pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -247,8 +284,8 @@ fn main(): i32
 
   // Test 27: Missing colon after fn params
   let src27: string = "fn test(x: i32) i32\n  return x\n"
-  let r27: PR = parse(src27)
-  if expect_node_kind("err_missing_colon", r27, r27.node, "FileN"):
+  let r27: ParseOutput = parse(src27)
+  if expect_node_kind_po("err_missing_colon", r27, r27.root, "FileN"):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -258,20 +295,20 @@ fn main(): i32
   // Test 28: Class with generic field type — verifies field pairs
   // are contiguous in idx despite nested generic type list entries.
   let src28: string = "class Foo:\n  items: Vector<Token>\n  count: i64\n"
-  let r28: PR = parse(src28)
-  if expect_no_parse_errors("class_generic_field_no_err", r28):
+  let r28: ParseOutput = parse(src28)
+  if expect_no_parse_errors_po("class_generic_field_no_err", r28):
     pass_count = pass_count + 1
 
   // Test 29: extern fn without return type produces diagnostic.
   let src29: string = "extern fn bad(x: i32)\n"
-  let r29: PR = parse(src29)
-  if expect_parse_errors("extern_fn_no_ret", r29, to_i64(1)):
+  let r29: ParseOutput = parse(src29)
+  if expect_parse_errors_po("extern_fn_no_ret", r29, to_i64(1)):
     pass_count = pass_count + 1
 
   // Test 30: Empty class body produces diagnostic.
   let src30: string = "class Empty:\n  \n"
-  let r30: PR = parse(src30)
-  if expect_parse_errors("empty_class_body", r30, to_i64(1)):
+  let r30: ParseOutput = parse(src30)
+  if expect_parse_errors_po("empty_class_body", r30, to_i64(1)):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -284,20 +321,20 @@ fn main(): i32
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"
   if file_exists(self_path):
     let self_src: string = read_file(self_path)
-    let self_r: PR = parse(self_src)
-    if expect_node_kind("self_parse_file", self_r, self_r.node, "FileN"):
+    let self_r: ParseOutput = parse(self_src)
+    if expect_node_kind_po("self_parse_file", self_r, self_r.root, "FileN"):
       pass_count = pass_count + 1
-    if expect_node_count_min("self_parse_nodes", self_r, to_i64(20)):
+    if expect_node_count_min_po("self_parse_nodes", self_r, to_i64(20)):
       pass_count = pass_count + 1
-    let err_count: i64 = self_r.ps.diags.length()
+    let err_count: i64 = self_r.diags.length()
     print("  [info] self-parse diagnostics: " + i64_to_string(err_count))
-    print("  [info] self-parse node count: " + i64_to_string(self_r.ps.nodes.length()))
-    print("  [info] self-parse idx list size: " + i64_to_string(self_r.ps.idx.length()))
-    if self_r.ps.nodes.length() > 30:
+    print("  [info] self-parse node count: " + i64_to_string(self_r.nodes.length()))
+    print("  [info] self-parse idx list size: " + i64_to_string(self_r.idx.length()))
+    if self_r.nodes.length() > 30:
       print("PASS self_parse_sanity")
       pass_count = pass_count + 1
     else:
-      print("FAIL self_parse_sanity: too few nodes (" + i64_to_string(self_r.ps.nodes.length()) + ")")
+      print("FAIL self_parse_sanity: too few nodes (" + i64_to_string(self_r.nodes.length()) + ")")
   else:
     print("SKIP self_parse_file: file not found at " + self_path)
     print("SKIP self_parse_nodes: file not found")
@@ -309,14 +346,14 @@ fn main(): i32
 
   // Test 34: Generic fn declaration — fn foo<T>(x: T): T
   let src34: string = "fn foo<T>(x: T): T\n  return x\n"
-  let r34: PR = parse(src34)
-  if expect_no_parse_errors("generic_fn_no_err", r34):
+  let r34: ParseOutput = parse(src34)
+  if expect_no_parse_errors_po("generic_fn_no_err", r34):
     pass_count = pass_count + 1
 
   // Test 35: Generic class declaration — class Box<T>
   let src35: string = "class Box<T>:\n  value: T\n"
-  let r35: PR = parse(src35)
-  if expect_no_parse_errors("generic_class_no_err", r35):
+  let r35: ParseOutput = parse(src35)
+  if expect_no_parse_errors_po("generic_class_no_err", r35):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -325,14 +362,14 @@ fn main(): i32
 
   // Test 36: Class with method
   let src36: string = "class Foo:\n  x: i32\n  fn get_x(self): i32\n    return self.x\n"
-  let r36: PR = parse(src36)
-  if expect_no_parse_errors("class_method_no_err", r36):
+  let r36: ParseOutput = parse(src36)
+  if expect_no_parse_errors_po("class_method_no_err", r36):
     pass_count = pass_count + 1
 
   // Test 37: Class with method and multiple params
   let src37: string = "class Bar:\n  val: i64\n  fn add(self, n: i64): i64\n    return self.val + n\n"
-  let r37: PR = parse(src37)
-  if expect_no_parse_errors("class_method_multi_param_no_err", r37):
+  let r37: ParseOutput = parse(src37)
+  if expect_no_parse_errors_po("class_method_multi_param_no_err", r37):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------
@@ -341,20 +378,20 @@ fn main(): i32
 
   // Test 38: concept declaration parses without error
   let src38: string = "concept Printable:\n  fn to_string(self): string\n"
-  let r38: PR = parse(src38)
-  if expect_no_parse_errors("concept_decl_no_err", r38):
+  let r38: ParseOutput = parse(src38)
+  if expect_no_parse_errors_po("concept_decl_no_err", r38):
     pass_count = pass_count + 1
 
   // Test 39: extend declaration parses without error
   let src39: string = "class Foo:\n  x: i32\n\nconcept Printable:\n  fn to_string(self): string\n\nextend Foo as Printable:\n  fn to_string(self): string\n    return \"Foo\"\n"
-  let r39: PR = parse(src39)
-  if expect_no_parse_errors("extend_decl_no_err", r39):
+  let r39: ParseOutput = parse(src39)
+  if expect_no_parse_errors_po("extend_decl_no_err", r39):
     pass_count = pass_count + 1
 
   // Test 40: concept with multiple method signatures
   let src40: string = "concept Showable:\n  fn show(self): string\n  fn size(self): i64\n"
-  let r40: PR = parse(src40)
-  if expect_no_parse_errors("concept_multi_sig_no_err", r40):
+  let r40: ParseOutput = parse(src40)
+  if expect_no_parse_errors_po("concept_multi_sig_no_err", r40):
     pass_count = pass_count + 1
 
   // -----------------------------------------------------------------

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -29,11 +29,14 @@ class Scope:
   parent: i64
   decls: HashMap<i64>
 
-class RS:
+class RC:
   nodes: Vector<Node>
   idx_data: Vector<i64>
   toks: Vector<Token>
   src: string
+
+class RS:
+  rc: RC
   symbols: Vector<Symbol>
   scopes: Vector<Scope>
   uses: Vector<i64>
@@ -62,20 +65,20 @@ class ScopeR:
 fn rs_add_symbol(rs: RS, sym: Symbol): SymR
   let idx: i64 = rs.symbols.length()
   let new_syms: Vector<Symbol> = rs.symbols.push(sym)
-  let new_rs: RS = RS(rs.nodes, rs.idx_data, rs.toks, rs.src, new_syms, rs.scopes, rs.uses, rs.diags, rs.current_scope)
+  let new_rs: RS = RS(rs.rc, new_syms, rs.scopes, rs.uses, rs.diags, rs.current_scope)
   return SymR(new_rs, idx)
 
 fn rs_set_scopes(rs: RS, scopes: Vector<Scope>): RS
-  return RS(rs.nodes, rs.idx_data, rs.toks, rs.src, rs.symbols, scopes, rs.uses, rs.diags, rs.current_scope)
+  return RS(rs.rc, rs.symbols, scopes, rs.uses, rs.diags, rs.current_scope)
 
 fn rs_set_current_scope(rs: RS, scope_idx: i64): RS
-  return RS(rs.nodes, rs.idx_data, rs.toks, rs.src, rs.symbols, rs.scopes, rs.uses, rs.diags, scope_idx)
+  return RS(rs.rc, rs.symbols, rs.scopes, rs.uses, rs.diags, scope_idx)
 
 fn rs_set_uses(rs: RS, uses: Vector<i64>): RS
-  return RS(rs.nodes, rs.idx_data, rs.toks, rs.src, rs.symbols, rs.scopes, uses, rs.diags, rs.current_scope)
+  return RS(rs.rc, rs.symbols, rs.scopes, uses, rs.diags, rs.current_scope)
 
 fn rs_set_diags(rs: RS, diags: Vector<Diagnostic>): RS
-  return RS(rs.nodes, rs.idx_data, rs.toks, rs.src, rs.symbols, rs.scopes, rs.uses, diags, rs.current_scope)
+  return RS(rs.rc, rs.symbols, rs.scopes, rs.uses, diags, rs.current_scope)
 
 fn rs_push_scope(rs: RS, kind: ScopeKind): ScopeR
   let idx: i64 = rs.scopes.length()
@@ -125,7 +128,7 @@ fn scope_declare(rs: RS, name: string, sym_idx: i64, decl_tidx: i64): RS
       // Duplicate declaration — emit diagnostic at the duplicate's span
       let sp: Span = Span(to_i64(0), to_i64(1))
       if decl_tidx >= 0:
-        let tok: Token = rs.toks.get(decl_tidx)
+        let tok: Token = rs.rc.toks.get(decl_tidx)
         sp = Span(tok.offset, tok.len)
       let rs2: RS = rs_add_diag(rs, sp, "duplicate declaration '" + name + "'")
       return rs2
@@ -185,11 +188,11 @@ fn read_pairs(idx_data: Vector<i64>, lp: i64): Vector<i64>
 // =========================================================================
 
 fn tok_name(rs: RS, tidx: i64): string
-  let tok: Token = rs.toks.get(tidx)
-  return substring(rs.src, tok.offset, tok.len)
+  let tok: Token = rs.rc.toks.get(tidx)
+  return substring(rs.rc.src, tok.offset, tok.len)
 
 fn tok_name_span(rs: RS, tidx: i64): Span
-  let tok: Token = rs.toks.get(tidx)
+  let tok: Token = rs.rc.toks.get(tidx)
   return Span(tok.offset, tok.len)
 
 // =========================================================================
@@ -274,7 +277,7 @@ fn is_type_symbol(rs: RS, sym_idx: i64): bool
 fn resolve_type_node(rs: RS, node_idx: i64): RS
   if node_idx < 0:
     return rs
-  let node: Node = rs.nodes.get(node_idx)
+  let node: Node = rs.rc.nodes.get(node_idx)
   match node:
     Node.NamedT(tidx):
       let name: string = tok_name(rs, tidx)
@@ -292,7 +295,7 @@ fn resolve_type_node(rs: RS, node_idx: i64): RS
       if sym >= 0:
         if is_type_symbol(r, sym):
           r = rs_add_use(r, name_tidx, sym)
-      let args: Vector<i64> = read_list(r.idx_data, args_lp)
+      let args: Vector<i64> = read_list(r.rc.idx_data, args_lp)
       let i: i64 = 0
       while i < args.length():
         r = resolve_type_node(r, args.get(i))
@@ -311,7 +314,7 @@ fn resolve_type_node(rs: RS, node_idx: i64): RS
 fn resolve_expr(rs: RS, node_idx: i64): RS
   if node_idx < 0:
     return rs
-  let node: Node = rs.nodes.get(node_idx)
+  let node: Node = rs.rc.nodes.get(node_idx)
   match node:
     Node.IdentE(tidx):
       let name: string = tok_name(rs, tidx)
@@ -323,7 +326,7 @@ fn resolve_expr(rs: RS, node_idx: i64): RS
       return rs_add_diag(rs, sp, "unknown name '" + name + "'")
     Node.QualNameE(seg_lp, seg_count):
       // Resolve first segment only
-      let segs: Vector<i64> = read_list(rs.idx_data, seg_lp)
+      let segs: Vector<i64> = read_list(rs.rc.idx_data, seg_lp)
       if segs.length() > 0:
         let first_tidx: i64 = segs.get(0)
         let name: string = tok_name(rs, first_tidx)
@@ -340,7 +343,7 @@ fn resolve_expr(rs: RS, node_idx: i64): RS
       return resolve_expr(rs, operand)
     Node.CallE(callee, args_lp, arg_count):
       let r: RS = resolve_expr(rs, callee)
-      let args: Vector<i64> = read_list(r.idx_data, args_lp)
+      let args: Vector<i64> = read_list(r.rc.idx_data, args_lp)
       let i: i64 = 0
       while i < args.length():
         r = resolve_expr(r, args.get(i))
@@ -362,7 +365,7 @@ fn resolve_expr(rs: RS, node_idx: i64): RS
       let sr: ScopeR = rs_push_scope(rs, ScopeKind.BlockScope)
       let r: RS = sr.rs
       // Declare lambda parameters
-      let param_toks: Vector<i64> = read_list(r.idx_data, params_lp)
+      let param_toks: Vector<i64> = read_list(r.rc.idx_data, params_lp)
       let i: i64 = 0
       while i < param_toks.length():
         let ptidx: i64 = param_toks.get(i)
@@ -374,7 +377,7 @@ fn resolve_expr(rs: RS, node_idx: i64): RS
       r = resolve_expr(r, body)
       return rs_pop_scope(r)
     Node.ListLitE(elems_lp, elem_count):
-      let elems: Vector<i64> = read_list(rs.idx_data, elems_lp)
+      let elems: Vector<i64> = read_list(rs.rc.idx_data, elems_lp)
       let r: RS = rs
       let i: i64 = 0
       while i < elems.length():
@@ -400,7 +403,7 @@ fn resolve_expr(rs: RS, node_idx: i64): RS
 fn resolve_body_stmts(rs: RS, list_pos: i64): RS
   if list_pos < 0:
     return rs
-  let stmts: Vector<i64> = read_list(rs.idx_data, list_pos)
+  let stmts: Vector<i64> = read_list(rs.rc.idx_data, list_pos)
   let r: RS = rs
   let i: i64 = 0
   while i < stmts.length():
@@ -418,7 +421,7 @@ fn resolve_body_in_new_scope(rs: RS, list_pos: i64): RS
 fn resolve_stmt(rs: RS, node_idx: i64): RS
   if node_idx < 0:
     return rs
-  let node: Node = rs.nodes.get(node_idx)
+  let node: Node = rs.rc.nodes.get(node_idx)
   match node:
     Node.LetS(name_tidx, type_node, init_node):
       // Resolve type and init BEFORE declaring (prevents self-reference)
@@ -460,7 +463,7 @@ fn resolve_stmt(rs: RS, node_idx: i64): RS
     Node.MatchS(scrut_node, arms_lp):
       let r: RS = resolve_expr(rs, scrut_node)
       // Arms are pairs: [pattern_node, body_list_pos]
-      let arms: Vector<i64> = read_pairs(r.idx_data, arms_lp)
+      let arms: Vector<i64> = read_pairs(r.rc.idx_data, arms_lp)
       let i: i64 = 0
       while i < arms.length():
         let pat_node: i64 = arms.get(i)
@@ -484,12 +487,12 @@ fn resolve_stmt(rs: RS, node_idx: i64): RS
 fn resolve_type_params(rs: RS, tparams_lp: i64, node_idx: i64): RS
   if tparams_lp < 0:
     return rs
-  let tparams: Vector<i64> = read_list(rs.idx_data, tparams_lp)
+  let tparams: Vector<i64> = read_list(rs.rc.idx_data, tparams_lp)
   let r: RS = rs
   let i: i64 = 0
   while i < tparams.length():
     let tp_node_idx: i64 = tparams.get(i)
-    let tp_node: Node = r.nodes.get(tp_node_idx)
+    let tp_node: Node = r.rc.nodes.get(tp_node_idx)
     match tp_node:
       Node.GenericParamT(tidx):
         let tname: string = tok_name(r, tidx)
@@ -507,7 +510,7 @@ fn resolve_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, param
   r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
-  let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(r.rc.idx_data, params_lp)
   let i: i64 = 0
   while i < pairs.length():
     let p_tidx: i64 = pairs.get(i)
@@ -539,7 +542,7 @@ fn resolve_expr_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, 
   r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
-  let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(r.rc.idx_data, params_lp)
   let i: i64 = 0
   while i < pairs.length():
     let p_tidx: i64 = pairs.get(i)
@@ -570,7 +573,7 @@ fn resolve_extern_fn_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64
   r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare parameters
-  let pairs: Vector<i64> = read_pairs(r.idx_data, params_lp)
+  let pairs: Vector<i64> = read_pairs(r.rc.idx_data, params_lp)
   let i: i64 = 0
   while i < pairs.length():
     let p_tidx: i64 = pairs.get(i)
@@ -596,7 +599,7 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fi
   r = resolve_type_params(r, tparams_lp, node_idx)
 
   // Declare fields
-  let pairs: Vector<i64> = read_pairs(r.idx_data, fields_lp)
+  let pairs: Vector<i64> = read_pairs(r.rc.idx_data, fields_lp)
   let i: i64 = 0
   while i < pairs.length():
     let f_tidx: i64 = pairs.get(i)
@@ -611,11 +614,11 @@ fn resolve_class_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, fi
   // Resolve methods BEFORE popping struct scope, so class type params
   // (e.g. T in class Box<T>) are visible in method signatures/bodies.
   if methods_lp >= 0:
-    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let methods: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
     let mi: i64 = 0
     while mi < methods.length():
       let meth_idx: i64 = methods.get(mi)
-      let meth_node: Node = r.nodes.get(meth_idx)
+      let meth_node: Node = r.rc.nodes.get(meth_idx)
       match meth_node:
         Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
           r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
@@ -634,14 +637,14 @@ fn resolve_enum_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, var
     r0 = resolve_type_params(sr.rs, tparams_lp, node_idx)
     has_tparams = true
   // Resolve payload types for each variant
-  let pairs: Vector<i64> = read_pairs(r0.idx_data, variants_lp)
+  let pairs: Vector<i64> = read_pairs(r0.rc.idx_data, variants_lp)
   let r: RS = r0
   let i: i64 = 0
   while i < pairs.length():
     let v_tidx: i64 = pairs.get(i)
     let payload_lp: i64 = pairs.get(i + 1)
     // Resolve each payload type
-    let payload_types: Vector<i64> = read_list(r.idx_data, payload_lp)
+    let payload_types: Vector<i64> = read_list(r.rc.idx_data, payload_lp)
     let j: i64 = 0
     while j < payload_types.length():
       r = resolve_type_node(r, payload_types.get(j))
@@ -661,11 +664,11 @@ fn resolve_concept_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, 
   r = resolve_type_params(r, tparams_lp, node_idx)
   // Resolve method signature types (ExternFnD nodes — no body)
   if methods_lp >= 0:
-    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let methods: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
     let mi: i64 = 0
     while mi < methods.length():
       let meth_idx: i64 = methods.get(mi)
-      let meth_node: Node = r.nodes.get(meth_idx)
+      let meth_node: Node = r.rc.nodes.get(meth_idx)
       match meth_node:
         Node.ExternFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type):
           r = resolve_extern_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type)
@@ -683,11 +686,11 @@ fn resolve_extend_decl(rs: RS, node_idx: i64, target_type_node: i64, concept_nam
     r = rs_add_use(r, concept_name_tidx, csym)
   // Resolve each method body
   if methods_lp >= 0:
-    let methods: Vector<i64> = read_list(r.idx_data, methods_lp)
+    let methods: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
     let mi: i64 = 0
     while mi < methods.length():
       let meth_idx: i64 = methods.get(mi)
-      let meth_node: Node = r.nodes.get(meth_idx)
+      let meth_node: Node = r.rc.nodes.get(meth_idx)
       match meth_node:
         Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
           r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
@@ -697,7 +700,7 @@ fn resolve_extend_decl(rs: RS, node_idx: i64, target_type_node: i64, concept_nam
 fn resolve_decl(rs: RS, node_idx: i64): RS
   if node_idx < 0:
     return rs
-  let node: Node = rs.nodes.get(node_idx)
+  let node: Node = rs.rc.nodes.get(node_idx)
   match node:
     Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_lp):
       return resolve_fn_decl(rs, node_idx, name_tidx, tparams_lp, params_lp, ret_type, body_lp)
@@ -724,15 +727,15 @@ fn resolve_decl(rs: RS, node_idx: i64): RS
 // =========================================================================
 
 fn collect_top_level(rs: RS, file_node_idx: i64): RS
-  let file_node: Node = rs.nodes.get(file_node_idx)
+  let file_node: Node = rs.rc.nodes.get(file_node_idx)
   match file_node:
     Node.FileN(decls_lp):
-      let decls: Vector<i64> = read_list(rs.idx_data, decls_lp)
+      let decls: Vector<i64> = read_list(rs.rc.idx_data, decls_lp)
       let r: RS = rs
       let i: i64 = 0
       while i < decls.length():
         let decl_idx: i64 = decls.get(i)
-        let decl_node: Node = r.nodes.get(decl_idx)
+        let decl_node: Node = r.rc.nodes.get(decl_idx)
         match decl_node:
           Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_lp):
             let name: string = tok_name(r, name_tidx)
@@ -752,11 +755,11 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
             r = scope_declare(sr.rs, name, sr.sym_idx, name_tidx)
             // Register mangled method symbols in file scope
             if methods_lp >= 0:
-              let meths: Vector<i64> = read_list(r.idx_data, methods_lp)
+              let meths: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
               let mi: i64 = 0
               while mi < meths.length():
                 let meth_idx: i64 = meths.get(mi)
-                let meth_node: Node = r.nodes.get(meth_idx)
+                let meth_node: Node = r.rc.nodes.get(meth_idx)
                 match meth_node:
                   Node.FnDeclD(m_name_tidx, m_tp, m_plp, m_rt, m_blp):
                     let mname: string = tok_name(r, m_name_tidx)
@@ -781,15 +784,15 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
             if methods_lp >= 0:
               let target_name: string = ""
               if target_type_node >= 0:
-                let tnode: Node = r.nodes.get(target_type_node)
+                let tnode: Node = r.rc.nodes.get(target_type_node)
                 match tnode:
                   Node.NamedT(t_tidx):
                     target_name = tok_name(r, t_tidx)
-              let meths: Vector<i64> = read_list(r.idx_data, methods_lp)
+              let meths: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
               let mi: i64 = 0
               while mi < meths.length():
                 let meth_idx: i64 = meths.get(mi)
-                let meth_node: Node = r.nodes.get(meth_idx)
+                let meth_node: Node = r.rc.nodes.get(meth_idx)
                 match meth_node:
                   Node.FnDeclD(m_name_tidx, m_tp, m_plp, m_rt, m_blp):
                     let mname: string = tok_name(r, m_name_tidx)
@@ -808,10 +811,10 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
 // =========================================================================
 
 fn resolve_bodies(rs: RS, file_node_idx: i64): RS
-  let file_node: Node = rs.nodes.get(file_node_idx)
+  let file_node: Node = rs.rc.nodes.get(file_node_idx)
   match file_node:
     Node.FileN(decls_lp):
-      let decls: Vector<i64> = read_list(rs.idx_data, decls_lp)
+      let decls: Vector<i64> = read_list(rs.rc.idx_data, decls_lp)
       let r: RS = rs
       let i: i64 = 0
       while i < decls.length():
@@ -826,11 +829,12 @@ fn resolve_bodies(rs: RS, file_node_idx: i64): RS
 
 fn resolve(src: string): ResolveResult
   // Parse the source
-  let pr: PR = parse(src)
-  let file_node_idx: i64 = pr.node
+  let po: ParseOutput = parse(src)
+  let file_node_idx: i64 = po.root
 
   // Initialize resolver state
-  let rs: RS = RS(pr.ps.nodes, pr.ps.idx, pr.ps.toks, src, Vector<Symbol>::new(), Vector<Scope>::new(), Vector<i64>::new(), pr.ps.diags, to_i64(-1))
+  let rc: RC = RC(po.nodes, po.idx, po.toks, src)
+  let rs: RS = RS(rc, Vector<Symbol>::new(), Vector<Scope>::new(), Vector<i64>::new(), po.diags, to_i64(-1))
 
   // Create file scope
   let file_sr: ScopeR = rs_push_scope(rs, ScopeKind.FileScope)
@@ -845,7 +849,7 @@ fn resolve(src: string): ResolveResult
   // Pass 2: Resolve bodies
   rs = resolve_bodies(rs, file_node_idx)
 
-  return ResolveResult(rs.symbols, rs.scopes, rs.uses, rs.diags, pr.ps.nodes.length())
+  return ResolveResult(rs.symbols, rs.scopes, rs.uses, rs.diags, po.nodes.length())
 
 // BEGIN_RESOLVER_TESTS
 // =========================================================================

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -809,9 +809,11 @@ enum class Node:
 // Section 7: Parser state and result types
 // =========================================================================
 
-class PS:
+class PC:
   toks: Vector<Token>
   src: string
+
+class PS:
   pos: i64
   nodes: Vector<Node>
   idx: Vector<i64>
@@ -821,26 +823,34 @@ class PR:
   ps: PS
   node: i64
 
+class ParseOutput:
+  toks: Vector<Token>
+  src: string
+  nodes: Vector<Node>
+  idx: Vector<i64>
+  diags: Vector<Diagnostic>
+  root: i64
+
 // =========================================================================
 // Section 8: Parser state helpers
 // =========================================================================
 
 fn ps_set_pos(ps: PS, p: i64): PS
-  return PS(ps.toks, ps.src, p, ps.nodes, ps.idx, ps.diags)
+  return PS(p, ps.nodes, ps.idx, ps.diags)
 
 fn ps_set_nodes(ps: PS, n: Vector<Node>): PS
-  return PS(ps.toks, ps.src, ps.pos, n, ps.idx, ps.diags)
+  return PS(ps.pos, n, ps.idx, ps.diags)
 
 fn ps_set_idx(ps: PS, ix: Vector<i64>): PS
-  return PS(ps.toks, ps.src, ps.pos, ps.nodes, ix, ps.diags)
+  return PS(ps.pos, ps.nodes, ix, ps.diags)
 
 fn ps_set_diags(ps: PS, d: Vector<Diagnostic>): PS
-  return PS(ps.toks, ps.src, ps.pos, ps.nodes, ps.idx, d)
+  return PS(ps.pos, ps.nodes, ps.idx, d)
 
-fn ps_advance(ps: PS): PS
-  if ps.pos >= ps.toks.length():
+fn ps_advance(pc: PC, ps: PS): PS
+  if ps.pos >= pc.toks.length():
     return ps
-  let tok: Token = ps.toks.get(ps.pos)
+  let tok: Token = pc.toks.get(ps.pos)
   if tk_name(tok.kind) == tk_name(TK.Eof):
     return ps
   return ps_set_pos(ps, ps.pos + 1)
@@ -857,41 +867,41 @@ fn ps_add_diag(ps: PS, span: Span, msg: string): PS
 fn idx_push(ps: PS, val: i64): PS
   return ps_set_idx(ps, ps.idx.push(val))
 
-fn peek_kind(ps: PS): TK
-  if ps.pos >= ps.toks.length():
+fn peek_kind(pc: PC, ps: PS): TK
+  if ps.pos >= pc.toks.length():
     return TK.Eof
-  let tok: Token = ps.toks.get(ps.pos)
+  let tok: Token = pc.toks.get(ps.pos)
   return tok.kind
 
-fn peek_tok(ps: PS): Token
-  if ps.pos >= ps.toks.length():
+fn peek_tok(pc: PC, ps: PS): Token
+  if ps.pos >= pc.toks.length():
     return Token(TK.Eof, to_i64(0), to_i64(0))
-  return ps.toks.get(ps.pos)
+  return pc.toks.get(ps.pos)
 
-fn at_end(ps: PS): bool
-  return tk_name(peek_kind(ps)) == tk_name(TK.Eof)
+fn at_end(pc: PC, ps: PS): bool
+  return tk_name(peek_kind(pc, ps)) == tk_name(TK.Eof)
 
-fn tok_span(ps: PS): Span
-  let tok: Token = peek_tok(ps)
+fn tok_span(pc: PC, ps: PS): Span
+  let tok: Token = peek_tok(pc, ps)
   return Span(tok.offset, tok.len)
 
-fn expect(ps: PS, kind: TK): PS
-  if tk_name(peek_kind(ps)) == tk_name(kind):
-    return ps_advance(ps)
-  let sp: Span = tok_span(ps)
-  return ps_add_diag(ps, sp, "expected " + tk_name(kind) + ", got " + tk_name(peek_kind(ps)))
+fn expect(pc: PC, ps: PS, kind: TK): PS
+  if tk_name(peek_kind(pc, ps)) == tk_name(kind):
+    return ps_advance(pc, ps)
+  let sp: Span = tok_span(pc, ps)
+  return ps_add_diag(ps, sp, "expected " + tk_name(kind) + ", got " + tk_name(peek_kind(pc, ps)))
 
-fn match_tok(ps: PS, kind: TK): PS
-  if tk_name(peek_kind(ps)) == tk_name(kind):
-    return ps_advance(ps)
+fn match_tok(pc: PC, ps: PS, kind: TK): PS
+  if tk_name(peek_kind(pc, ps)) == tk_name(kind):
+    return ps_advance(pc, ps)
   return ps
 
-fn skip_newlines(ps: PS): PS
+fn skip_newlines(pc: PC, ps: PS): PS
   let cur: PS = ps
   let done: bool = false
   while done == false:
-    if tk_name(peek_kind(cur)) == tk_name(TK.Newline):
-      cur = ps_advance(cur)
+    if tk_name(peek_kind(pc, cur)) == tk_name(TK.Newline):
+      cur = ps_advance(pc, cur)
     else:
       done = true
   return cur
@@ -926,24 +936,24 @@ fn flush_pairs(ps: PS, items: Vector<i64>, pair_count: i64): FlushResult
   cur = idx_push(cur, pair_count)
   return FlushResult(cur, lp)
 
-fn tok_text(ps: PS, tidx: i64): string
-  let tok: Token = ps.toks.get(tidx)
+fn tok_text(pc: PC, tidx: i64): string
+  let tok: Token = pc.toks.get(tidx)
   if tok.len <= 0:
     return ""
-  return substring(ps.src, tok.offset, tok.len)
+  return substring(pc.src, tok.offset, tok.len)
 
 // =========================================================================
 // Section 9: Error recovery helpers
 // =========================================================================
 
-fn sync_to_decl(ps: PS): PS
+fn sync_to_decl(pc: PC, ps: PS): PS
   let cur: PS = ps
   let done: bool = false
   while done == false:
-    if at_end(cur):
+    if at_end(pc, cur):
       done = true
     else:
-      let k: TK = peek_kind(cur)
+      let k: TK = peek_kind(pc, cur)
       if tk_name(k) == tk_name(TK.KwFn):
         done = true
       else:
@@ -962,65 +972,65 @@ fn sync_to_decl(ps: PS): PS
                 if tk_name(k) == tk_name(TK.Dedent):
                   done = true
                 else:
-                  cur = ps_advance(cur)
+                  cur = ps_advance(pc, cur)
   return cur
 
-fn sync_to_stmt(ps: PS): PS
+fn sync_to_stmt(pc: PC, ps: PS): PS
   let cur: PS = ps
   let done: bool = false
   while done == false:
-    if at_end(cur):
+    if at_end(pc, cur):
       done = true
     else:
-      let k: TK = peek_kind(cur)
+      let k: TK = peek_kind(pc, cur)
       if tk_name(k) == tk_name(TK.Newline):
         done = true
       else:
         if tk_name(k) == tk_name(TK.Dedent):
           done = true
         else:
-          cur = ps_advance(cur)
+          cur = ps_advance(pc, cur)
   return cur
 
 // =========================================================================
 // Section 10: Type parsing
 // =========================================================================
 
-fn parse_type(ps: PS): PR
+fn parse_type(pc: PC, ps: PS): PR
   // Pointer type: *T
-  if tk_name(peek_kind(ps)) == tk_name(TK.Star):
-    let ps2: PS = ps_advance(ps)
-    let inner: PR = parse_type(ps2)
+  if tk_name(peek_kind(pc, ps)) == tk_name(TK.Star):
+    let ps2: PS = ps_advance(pc, ps)
+    let inner: PR = parse_type(pc, ps2)
     if inner.node < 0:
       return inner
     return ps_add_node(inner.ps, Node.PointerT(inner.node))
   // Named or generic type
-  return parse_named_type(ps)
+  return parse_named_type(pc, ps)
 
-fn parse_named_type(ps: PS): PR
-  if tk_name(peek_kind(ps)) != tk_name(TK.Identifier):
-    let sp: Span = tok_span(ps)
+fn parse_named_type(pc: PC, ps: PS): PR
+  if tk_name(peek_kind(pc, ps)) != tk_name(TK.Identifier):
+    let sp: Span = tok_span(pc, ps)
     let ps2: PS = ps_add_diag(ps, sp, "expected type name")
-    let ps3: PS = ps_advance(ps2)
+    let ps3: PS = ps_advance(pc, ps2)
     return ps_add_node(ps3, Node.ErrorT(ps.pos))
 
   let name_tidx: i64 = ps.pos
-  let ps2: PS = ps_advance(ps)
+  let ps2: PS = ps_advance(pc, ps)
 
   // Check for generic: Name<...>
-  if tk_name(peek_kind(ps2)) == tk_name(TK.Lt):
-    let ps3: PS = ps_advance(ps2)
+  if tk_name(peek_kind(pc, ps2)) == tk_name(TK.Lt):
+    let ps3: PS = ps_advance(pc, ps2)
     // Parse type arguments — collect then flush for contiguity
     let collected: Vector<i64> = Vector<i64>::new()
-    let first_arg: PR = parse_type(ps3)
+    let first_arg: PR = parse_type(pc, ps3)
     if first_arg.node >= 0:
       collected = collected.push(first_arg.node)
       let cur: PS = first_arg.ps
       let done: bool = false
       while done == false:
-        if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-          cur = ps_advance(cur)
-          let arg: PR = parse_type(cur)
+        if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+          cur = ps_advance(pc, cur)
+          let arg: PR = parse_type(pc, cur)
           if arg.node >= 0:
             collected = collected.push(arg.node)
             cur = arg.ps
@@ -1030,11 +1040,11 @@ fn parse_named_type(ps: PS): PR
         else:
           done = true
       let fl: FlushResult = flush_list(cur, collected)
-      let ps7: PS = expect(fl.ps, TK.Gt)
+      let ps7: PS = expect(pc, fl.ps, TK.Gt)
       return ps_add_node(ps7, Node.GenericT(name_tidx, fl.list_pos, collected.length()))
     else:
       // Error parsing first type arg
-      let ps5: PS = expect(first_arg.ps, TK.Gt)
+      let ps5: PS = expect(pc, first_arg.ps, TK.Gt)
       return ps_add_node(ps5, Node.ErrorT(name_tidx))
 
   // Simple named type
@@ -1045,80 +1055,80 @@ fn parse_named_type(ps: PS): PR
 // =========================================================================
 
 // Primary expressions
-fn parse_primary(ps: PS): PR
-  let k: TK = peek_kind(ps)
+fn parse_primary(pc: PC, ps: PS): PR
+  let k: TK = peek_kind(pc, ps)
 
   // Integer literal
   if tk_name(k) == tk_name(TK.IntLiteral):
     let tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.IntLitE(tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.IntLitE(tidx))
 
   // Float literal
   if tk_name(k) == tk_name(TK.FloatLiteral):
     let tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.FloatLitE(tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.FloatLitE(tidx))
 
   // String literal
   if tk_name(k) == tk_name(TK.StringLiteral):
     let tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.StringLitE(tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.StringLitE(tidx))
 
   // Bool literal true
   if tk_name(k) == tk_name(TK.KwTrue):
     let tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.BoolLitE(tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.BoolLitE(tidx))
 
   // Bool literal false
   if tk_name(k) == tk_name(TK.KwFalse):
     let tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.BoolLitE(tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.BoolLitE(tidx))
 
   // Parenthesized expression
   if tk_name(k) == tk_name(TK.LParen):
-    let ps2: PS = ps_advance(ps)
-    let inner: PR = parse_expr(ps2)
+    let ps2: PS = ps_advance(pc, ps)
+    let inner: PR = parse_expr(pc, ps2)
     if inner.node < 0:
       return inner
-    let ps3: PS = expect(inner.ps, TK.RParen)
+    let ps3: PS = expect(pc, inner.ps, TK.RParen)
     return PR(ps3, inner.node)
 
   // List literal: [elem, ...]
   if tk_name(k) == tk_name(TK.LBracket):
-    return parse_list_literal(ps)
+    return parse_list_literal(pc, ps)
 
   // Lambda: |params| -> body
   if tk_name(k) == tk_name(TK.Pipe):
-    return parse_lambda(ps)
+    return parse_lambda(pc, ps)
 
   // Identifier or qualified name
   if tk_name(k) == tk_name(TK.Identifier):
-    return parse_ident_or_qual(ps)
+    return parse_ident_or_qual(pc, ps)
 
   // self keyword as expression (inside method bodies)
   if tk_name(k) == tk_name(TK.KwSelf):
     let self_tidx: i64 = ps.pos
-    return ps_add_node(ps_advance(ps), Node.IdentE(self_tidx))
+    return ps_add_node(ps_advance(pc, ps), Node.IdentE(self_tidx))
 
   // Error
-  let sp: Span = tok_span(ps)
+  let sp: Span = tok_span(pc, ps)
   let ps2: PS = ps_add_diag(ps, sp, "expected expression")
-  return ps_add_node(ps_advance(ps2), Node.ErrorE(ps.pos))
+  return ps_add_node(ps_advance(pc, ps2), Node.ErrorE(ps.pos))
 
-fn parse_list_literal(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_list_literal(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let collected: Vector<i64> = Vector<i64>::new()
   let cur: PS = ps2
 
-  if tk_name(peek_kind(cur)) != tk_name(TK.RBracket):
-    let first: PR = parse_expr(cur)
+  if tk_name(peek_kind(pc, cur)) != tk_name(TK.RBracket):
+    let first: PR = parse_expr(pc, cur)
     if first.node >= 0:
       collected = collected.push(first.node)
       cur = first.ps
       let done: bool = false
       while done == false:
-        if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-          cur = ps_advance(cur)
-          let elem: PR = parse_expr(cur)
+        if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+          cur = ps_advance(pc, cur)
+          let elem: PR = parse_expr(pc, cur)
           if elem.node >= 0:
             collected = collected.push(elem.node)
             cur = elem.ps
@@ -1131,43 +1141,43 @@ fn parse_list_literal(ps: PS): PR
       cur = first.ps
 
   let fl: FlushResult = flush_list(cur, collected)
-  cur = expect(fl.ps, TK.RBracket)
+  cur = expect(pc, fl.ps, TK.RBracket)
   return ps_add_node(cur, Node.ListLitE(fl.list_pos, collected.length()))
 
-fn parse_lambda(ps: PS): PR
-  let ps2: PS = expect(ps, TK.Pipe)
+fn parse_lambda(pc: PC, ps: PS): PR
+  let ps2: PS = expect(pc, ps, TK.Pipe)
   let param_toks: Vector<i64> = Vector<i64>::new()
   let cur: PS = ps2
 
-  if tk_name(peek_kind(cur)) != tk_name(TK.Pipe):
+  if tk_name(peek_kind(pc, cur)) != tk_name(TK.Pipe):
     // First param
     let tidx: i64 = cur.pos
-    cur = expect(cur, TK.Identifier)
+    cur = expect(pc, cur, TK.Identifier)
     param_toks = param_toks.push(tidx)
     let done: bool = false
     while done == false:
-      if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-        cur = ps_advance(cur)
+      if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+        cur = ps_advance(pc, cur)
         let tidx2: i64 = cur.pos
-        cur = expect(cur, TK.Identifier)
+        cur = expect(pc, cur, TK.Identifier)
         param_toks = param_toks.push(tidx2)
       else:
         done = true
 
   let param_fl: FlushResult = flush_list(cur, param_toks)
-  cur = expect(param_fl.ps, TK.Pipe)
-  cur = expect(cur, TK.Arrow)
-  let body: PR = parse_expr(cur)
+  cur = expect(pc, param_fl.ps, TK.Pipe)
+  cur = expect(pc, cur, TK.Arrow)
+  let body: PR = parse_expr(pc, cur)
   if body.node < 0:
     return body
   return ps_add_node(body.ps, Node.LambdaE(param_fl.list_pos, param_toks.length(), body.node))
 
-fn parse_ident_or_qual(ps: PS): PR
+fn parse_ident_or_qual(pc: PC, ps: PS): PR
   let first_tidx: i64 = ps.pos
-  let ps2: PS = ps_advance(ps)
+  let ps2: PS = ps_advance(pc, ps)
 
   // Check for :: (qualified name)
-  if tk_name(peek_kind(ps2)) != tk_name(TK.ColonColon):
+  if tk_name(peek_kind(pc, ps2)) != tk_name(TK.ColonColon):
     return ps_add_node(ps2, Node.IdentE(first_tidx))
 
   // Qualified name: ident::ident (::ident)*
@@ -1176,10 +1186,10 @@ fn parse_ident_or_qual(ps: PS): PR
   let cur: PS = ps2
   let done: bool = false
   while done == false:
-    if tk_name(peek_kind(cur)) == tk_name(TK.ColonColon):
-      cur = ps_advance(cur)
+    if tk_name(peek_kind(pc, cur)) == tk_name(TK.ColonColon):
+      cur = ps_advance(pc, cur)
       let tidx: i64 = cur.pos
-      cur = expect(cur, TK.Identifier)
+      cur = expect(pc, cur, TK.Identifier)
       seg_toks = seg_toks.push(tidx)
     else:
       done = true
@@ -1188,31 +1198,31 @@ fn parse_ident_or_qual(ps: PS): PR
   return ps_add_node(seg_fl.ps, Node.QualNameE(seg_fl.list_pos, seg_toks.length()))
 
 // Postfix expressions: call, field, index, try
-fn parse_postfix(ps: PS): PR
-  let prim: PR = parse_primary(ps)
+fn parse_postfix(pc: PC, ps: PS): PR
+  let prim: PR = parse_primary(pc, ps)
   if prim.node < 0:
     return prim
   let cur_ps: PS = prim.ps
   let cur_node: i64 = prim.node
   let done: bool = false
   while done == false:
-    let k: TK = peek_kind(cur_ps)
+    let k: TK = peek_kind(pc, cur_ps)
 
     // Call: expr(args)
     if tk_name(k) == tk_name(TK.LParen):
-      let ps2: PS = ps_advance(cur_ps)
+      let ps2: PS = ps_advance(pc, cur_ps)
       let call_args: Vector<i64> = Vector<i64>::new()
       let inner: PS = ps2
-      if tk_name(peek_kind(inner)) != tk_name(TK.RParen):
-        let arg: PR = parse_expr(inner)
+      if tk_name(peek_kind(pc, inner)) != tk_name(TK.RParen):
+        let arg: PR = parse_expr(pc, inner)
         if arg.node >= 0:
           call_args = call_args.push(arg.node)
           inner = arg.ps
           let arg_done: bool = false
           while arg_done == false:
-            if tk_name(peek_kind(inner)) == tk_name(TK.Comma):
-              inner = ps_advance(inner)
-              let arg2: PR = parse_expr(inner)
+            if tk_name(peek_kind(pc, inner)) == tk_name(TK.Comma):
+              inner = ps_advance(pc, inner)
+              let arg2: PR = parse_expr(pc, inner)
               if arg2.node >= 0:
                 call_args = call_args.push(arg2.node)
                 inner = arg2.ps
@@ -1224,7 +1234,7 @@ fn parse_postfix(ps: PS): PR
         else:
           inner = arg.ps
       let call_fl: FlushResult = flush_list(inner, call_args)
-      inner = expect(call_fl.ps, TK.RParen)
+      inner = expect(pc, call_fl.ps, TK.RParen)
       let call_r: PR = ps_add_node(inner, Node.CallE(cur_node, call_fl.list_pos, call_args.length()))
       cur_ps = call_r.ps
       cur_node = call_r.node
@@ -1232,9 +1242,9 @@ fn parse_postfix(ps: PS): PR
     // Field access: expr.field
     else:
       if tk_name(k) == tk_name(TK.Dot):
-        let ps2: PS = ps_advance(cur_ps)
+        let ps2: PS = ps_advance(pc, cur_ps)
         let field_tidx: i64 = ps2.pos
-        let ps3: PS = expect(ps2, TK.Identifier)
+        let ps3: PS = expect(pc, ps2, TK.Identifier)
         let fld_r: PR = ps_add_node(ps3, Node.FieldE(cur_node, field_tidx))
         cur_ps = fld_r.ps
         cur_node = fld_r.node
@@ -1242,11 +1252,11 @@ fn parse_postfix(ps: PS): PR
       // Index: expr[index]
       else:
         if tk_name(k) == tk_name(TK.LBracket):
-          let ps2: PS = ps_advance(cur_ps)
-          let idx_expr: PR = parse_expr(ps2)
+          let ps2: PS = ps_advance(pc, cur_ps)
+          let idx_expr: PR = parse_expr(pc, ps2)
           if idx_expr.node < 0:
             return idx_expr
-          let ps3: PS = expect(idx_expr.ps, TK.RBracket)
+          let ps3: PS = expect(pc, idx_expr.ps, TK.RBracket)
           let idx_r: PR = ps_add_node(ps3, Node.IndexE(cur_node, idx_expr.node))
           cur_ps = idx_r.ps
           cur_node = idx_r.node
@@ -1254,7 +1264,7 @@ fn parse_postfix(ps: PS): PR
         // Try: expr?
         else:
           if tk_name(k) == tk_name(TK.Question):
-            let ps2: PS = ps_advance(cur_ps)
+            let ps2: PS = ps_advance(pc, cur_ps)
             let try_r: PR = ps_add_node(ps2, Node.TryE(cur_node))
             cur_ps = try_r.ps
             cur_node = try_r.node
@@ -1265,29 +1275,29 @@ fn parse_postfix(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Unary: -expr, !expr, *expr, &expr
-fn parse_unary(ps: PS): PR
-  let k: TK = peek_kind(ps)
+fn parse_unary(pc: PC, ps: PS): PR
+  let k: TK = peek_kind(pc, ps)
   if tk_name(k) == tk_name(TK.Minus) or tk_name(k) == tk_name(TK.Bang) or tk_name(k) == tk_name(TK.Star) or tk_name(k) == tk_name(TK.Amp):
     let op_tidx: i64 = ps.pos
-    let operand: PR = parse_unary(ps_advance(ps))
+    let operand: PR = parse_unary(pc, ps_advance(pc, ps))
     if operand.node < 0:
       return operand
     return ps_add_node(operand.ps, Node.UnaryE(op_tidx, operand.node))
-  return parse_postfix(ps)
+  return parse_postfix(pc, ps)
 
 // Multiplicative: expr * expr, expr / expr, expr % expr
-fn parse_multiplicative(ps: PS): PR
-  let left: PR = parse_unary(ps)
+fn parse_multiplicative(pc: PC, ps: PS): PR
+  let left: PR = parse_unary(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    let k: TK = peek_kind(cur_ps)
+    let k: TK = peek_kind(pc, cur_ps)
     if tk_name(k) == tk_name(TK.Star) or tk_name(k) == tk_name(TK.Slash) or tk_name(k) == tk_name(TK.Percent):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_unary(ps_advance(cur_ps))
+      let right: PR = parse_unary(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1298,18 +1308,18 @@ fn parse_multiplicative(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Additive: expr + expr, expr - expr
-fn parse_additive(ps: PS): PR
-  let left: PR = parse_multiplicative(ps)
+fn parse_additive(pc: PC, ps: PS): PR
+  let left: PR = parse_multiplicative(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    let k: TK = peek_kind(cur_ps)
+    let k: TK = peek_kind(pc, cur_ps)
     if tk_name(k) == tk_name(TK.Plus) or tk_name(k) == tk_name(TK.Minus):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_multiplicative(ps_advance(cur_ps))
+      let right: PR = parse_multiplicative(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1320,18 +1330,18 @@ fn parse_additive(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Relational: <, <=, >, >=
-fn parse_relational(ps: PS): PR
-  let left: PR = parse_additive(ps)
+fn parse_relational(pc: PC, ps: PS): PR
+  let left: PR = parse_additive(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    let k: TK = peek_kind(cur_ps)
+    let k: TK = peek_kind(pc, cur_ps)
     if tk_name(k) == tk_name(TK.Lt) or tk_name(k) == tk_name(TK.LtEq) or tk_name(k) == tk_name(TK.Gt) or tk_name(k) == tk_name(TK.GtEq):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_additive(ps_advance(cur_ps))
+      let right: PR = parse_additive(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1342,18 +1352,18 @@ fn parse_relational(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Equality: ==, !=
-fn parse_equality(ps: PS): PR
-  let left: PR = parse_relational(ps)
+fn parse_equality(pc: PC, ps: PS): PR
+  let left: PR = parse_relational(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    let k: TK = peek_kind(cur_ps)
+    let k: TK = peek_kind(pc, cur_ps)
     if tk_name(k) == tk_name(TK.EqEq) or tk_name(k) == tk_name(TK.BangEq):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_relational(ps_advance(cur_ps))
+      let right: PR = parse_relational(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1364,17 +1374,17 @@ fn parse_equality(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Logical and
-fn parse_logical_and(ps: PS): PR
-  let left: PR = parse_equality(ps)
+fn parse_logical_and(pc: PC, ps: PS): PR
+  let left: PR = parse_equality(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    if tk_name(peek_kind(cur_ps)) == tk_name(TK.KwAnd):
+    if tk_name(peek_kind(pc, cur_ps)) == tk_name(TK.KwAnd):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_equality(ps_advance(cur_ps))
+      let right: PR = parse_equality(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1385,17 +1395,17 @@ fn parse_logical_and(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Logical or
-fn parse_logical_or(ps: PS): PR
-  let left: PR = parse_logical_and(ps)
+fn parse_logical_or(pc: PC, ps: PS): PR
+  let left: PR = parse_logical_and(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    if tk_name(peek_kind(cur_ps)) == tk_name(TK.KwOr):
+    if tk_name(peek_kind(pc, cur_ps)) == tk_name(TK.KwOr):
       let op_tidx: i64 = cur_ps.pos
-      let right: PR = parse_logical_and(ps_advance(cur_ps))
+      let right: PR = parse_logical_and(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let bin_r: PR = ps_add_node(right.ps, Node.BinaryE(op_tidx, cur_node, right.node))
@@ -1406,16 +1416,16 @@ fn parse_logical_or(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Pipe: expr |> expr
-fn parse_pipe(ps: PS): PR
-  let left: PR = parse_logical_or(ps)
+fn parse_pipe(pc: PC, ps: PS): PR
+  let left: PR = parse_logical_or(pc, ps)
   if left.node < 0:
     return left
   let cur_ps: PS = left.ps
   let cur_node: i64 = left.node
   let done: bool = false
   while done == false:
-    if tk_name(peek_kind(cur_ps)) == tk_name(TK.PipeGt):
-      let right: PR = parse_logical_or(ps_advance(cur_ps))
+    if tk_name(peek_kind(pc, cur_ps)) == tk_name(TK.PipeGt):
+      let right: PR = parse_logical_or(pc, ps_advance(pc, cur_ps))
       if right.node < 0:
         return right
       let pipe_r: PR = ps_add_node(right.ps, Node.PipeE(cur_node, right.node))
@@ -1426,8 +1436,8 @@ fn parse_pipe(ps: PS): PR
   return PR(cur_ps, cur_node)
 
 // Top-level expression entry
-fn parse_expr(ps: PS): PR
-  return parse_pipe(ps)
+fn parse_expr(pc: PC, ps: PS): PR
+  return parse_pipe(pc, ps)
 
 // =========================================================================
 // Section 12: Statement parsing
@@ -1435,131 +1445,131 @@ fn parse_expr(ps: PS): PR
 
 // Parse a suite (body block): NEWLINE INDENT stmts DEDENT
 // Returns PR where .node = list_pos (position of count in idx)
-fn parse_suite(ps: PS): PR
-  let ps2: PS = expect(ps, TK.Newline)
-  let ps3: PS = expect(ps2, TK.Indent)
+fn parse_suite(pc: PC, ps: PS): PR
+  let ps2: PS = expect(pc, ps, TK.Newline)
+  let ps3: PS = expect(pc, ps2, TK.Indent)
   let collected: Vector<i64> = Vector<i64>::new()
   let cur: PS = ps3
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
-      let stmt: PR = parse_statement(cur)
+      let stmt: PR = parse_statement(pc, cur)
       if stmt.node >= 0:
         collected = collected.push(stmt.node)
         cur = stmt.ps
       else:
         // Error recovery: skip to next statement boundary
-        cur = sync_to_stmt(stmt.ps)
+        cur = sync_to_stmt(pc, stmt.ps)
         let err_r: PR = ps_add_node(cur, Node.ErrorS(cur.pos))
         collected = collected.push(err_r.node)
         cur = err_r.ps
 
   let fl: FlushResult = flush_list(cur, collected)
-  cur = expect(fl.ps, TK.Dedent)
+  cur = expect(pc, fl.ps, TK.Dedent)
   return PR(cur, fl.list_pos)
 
-fn parse_statement(ps: PS): PR
-  let k: TK = peek_kind(ps)
+fn parse_statement(pc: PC, ps: PS): PR
+  let k: TK = peek_kind(pc, ps)
 
   if tk_name(k) == tk_name(TK.KwLet):
-    return parse_let_stmt(ps)
+    return parse_let_stmt(pc, ps)
   if tk_name(k) == tk_name(TK.KwIf):
-    return parse_if_stmt(ps)
+    return parse_if_stmt(pc, ps)
   if tk_name(k) == tk_name(TK.KwWhile):
-    return parse_while_stmt(ps)
+    return parse_while_stmt(pc, ps)
   if tk_name(k) == tk_name(TK.KwFor):
-    return parse_for_stmt(ps)
+    return parse_for_stmt(pc, ps)
   if tk_name(k) == tk_name(TK.KwReturn):
-    return parse_return_stmt(ps)
+    return parse_return_stmt(pc, ps)
   if tk_name(k) == tk_name(TK.KwBreak):
     let tidx: i64 = ps.pos
-    let ps2: PS = ps_advance(ps)
-    let ps3: PS = match_tok(ps2, TK.Newline)
+    let ps2: PS = ps_advance(pc, ps)
+    let ps3: PS = match_tok(pc, ps2, TK.Newline)
     return ps_add_node(ps3, Node.BreakS(tidx))
   if tk_name(k) == tk_name(TK.KwMatch):
-    return parse_match_stmt(ps)
+    return parse_match_stmt(pc, ps)
 
   // Expression or assignment
-  let expr: PR = parse_expr(ps)
+  let expr: PR = parse_expr(pc, ps)
   if expr.node < 0:
     return expr
 
   // Check for assignment: expr = value
-  if tk_name(peek_kind(expr.ps)) == tk_name(TK.Eq):
-    let ps2: PS = ps_advance(expr.ps)
-    let val: PR = parse_expr(ps2)
+  if tk_name(peek_kind(pc, expr.ps)) == tk_name(TK.Eq):
+    let ps2: PS = ps_advance(pc, expr.ps)
+    let val: PR = parse_expr(pc, ps2)
     if val.node < 0:
       return val
-    let ps3: PS = match_tok(val.ps, TK.Newline)
+    let ps3: PS = match_tok(pc, val.ps, TK.Newline)
     return ps_add_node(ps3, Node.AssignS(expr.node, val.node))
 
   // Expression statement
-  let ps2: PS = match_tok(expr.ps, TK.Newline)
+  let ps2: PS = match_tok(pc, expr.ps, TK.Newline)
   return ps_add_node(ps2, Node.ExprStmtS(expr.node))
 
-fn parse_let_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_let_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
 
   let type_node: i64 = to_i64(-1)
   let init_node: i64 = to_i64(-1)
 
   // Check for : Type
-  if tk_name(peek_kind(ps3)) == tk_name(TK.Colon):
-    let ps4: PS = ps_advance(ps3)
-    let ty: PR = parse_type(ps4)
+  if tk_name(peek_kind(pc, ps3)) == tk_name(TK.Colon):
+    let ps4: PS = ps_advance(pc, ps3)
+    let ty: PR = parse_type(pc, ps4)
     if ty.node >= 0:
       type_node = ty.node
       ps3 = ty.ps
     else:
       ps3 = ty.ps
     // Check for = init after type
-    if tk_name(peek_kind(ps3)) == tk_name(TK.Eq):
-      let ps5: PS = ps_advance(ps3)
-      let init: PR = parse_expr(ps5)
+    if tk_name(peek_kind(pc, ps3)) == tk_name(TK.Eq):
+      let ps5: PS = ps_advance(pc, ps3)
+      let init: PR = parse_expr(pc, ps5)
       if init.node >= 0:
         init_node = init.node
         ps3 = init.ps
       else:
         ps3 = init.ps
   else:
-    if tk_name(peek_kind(ps3)) == tk_name(TK.Eq):
-      let ps4: PS = ps_advance(ps3)
-      let init: PR = parse_expr(ps4)
+    if tk_name(peek_kind(pc, ps3)) == tk_name(TK.Eq):
+      let ps4: PS = ps_advance(pc, ps3)
+      let init: PR = parse_expr(pc, ps4)
       if init.node >= 0:
         init_node = init.node
         ps3 = init.ps
       else:
         ps3 = init.ps
     else:
-      let sp: Span = tok_span(ps3)
+      let sp: Span = tok_span(pc, ps3)
       ps3 = ps_add_diag(ps3, sp, "expected ':' or '=' after let binding name")
 
-  let ps4: PS = match_tok(ps3, TK.Newline)
+  let ps4: PS = match_tok(pc, ps3, TK.Newline)
   return ps_add_node(ps4, Node.LetS(name_tidx, type_node, init_node))
 
-fn parse_if_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
-  let cond: PR = parse_expr(ps2)
+fn parse_if_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  let cond: PR = parse_expr(pc, ps2)
   if cond.node < 0:
-    let psr: PS = sync_to_stmt(cond.ps)
+    let psr: PS = sync_to_stmt(pc, cond.ps)
     return ps_add_node(psr, Node.ErrorS(ps.pos))
-  let ps3: PS = expect(cond.ps, TK.Colon)
-  let then_suite: PR = parse_suite(ps3)
+  let ps3: PS = expect(pc, cond.ps, TK.Colon)
+  let then_suite: PR = parse_suite(pc, ps3)
   let then_list_pos: i64 = then_suite.node
   let cur: PS = then_suite.ps
 
   let else_list_pos: i64 = to_i64(-1)
-  if tk_name(peek_kind(cur)) == tk_name(TK.KwElse):
-    cur = ps_advance(cur)
-    if tk_name(peek_kind(cur)) == tk_name(TK.KwIf):
+  if tk_name(peek_kind(pc, cur)) == tk_name(TK.KwElse):
+    cur = ps_advance(pc, cur)
+    if tk_name(peek_kind(pc, cur)) == tk_name(TK.KwIf):
       // else if — parse as a single-element body containing an if stmt
-      let nested_if: PR = parse_if_stmt(cur)
+      let nested_if: PR = parse_if_stmt(pc, cur)
       if nested_if.node >= 0:
         let else_items: Vector<i64> = Vector<i64>::new()
         else_items = else_items.push(nested_if.node)
@@ -1569,57 +1579,57 @@ fn parse_if_stmt(ps: PS): PR
       else:
         cur = nested_if.ps
     else:
-      let ps4: PS = expect(cur, TK.Colon)
-      let else_suite: PR = parse_suite(ps4)
+      let ps4: PS = expect(pc, cur, TK.Colon)
+      let else_suite: PR = parse_suite(pc, ps4)
       else_list_pos = else_suite.node
       cur = else_suite.ps
 
   return ps_add_node(cur, Node.IfS(cond.node, then_list_pos, else_list_pos))
 
-fn parse_while_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
-  let cond: PR = parse_expr(ps2)
+fn parse_while_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  let cond: PR = parse_expr(pc, ps2)
   if cond.node < 0:
-    let psr: PS = sync_to_stmt(cond.ps)
+    let psr: PS = sync_to_stmt(pc, cond.ps)
     return ps_add_node(psr, Node.ErrorS(ps.pos))
-  let ps3: PS = expect(cond.ps, TK.Colon)
-  let body: PR = parse_suite(ps3)
+  let ps3: PS = expect(pc, cond.ps, TK.Colon)
+  let body: PR = parse_suite(pc, ps3)
   return ps_add_node(body.ps, Node.WhileS(cond.node, body.node))
 
-fn parse_for_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_for_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let var_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
-  let ps4: PS = expect(ps3, TK.KwIn)
-  let iter: PR = parse_expr(ps4)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
+  let ps4: PS = expect(pc, ps3, TK.KwIn)
+  let iter: PR = parse_expr(pc, ps4)
   if iter.node < 0:
-    let psr: PS = sync_to_stmt(iter.ps)
+    let psr: PS = sync_to_stmt(pc, iter.ps)
     return ps_add_node(psr, Node.ErrorS(ps.pos))
-  let ps5: PS = expect(iter.ps, TK.Colon)
-  let body: PR = parse_suite(ps5)
+  let ps5: PS = expect(pc, iter.ps, TK.Colon)
+  let body: PR = parse_suite(pc, ps5)
   return ps_add_node(body.ps, Node.ForS(var_tidx, iter.node, body.node))
 
-fn parse_return_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
-  let k: TK = peek_kind(ps2)
-  if tk_name(k) == tk_name(TK.Newline) or tk_name(k) == tk_name(TK.Dedent) or at_end(ps2):
-    let ps3: PS = match_tok(ps2, TK.Newline)
+fn parse_return_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  let k: TK = peek_kind(pc, ps2)
+  if tk_name(k) == tk_name(TK.Newline) or tk_name(k) == tk_name(TK.Dedent) or at_end(pc, ps2):
+    let ps3: PS = match_tok(pc, ps2, TK.Newline)
     return ps_add_node(ps3, Node.ReturnS(to_i64(-1)))
-  let val: PR = parse_expr(ps2)
+  let val: PR = parse_expr(pc, ps2)
   if val.node < 0:
     return val
-  let ps3: PS = match_tok(val.ps, TK.Newline)
+  let ps3: PS = match_tok(pc, val.ps, TK.Newline)
   return ps_add_node(ps3, Node.ReturnS(val.node))
 
-fn parse_match_stmt(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
-  let scrut: PR = parse_expr(ps2)
+fn parse_match_stmt(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  let scrut: PR = parse_expr(pc, ps2)
   if scrut.node < 0:
-    let psr: PS = sync_to_stmt(scrut.ps)
+    let psr: PS = sync_to_stmt(pc, scrut.ps)
     return ps_add_node(psr, Node.ErrorS(ps.pos))
-  let ps3: PS = expect(scrut.ps, TK.Colon)
-  let ps4: PS = expect(ps3, TK.Newline)
-  let ps5: PS = expect(ps4, TK.Indent)
+  let ps3: PS = expect(pc, scrut.ps, TK.Colon)
+  let ps4: PS = expect(pc, ps3, TK.Newline)
+  let ps5: PS = expect(pc, ps4, TK.Indent)
 
   // Arms: collect [pattern, body_list_pos] pairs, then flush
   let arm_pairs: Vector<i64> = Vector<i64>::new()
@@ -1627,107 +1637,107 @@ fn parse_match_stmt(ps: PS): PR
   let cur: PS = ps5
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
       // Parse pattern (as expression)
-      let pat: PR = parse_expr(cur)
+      let pat: PR = parse_expr(pc, cur)
       if pat.node < 0:
-        cur = sync_to_stmt(pat.ps)
+        cur = sync_to_stmt(pc, pat.ps)
       else:
-        cur = expect(pat.ps, TK.Colon)
-        let arm_body: PR = parse_suite(cur)
+        cur = expect(pc, pat.ps, TK.Colon)
+        let arm_body: PR = parse_suite(pc, cur)
         arm_pairs = arm_pairs.push(pat.node)
         arm_pairs = arm_pairs.push(arm_body.node)
         cur = arm_body.ps
         arm_count = arm_count + 1
 
   let arms_fl: FlushResult = flush_pairs(cur, arm_pairs, arm_count)
-  cur = expect(arms_fl.ps, TK.Dedent)
+  cur = expect(pc, arms_fl.ps, TK.Dedent)
   return ps_add_node(cur, Node.MatchS(scrut.node, arms_fl.list_pos))
 
 // =========================================================================
 // Section 13: Declaration parsing
 // =========================================================================
 
-fn parse_declaration(ps: PS): PR
-  let k: TK = peek_kind(ps)
+fn parse_declaration(pc: PC, ps: PS): PR
+  let k: TK = peek_kind(pc, ps)
 
   if tk_name(k) == tk_name(TK.KwExtern):
-    return parse_extern_fn(ps)
+    return parse_extern_fn(pc, ps)
   if tk_name(k) == tk_name(TK.KwFn):
-    return parse_fn_decl(ps)
+    return parse_fn_decl(pc, ps)
   if tk_name(k) == tk_name(TK.KwClass):
-    return parse_class_decl(ps)
+    return parse_class_decl(pc, ps)
   if tk_name(k) == tk_name(TK.KwEnum):
-    return parse_enum_decl(ps)
+    return parse_enum_decl(pc, ps)
   if tk_name(k) == tk_name(TK.KwType):
-    return parse_type_alias(ps)
+    return parse_type_alias(pc, ps)
   if tk_name(k) == tk_name(TK.KwConcept):
-    return parse_concept_decl(ps)
+    return parse_concept_decl(pc, ps)
   if tk_name(k) == tk_name(TK.KwExtend):
-    return parse_extend_decl(ps)
+    return parse_extend_decl(pc, ps)
 
-  let sp: Span = tok_span(ps)
+  let sp: Span = tok_span(pc, ps)
   let ps2: PS = ps_add_diag(ps, sp, "expected declaration (fn, extern, class, enum, type, concept, or extend)")
-  return ps_add_node(ps_advance(ps2), Node.ErrorD(ps.pos))
+  return ps_add_node(ps_advance(pc, ps2), Node.ErrorD(ps.pos))
 
 // Parse optional type parameters: <T, U, V> — returns PR where .node = list_pos
 // Returns -1 if no type params are present.
-fn parse_type_params(ps: PS): PR
-  if tk_name(peek_kind(ps)) != tk_name(TK.Lt):
+fn parse_type_params(pc: PC, ps: PS): PR
+  if tk_name(peek_kind(pc, ps)) != tk_name(TK.Lt):
     return PR(ps, to_i64(-1))
-  let ps2: PS = ps_advance(ps)
+  let ps2: PS = ps_advance(pc, ps)
   let collected: Vector<i64> = Vector<i64>::new()
   // Parse first type param (must be an identifier)
-  if tk_name(peek_kind(ps2)) == tk_name(TK.Identifier):
+  if tk_name(peek_kind(pc, ps2)) == tk_name(TK.Identifier):
     let tidx: i64 = ps2.pos
-    let ps3: PS = ps_advance(ps2)
+    let ps3: PS = ps_advance(pc, ps2)
     let gp: PR = ps_add_node(ps3, Node.GenericParamT(tidx))
     collected = collected.push(gp.node)
     let cur: PS = gp.ps
     let done: bool = false
     while done == false:
-      if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-        cur = ps_advance(cur)
+      if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+        cur = ps_advance(pc, cur)
         let tidx2: i64 = cur.pos
-        cur = expect(cur, TK.Identifier)
+        cur = expect(pc, cur, TK.Identifier)
         let gp2: PR = ps_add_node(cur, Node.GenericParamT(tidx2))
         collected = collected.push(gp2.node)
         cur = gp2.ps
       else:
         done = true
     let fl: FlushResult = flush_list(cur, collected)
-    let ps_end: PS = expect(fl.ps, TK.Gt)
+    let ps_end: PS = expect(pc, fl.ps, TK.Gt)
     return PR(ps_end, fl.list_pos)
   else:
-    let sp: Span = tok_span(ps2)
+    let sp: Span = tok_span(pc, ps2)
     let pse: PS = ps_add_diag(ps2, sp, "expected type parameter name")
-    let pse2: PS = expect(pse, TK.Gt)
+    let pse2: PS = expect(pc, pse, TK.Gt)
     return PR(pse2, to_i64(-1))
 
 // Parse (name: Type, name: Type, ...) — returns PR where .node = list_pos
 // Pushes pairs [name_tok, type_node, ...], then count
-fn parse_params_list(ps: PS): PR
-  let ps2: PS = expect(ps, TK.LParen)
+fn parse_params_list(pc: PC, ps: PS): PR
+  let ps2: PS = expect(pc, ps, TK.LParen)
   let param_pairs: Vector<i64> = Vector<i64>::new()
   let count: i64 = 0
   let cur: PS = ps2
 
-  if tk_name(peek_kind(cur)) != tk_name(TK.RParen):
+  if tk_name(peek_kind(pc, cur)) != tk_name(TK.RParen):
     // Parse first param — accept KwSelf as a parameter name (self param)
     let name_tidx: i64 = cur.pos
-    if tk_name(peek_kind(cur)) == tk_name(TK.KwSelf):
-      cur = ps_advance(cur)
+    if tk_name(peek_kind(pc, cur)) == tk_name(TK.KwSelf):
+      cur = ps_advance(pc, cur)
       param_pairs = param_pairs.push(name_tidx)
       param_pairs = param_pairs.push(to_i64(-1))
       count = count + 1
     else:
-      cur = expect(cur, TK.Identifier)
-      cur = expect(cur, TK.Colon)
-      let ty: PR = parse_type(cur)
+      cur = expect(pc, cur, TK.Identifier)
+      cur = expect(pc, cur, TK.Colon)
+      let ty: PR = parse_type(pc, cur)
       cur = ty.ps
       param_pairs = param_pairs.push(name_tidx)
       if ty.node >= 0:
@@ -1738,21 +1748,21 @@ fn parse_params_list(ps: PS): PR
 
     let done: bool = false
     while done == false:
-      if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-        cur = ps_advance(cur)
+      if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+        cur = ps_advance(pc, cur)
         let name_tidx2: i64 = cur.pos
         // self is only valid as the first parameter — reject here
-        if tk_name(peek_kind(cur)) == tk_name(TK.KwSelf):
-          let sp: Span = tok_span(cur)
+        if tk_name(peek_kind(pc, cur)) == tk_name(TK.KwSelf):
+          let sp: Span = tok_span(pc, cur)
           cur = ps_add_diag(cur, sp, "self must be the first parameter")
-          cur = ps_advance(cur)
+          cur = ps_advance(pc, cur)
           param_pairs = param_pairs.push(name_tidx2)
           param_pairs = param_pairs.push(to_i64(-1))
           count = count + 1
         else:
-          cur = expect(cur, TK.Identifier)
-          cur = expect(cur, TK.Colon)
-          let ty2: PR = parse_type(cur)
+          cur = expect(pc, cur, TK.Identifier)
+          cur = expect(pc, cur, TK.Colon)
+          let ty2: PR = parse_type(pc, cur)
           cur = ty2.ps
           param_pairs = param_pairs.push(name_tidx2)
           if ty2.node >= 0:
@@ -1764,117 +1774,117 @@ fn parse_params_list(ps: PS): PR
         done = true
 
   let fl: FlushResult = flush_pairs(cur, param_pairs, count)
-  cur = expect(fl.ps, TK.RParen)
+  cur = expect(pc, fl.ps, TK.RParen)
   return PR(cur, fl.list_pos)
 
-fn parse_fn_decl(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_fn_decl(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
 
   // Parse optional type parameters
-  let tparams: PR = parse_type_params(ps3)
+  let tparams: PR = parse_type_params(pc, ps3)
   let tparams_lp: i64 = tparams.node
 
-  let params: PR = parse_params_list(tparams.ps)
+  let params: PR = parse_params_list(pc, tparams.ps)
   let params_lp: i64 = params.node
   let cur: PS = params.ps
 
   // Optional return type
   let ret_type: i64 = to_i64(-1)
-  if tk_name(peek_kind(cur)) == tk_name(TK.Colon):
-    cur = ps_advance(cur)
-    let ty: PR = parse_type(cur)
+  if tk_name(peek_kind(pc, cur)) == tk_name(TK.Colon):
+    cur = ps_advance(pc, cur)
+    let ty: PR = parse_type(pc, cur)
     if ty.node >= 0:
       ret_type = ty.node
     cur = ty.ps
 
   // Expression-bodied: -> expr NEWLINE
-  if tk_name(peek_kind(cur)) == tk_name(TK.Arrow):
-    cur = ps_advance(cur)
-    let body_expr: PR = parse_expr(cur)
+  if tk_name(peek_kind(pc, cur)) == tk_name(TK.Arrow):
+    cur = ps_advance(pc, cur)
+    let body_expr: PR = parse_expr(pc, cur)
     if body_expr.node < 0:
       return body_expr
-    let psfn: PS = match_tok(body_expr.ps, TK.Newline)
+    let psfn: PS = match_tok(pc, body_expr.ps, TK.Newline)
     return ps_add_node(psfn, Node.ExprFnD(name_tidx, tparams_lp, params_lp, ret_type, body_expr.node))
 
   // Block-bodied: NEWLINE INDENT stmts DEDENT
-  let ps4: PS = expect(cur, TK.Newline)
-  if tk_name(peek_kind(ps4)) == tk_name(TK.Indent):
-    let ps5: PS = ps_advance(ps4)
+  let ps4: PS = expect(pc, cur, TK.Newline)
+  if tk_name(peek_kind(pc, ps4)) == tk_name(TK.Indent):
+    let ps5: PS = ps_advance(pc, ps4)
     // Parse statement list inline — collect then flush
     let body_items: Vector<i64> = Vector<i64>::new()
     let bcur: PS = ps5
     let bdone: bool = false
     while bdone == false:
-      bcur = skip_newlines(bcur)
-      let bk: TK = peek_kind(bcur)
-      if tk_name(bk) == tk_name(TK.Dedent) or at_end(bcur):
+      bcur = skip_newlines(pc, bcur)
+      let bk: TK = peek_kind(pc, bcur)
+      if tk_name(bk) == tk_name(TK.Dedent) or at_end(pc, bcur):
         bdone = true
       else:
-        let stmt: PR = parse_statement(bcur)
+        let stmt: PR = parse_statement(pc, bcur)
         if stmt.node >= 0:
           body_items = body_items.push(stmt.node)
           bcur = stmt.ps
         else:
-          bcur = sync_to_stmt(stmt.ps)
+          bcur = sync_to_stmt(pc, stmt.ps)
           let err_r: PR = ps_add_node(bcur, Node.ErrorS(bcur.pos))
           body_items = body_items.push(err_r.node)
           bcur = err_r.ps
     let body_fl: FlushResult = flush_list(bcur, body_items)
-    bcur = expect(body_fl.ps, TK.Dedent)
+    bcur = expect(pc, body_fl.ps, TK.Dedent)
     return ps_add_node(bcur, Node.FnDeclD(name_tidx, tparams_lp, params_lp, ret_type, body_fl.list_pos))
   else:
     // No body — error
-    let sp: Span = tok_span(ps4)
+    let sp: Span = tok_span(pc, ps4)
     let pse: PS = ps_add_diag(ps4, sp, "expected function body (indented block or -> expression)")
     return ps_add_node(pse, Node.ErrorD(name_tidx))
 
-fn parse_extern_fn(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
-  if tk_name(peek_kind(ps2)) != tk_name(TK.KwFn):
-    let sp: Span = tok_span(ps2)
+fn parse_extern_fn(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  if tk_name(peek_kind(pc, ps2)) != tk_name(TK.KwFn):
+    let sp: Span = tok_span(pc, ps2)
     let pse: PS = ps_add_diag(ps2, sp, "expected 'fn' after 'extern'")
     return ps_add_node(pse, Node.ErrorD(ps.pos))
-  let ps3: PS = ps_advance(ps2)
+  let ps3: PS = ps_advance(pc, ps2)
   let name_tidx: i64 = ps3.pos
-  let ps4: PS = expect(ps3, TK.Identifier)
+  let ps4: PS = expect(pc, ps3, TK.Identifier)
 
   // Parse optional type parameters
-  let tparams: PR = parse_type_params(ps4)
+  let tparams: PR = parse_type_params(pc, ps4)
   let tparams_lp: i64 = tparams.node
 
-  let params: PR = parse_params_list(tparams.ps)
+  let params: PR = parse_params_list(pc, tparams.ps)
   let params_lp: i64 = params.node
   let cur: PS = params.ps
 
   // Return type is required for extern fn (CONTRACT_SYNTAX_SURFACE.md §extern).
   let ret_type: i64 = to_i64(-1)
-  if tk_name(peek_kind(cur)) == tk_name(TK.Colon):
-    cur = ps_advance(cur)
-    let ty: PR = parse_type(cur)
+  if tk_name(peek_kind(pc, cur)) == tk_name(TK.Colon):
+    cur = ps_advance(pc, cur)
+    let ty: PR = parse_type(pc, cur)
     if ty.node >= 0:
       ret_type = ty.node
     cur = ty.ps
   else:
-    let sp: Span = tok_span(cur)
+    let sp: Span = tok_span(pc, cur)
     cur = ps_add_diag(cur, sp, "extern fn requires a return type annotation")
 
-  cur = match_tok(cur, TK.Newline)
+  cur = match_tok(pc, cur, TK.Newline)
   return ps_add_node(cur, Node.ExternFnD(name_tidx, tparams_lp, params_lp, ret_type))
 
-fn parse_class_decl(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_class_decl(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
 
   // Parse optional type parameters
-  let tparams: PR = parse_type_params(ps3)
+  let tparams: PR = parse_type_params(pc, ps3)
   let tparams_lp: i64 = tparams.node
 
-  let ps4: PS = expect(tparams.ps, TK.Colon)
-  let ps5: PS = expect(ps4, TK.Newline)
-  let ps6: PS = expect(ps5, TK.Indent)
+  let ps4: PS = expect(pc, tparams.ps, TK.Colon)
+  let ps5: PS = expect(pc, ps4, TK.Newline)
+  let ps6: PS = expect(pc, ps5, TK.Indent)
 
   // Parse fields: collect [name_tok, type_node] pairs, then flush.
   let field_pairs: Vector<i64> = Vector<i64>::new()
@@ -1882,18 +1892,18 @@ fn parse_class_decl(ps: PS): PR
   let cur: PS = ps6
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
       if tk_name(k) == tk_name(TK.KwFn):
         done = true
       else:
         let fname_tidx: i64 = cur.pos
-        cur = expect(cur, TK.Identifier)
-        cur = expect(cur, TK.Colon)
-        let fty: PR = parse_type(cur)
+        cur = expect(pc, cur, TK.Identifier)
+        cur = expect(pc, cur, TK.Colon)
+        let fty: PR = parse_type(pc, cur)
         cur = fty.ps
         field_pairs = field_pairs.push(fname_tidx)
         if fty.node >= 0:
@@ -1901,11 +1911,11 @@ fn parse_class_decl(ps: PS): PR
         else:
           field_pairs = field_pairs.push(to_i64(-1))
         field_count = field_count + 1
-        cur = match_tok(cur, TK.Newline)
+        cur = match_tok(pc, cur, TK.Newline)
 
   // Diagnose empty class body (contract: must have at least one field).
   if field_count == 0:
-    let sp: Span = tok_span(cur)
+    let sp: Span = tok_span(pc, cur)
     cur = ps_add_diag(cur, sp, "class body must contain at least one field")
 
   let fields_fl: FlushResult = flush_pairs(cur, field_pairs, field_count)
@@ -1915,10 +1925,10 @@ fn parse_class_decl(ps: PS): PR
   let method_items: Vector<i64> = Vector<i64>::new()
   let mdone: bool = false
   while mdone == false:
-    cur = skip_newlines(cur)
-    let mk: TK = peek_kind(cur)
+    cur = skip_newlines(pc, cur)
+    let mk: TK = peek_kind(pc, cur)
     if tk_name(mk) == tk_name(TK.KwFn):
-      let meth: PR = parse_fn_decl(cur)
+      let meth: PR = parse_fn_decl(pc, cur)
       if meth.node >= 0:
         method_items = method_items.push(meth.node)
       cur = meth.ps
@@ -1931,21 +1941,24 @@ fn parse_class_decl(ps: PS): PR
     cur = mfl.ps
     methods_lp = mfl.list_pos
 
-  cur = expect(cur, TK.Dedent)
+  cur = expect(pc, cur, TK.Dedent)
   return ps_add_node(cur, Node.ClassDeclD(name_tidx, tparams_lp, fields_fl.list_pos, methods_lp))
 
-fn parse_enum_decl(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_enum_decl(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
+  // Skip 'class' keyword for 'enum class' declarations.
+  if tk_name(peek_kind(pc, ps2)) == tk_name(TK.KwClass):
+    ps2 = ps_advance(pc, ps2)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
 
   // Parse optional type parameters
-  let tparams: PR = parse_type_params(ps3)
+  let tparams: PR = parse_type_params(pc, ps3)
   let tparams_lp: i64 = tparams.node
 
-  let ps4: PS = expect(tparams.ps, TK.Colon)
-  let ps5: PS = expect(ps4, TK.Newline)
-  let ps6: PS = expect(ps5, TK.Indent)
+  let ps4: PS = expect(pc, tparams.ps, TK.Colon)
+  let ps5: PS = expect(pc, ps4, TK.Newline)
+  let ps6: PS = expect(pc, ps5, TK.Indent)
 
   // Variants: push [name_tok, payload_list_pos] pairs, then count
   // Each variant has a name_tok and a payload_list_pos.
@@ -1955,20 +1968,29 @@ fn parse_enum_decl(ps: PS): PR
   let cur: PS = ps6
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
       let vname_tidx: i64 = cur.pos
-      cur = expect(cur, TK.Identifier)
+      cur = expect(pc, cur, TK.Identifier)
 
-      // Parse optional payload: (Type, Type, ...) — collect then flush
+      // Parse optional payload: (Type, ...) or (name: Type, ...)
+      // For enum class, fields are name: Type. Skip the name and colon.
       let payload_types: Vector<i64> = Vector<i64>::new()
-      if tk_name(peek_kind(cur)) == tk_name(TK.LParen):
-        cur = ps_advance(cur)
-        if tk_name(peek_kind(cur)) != tk_name(TK.RParen):
-          let pty: PR = parse_type(cur)
+      if tk_name(peek_kind(pc, cur)) == tk_name(TK.LParen):
+        cur = ps_advance(pc, cur)
+        if tk_name(peek_kind(pc, cur)) != tk_name(TK.RParen):
+          // Skip field name and colon if present (enum class syntax)
+          if tk_name(peek_kind(pc, cur)) == tk_name(TK.Identifier):
+            let la: i64 = cur.pos + 1
+            if la < pc.toks.length():
+              let la_tok: Token = pc.toks.get(la)
+              if tk_name(la_tok.kind) == tk_name(TK.Colon):
+                cur = ps_advance(pc, cur)
+                cur = ps_advance(pc, cur)
+          let pty: PR = parse_type(pc, cur)
           if pty.node >= 0:
             payload_types = payload_types.push(pty.node)
             cur = pty.ps
@@ -1976,9 +1998,17 @@ fn parse_enum_decl(ps: PS): PR
             cur = pty.ps
           let pdone: bool = false
           while pdone == false:
-            if tk_name(peek_kind(cur)) == tk_name(TK.Comma):
-              cur = ps_advance(cur)
-              let pty2: PR = parse_type(cur)
+            if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
+              cur = ps_advance(pc, cur)
+              // Skip field name and colon if present
+              if tk_name(peek_kind(pc, cur)) == tk_name(TK.Identifier):
+                let la2: i64 = cur.pos + 1
+                if la2 < pc.toks.length():
+                  let la2_tok: Token = pc.toks.get(la2)
+                  if tk_name(la2_tok.kind) == tk_name(TK.Colon):
+                    cur = ps_advance(pc, cur)
+                    cur = ps_advance(pc, cur)
+              let pty2: PR = parse_type(pc, cur)
               if pty2.node >= 0:
                 payload_types = payload_types.push(pty2.node)
                 cur = pty2.ps
@@ -1987,7 +2017,7 @@ fn parse_enum_decl(ps: PS): PR
                 pdone = true
             else:
               pdone = true
-        cur = expect(cur, TK.RParen)
+        cur = expect(pc, cur, TK.RParen)
 
       // Flush payload list
       let payload_fl: FlushResult = flush_list(cur, payload_types)
@@ -1997,71 +2027,71 @@ fn parse_enum_decl(ps: PS): PR
       variant_pairs = variant_pairs.push(vname_tidx)
       variant_pairs = variant_pairs.push(payload_fl.list_pos)
       variant_count = variant_count + 1
-      cur = match_tok(cur, TK.Newline)
+      cur = match_tok(pc, cur, TK.Newline)
 
   // Flush variant pairs
   let variants_fl: FlushResult = flush_pairs(cur, variant_pairs, variant_count)
-  cur = expect(variants_fl.ps, TK.Dedent)
+  cur = expect(pc, variants_fl.ps, TK.Dedent)
   return ps_add_node(cur, Node.EnumDeclD(name_tidx, tparams_lp, variants_fl.list_pos))
 
-fn parse_type_alias(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_type_alias(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
-  let ps4: PS = expect(ps3, TK.Eq)
-  let ty: PR = parse_type(ps4)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
+  let ps4: PS = expect(pc, ps3, TK.Eq)
+  let ty: PR = parse_type(pc, ps4)
   if ty.node < 0:
     return ty
-  let cur: PS = match_tok(ty.ps, TK.Newline)
+  let cur: PS = match_tok(pc, ty.ps, TK.Newline)
   return ps_add_node(cur, Node.TypeAliasD(name_tidx, ty.node))
 
-fn parse_concept_decl(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_concept_decl(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
   let name_tidx: i64 = ps2.pos
-  let ps3: PS = expect(ps2, TK.Identifier)
+  let ps3: PS = expect(pc, ps2, TK.Identifier)
 
   // Parse optional type parameters
-  let tparams: PR = parse_type_params(ps3)
+  let tparams: PR = parse_type_params(pc, ps3)
   let tparams_lp: i64 = tparams.node
 
-  let ps4: PS = expect(tparams.ps, TK.Colon)
-  let ps5: PS = expect(ps4, TK.Newline)
-  let ps6: PS = expect(ps5, TK.Indent)
+  let ps4: PS = expect(pc, tparams.ps, TK.Colon)
+  let ps5: PS = expect(pc, ps4, TK.Newline)
+  let ps6: PS = expect(pc, ps5, TK.Indent)
 
   // Parse method signatures (fn without body)
   let method_items: Vector<i64> = Vector<i64>::new()
   let cur: PS = ps6
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
       if tk_name(k) == tk_name(TK.KwFn):
         // Parse signature only: fn name(params): RetType NEWLINE (no body)
-        let ps_fn: PS = ps_advance(cur)
+        let ps_fn: PS = ps_advance(pc, cur)
         let sig_name_tidx: i64 = ps_fn.pos
-        let ps_fn2: PS = expect(ps_fn, TK.Identifier)
-        let sig_tparams: PR = parse_type_params(ps_fn2)
-        let sig_params: PR = parse_params_list(sig_tparams.ps)
+        let ps_fn2: PS = expect(pc, ps_fn, TK.Identifier)
+        let sig_tparams: PR = parse_type_params(pc, ps_fn2)
+        let sig_params: PR = parse_params_list(pc, sig_tparams.ps)
         let sig_cur: PS = sig_params.ps
         let sig_ret_type: i64 = to_i64(-1)
-        if tk_name(peek_kind(sig_cur)) == tk_name(TK.Colon):
-          sig_cur = ps_advance(sig_cur)
-          let sig_ty: PR = parse_type(sig_cur)
+        if tk_name(peek_kind(pc, sig_cur)) == tk_name(TK.Colon):
+          sig_cur = ps_advance(pc, sig_cur)
+          let sig_ty: PR = parse_type(pc, sig_cur)
           if sig_ty.node >= 0:
             sig_ret_type = sig_ty.node
           sig_cur = sig_ty.ps
-        sig_cur = match_tok(sig_cur, TK.Newline)
+        sig_cur = match_tok(pc, sig_cur, TK.Newline)
         let sig_r: PR = ps_add_node(sig_cur, Node.ExternFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type))
         method_items = method_items.push(sig_r.node)
         cur = sig_r.ps
       else:
         // Skip unexpected token
-        let sp: Span = tok_span(cur)
+        let sp: Span = tok_span(pc, cur)
         cur = ps_add_diag(cur, sp, "expected method signature in concept body")
-        cur = ps_advance(cur)
+        cur = ps_advance(pc, cur)
 
   let methods_lp: i64 = to_i64(-1)
   if method_items.length() > 0:
@@ -2069,46 +2099,46 @@ fn parse_concept_decl(ps: PS): PR
     cur = mfl.ps
     methods_lp = mfl.list_pos
 
-  cur = expect(cur, TK.Dedent)
+  cur = expect(pc, cur, TK.Dedent)
   return ps_add_node(cur, Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp))
 
-fn parse_extend_decl(ps: PS): PR
-  let ps2: PS = ps_advance(ps)
+fn parse_extend_decl(pc: PC, ps: PS): PR
+  let ps2: PS = ps_advance(pc, ps)
 
   // Parse target type
-  let target_ty: PR = parse_type(ps2)
+  let target_ty: PR = parse_type(pc, ps2)
   let target_type_node: i64 = target_ty.node
   let cur: PS = target_ty.ps
 
   // Consume 'as'
-  cur = expect(cur, TK.KwAs)
+  cur = expect(pc, cur, TK.KwAs)
 
   // Parse concept name (identifier token)
   let concept_name_tidx: i64 = cur.pos
-  cur = expect(cur, TK.Identifier)
+  cur = expect(pc, cur, TK.Identifier)
 
-  cur = expect(cur, TK.Colon)
-  cur = expect(cur, TK.Newline)
-  cur = expect(cur, TK.Indent)
+  cur = expect(pc, cur, TK.Colon)
+  cur = expect(pc, cur, TK.Newline)
+  cur = expect(pc, cur, TK.Indent)
 
   // Parse method definitions (full fn with body)
   let method_items: Vector<i64> = Vector<i64>::new()
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    let k: TK = peek_kind(cur)
-    if tk_name(k) == tk_name(TK.Dedent) or at_end(cur):
+    cur = skip_newlines(pc, cur)
+    let k: TK = peek_kind(pc, cur)
+    if tk_name(k) == tk_name(TK.Dedent) or at_end(pc, cur):
       done = true
     else:
       if tk_name(k) == tk_name(TK.KwFn):
-        let meth: PR = parse_fn_decl(cur)
+        let meth: PR = parse_fn_decl(pc, cur)
         if meth.node >= 0:
           method_items = method_items.push(meth.node)
         cur = meth.ps
       else:
-        let sp: Span = tok_span(cur)
+        let sp: Span = tok_span(pc, cur)
         cur = ps_add_diag(cur, sp, "expected method definition in extend body")
-        cur = ps_advance(cur)
+        cur = ps_advance(pc, cur)
 
   let methods_lp: i64 = to_i64(-1)
   if method_items.length() > 0:
@@ -2116,32 +2146,32 @@ fn parse_extend_decl(ps: PS): PR
     cur = mfl.ps
     methods_lp = mfl.list_pos
 
-  cur = expect(cur, TK.Dedent)
+  cur = expect(pc, cur, TK.Dedent)
   return ps_add_node(cur, Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp))
 
 // =========================================================================
 // Section 14: File-level parsing
 // =========================================================================
 
-fn parse_file(ps: PS): PR
-  let cur: PS = skip_newlines(ps)
+fn parse_file(pc: PC, ps: PS): PR
+  let cur: PS = skip_newlines(pc, ps)
   let decl_items: Vector<i64> = Vector<i64>::new()
   let done: bool = false
   while done == false:
-    cur = skip_newlines(cur)
-    if at_end(cur):
+    cur = skip_newlines(pc, cur)
+    if at_end(pc, cur):
       done = true
     else:
-      let decl: PR = parse_declaration(cur)
+      let decl: PR = parse_declaration(pc, cur)
       if decl.node >= 0:
         decl_items = decl_items.push(decl.node)
         cur = decl.ps
       else:
-        cur = sync_to_decl(decl.ps)
+        cur = sync_to_decl(pc, decl.ps)
         let err_r: PR = ps_add_node(cur, Node.ErrorD(cur.pos))
         decl_items = decl_items.push(err_r.node)
         cur = err_r.ps
-    cur = skip_newlines(cur)
+    cur = skip_newlines(pc, cur)
 
   let decls_fl: FlushResult = flush_list(cur, decl_items)
   return ps_add_node(decls_fl.ps, Node.FileN(decls_fl.list_pos))
@@ -2150,10 +2180,12 @@ fn parse_file(ps: PS): PR
 // Section 15: Public API
 // =========================================================================
 
-fn parse(src: string): PR
+fn parse(src: string): ParseOutput
   let lr: LexResult = lex(src)
-  let ps: PS = PS(lr.tokens, src, to_i64(0), Vector<Node>::new(), Vector<i64>::new(), lr.diagnostics)
-  return parse_file(ps)
+  let pc: PC = PC(lr.tokens, src)
+  let ps: PS = PS(to_i64(0), Vector<Node>::new(), Vector<i64>::new(), lr.diagnostics)
+  let result: PR = parse_file(pc, ps)
+  return ParseOutput(pc.toks, pc.src, result.ps.nodes, result.ps.idx, result.ps.diags, result.node)
 
 // =========================================================================
 // Section 16: Node kind name (for test output)

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -1946,9 +1946,12 @@ fn parse_class_decl(pc: PC, ps: PS): PR
 
 fn parse_enum_decl(pc: PC, ps: PS): PR
   let ps2: PS = ps_advance(pc, ps)
-  // Skip 'class' keyword for 'enum class' declarations.
+  // Track whether this is 'enum class' (named-field variants) or
+  // plain 'enum' (fieldless only, per CONTRACT_SYNTAX_SURFACE.md).
+  let is_enum_class: bool = false
   if tk_name(peek_kind(pc, ps2)) == tk_name(TK.KwClass):
     ps2 = ps_advance(pc, ps2)
+    is_enum_class = true
   let name_tidx: i64 = ps2.pos
   let ps3: PS = expect(pc, ps2, TK.Identifier)
 
@@ -1976,20 +1979,21 @@ fn parse_enum_decl(pc: PC, ps: PS): PR
       let vname_tidx: i64 = cur.pos
       cur = expect(pc, cur, TK.Identifier)
 
-      // Parse optional payload: (Type, ...) or (name: Type, ...)
-      // For enum class, fields are name: Type. Skip the name and colon.
+      // Parse optional payload.
+      // Plain enum: payloads are illegal (CONTRACT_SYNTAX_SURFACE §Enum).
+      // Enum class: fields must be named (CONTRACT_SYNTAX_SURFACE §Enum Class).
       let payload_types: Vector<i64> = Vector<i64>::new()
       if tk_name(peek_kind(pc, cur)) == tk_name(TK.LParen):
+        if is_enum_class == false:
+          // Plain enum with payload — diagnose per contract.
+          let sp: Span = tok_span(pc, cur)
+          cur = ps_add_diag(cur, sp, "enum variants cannot carry payloads; use 'enum class' for structured variants")
         cur = ps_advance(pc, cur)
         if tk_name(peek_kind(pc, cur)) != tk_name(TK.RParen):
-          // Skip field name and colon if present (enum class syntax)
-          if tk_name(peek_kind(pc, cur)) == tk_name(TK.Identifier):
-            let la: i64 = cur.pos + 1
-            if la < pc.toks.length():
-              let la_tok: Token = pc.toks.get(la)
-              if tk_name(la_tok.kind) == tk_name(TK.Colon):
-                cur = ps_advance(pc, cur)
-                cur = ps_advance(pc, cur)
+          if is_enum_class:
+            // Enum class: require name: Type syntax.
+            cur = expect(pc, cur, TK.Identifier)
+            cur = expect(pc, cur, TK.Colon)
           let pty: PR = parse_type(pc, cur)
           if pty.node >= 0:
             payload_types = payload_types.push(pty.node)
@@ -2000,14 +2004,10 @@ fn parse_enum_decl(pc: PC, ps: PS): PR
           while pdone == false:
             if tk_name(peek_kind(pc, cur)) == tk_name(TK.Comma):
               cur = ps_advance(pc, cur)
-              // Skip field name and colon if present
-              if tk_name(peek_kind(pc, cur)) == tk_name(TK.Identifier):
-                let la2: i64 = cur.pos + 1
-                if la2 < pc.toks.length():
-                  let la2_tok: Token = pc.toks.get(la2)
-                  if tk_name(la2_tok.kind) == tk_name(TK.Colon):
-                    cur = ps_advance(pc, cur)
-                    cur = ps_advance(pc, cur)
+              if is_enum_class:
+                // Enum class: require name: Type syntax.
+                cur = expect(pc, cur, TK.Identifier)
+                cur = expect(pc, cur, TK.Colon)
               let pty2: PR = parse_type(pc, cur)
               if pty2.node >= 0:
                 payload_types = payload_types.push(pty2.node)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -1539,19 +1539,19 @@ fn tc_pass2(ts: TS, file_node_idx: i64): TS
 // =========================================================================
 
 fn typecheck(src: string): TypeCheckResult
-  let pr: PR = parse(src)
-  let file_node_idx: i64 = pr.node
+  let po: ParseOutput = parse(src)
+  let file_node_idx: i64 = po.root
   let rr: ResolveResult = resolve(src)
 
   let um: HashMap<i64> = build_uses_map(rr.uses)
-  let tc: TC = TC(pr.ps.nodes, pr.ps.idx, pr.ps.toks, src, rr.symbols, rr.scopes, um)
+  let tc: TC = TC(po.nodes, po.idx, po.toks, src, rr.symbols, rr.scopes, um)
   let ts: TS = TS(tc, Vector<DaoType>::new(), Vector<i64>::new(), Vector<i64>::new(), rr.diags, to_i64(-1), to_i64(0), HashMap<i64>::new())
 
   ts = register_builtins(ts)
   ts = tc_pass1(ts, file_node_idx)
   ts = tc_pass2(ts, file_node_idx)
 
-  return TypeCheckResult(ts.types, ts.type_info, ts.expr_types, ts.sym_types, ts.diags, pr.ps.nodes.length())
+  return TypeCheckResult(ts.types, ts.type_info, ts.expr_types, ts.sym_types, ts.diags, po.nodes.length())
 
 // BEGIN_TYPECHECK_TESTS
 

--- a/stdlib/core/vector.dao
+++ b/stdlib/core/vector.dao
@@ -1,36 +1,55 @@
 // vector.dao — Generic dynamic array.
 //
-// Vector<T> is an ordinary library type built on the low-level memory
-// substrate. No compiler-privileged container semantics.
-//
-// Value semantics: every mutation returns a freshly allocated copy.
-// No aliased Vector values share mutable storage. This is correct
-// but expensive; future COW or ownership tracking can optimize.
+// Vector<T> uses COW (copy-on-write) via a generation counter.
+// The gen pointer tracks the "write frontier" of each buffer.
+// When push detects it is the latest writer (*gen == self.len),
+// it writes in-place (O(1)). Otherwise it copies (O(n)).
+// This makes linear usage patterns O(n) total instead of O(n²).
 
 class Vector<T>:
   data: *T
   len: i64
   cap: i64
+  gen: *i64
 
   fn push(self, elem: T): Vector<T>
-    let new_cap: i64 = self.cap
-    if self.len + 1 > self.cap:
-      new_cap = self.cap * 2
+    mode unsafe =>
+      // Fast path: we are the latest writer and have spare capacity.
+      if self.len < self.cap:
+        if *self.gen == self.len:
+          *ptr_offset(self.data, self.len) = elem
+          *self.gen = self.len + 1
+          return Vector(self.data, self.len + 1, self.cap, self.gen)
+        // Forked: another push already wrote at our position. Copy.
+        let fork_cap: i64 = self.cap
+        let fork_raw = __dao_mem_alloc(
+          size_of<T>() * fork_cap, align_of<T>())
+        let fork_data = ptr_cast<T>(fork_raw)
+        let fi: i64 = 0
+        while fi < self.len:
+          *ptr_offset(fork_data, fi) = *ptr_offset(self.data, fi)
+          fi = fi + 1
+        *ptr_offset(fork_data, self.len) = elem
+        let fork_gen_raw = __dao_mem_alloc(size_of<i64>(), align_of<i64>())
+        let fork_gen = ptr_cast<i64>(fork_gen_raw)
+        *fork_gen = self.len + 1
+        return Vector(fork_data, self.len + 1, fork_cap, fork_gen)
+      // Must grow: double capacity, allocate fresh, copy, append.
+      let new_cap: i64 = self.cap * 2
       if self.cap == 0:
         new_cap = 8
-    // Always allocate a fresh buffer for the returned vector.
-    let new_data_raw = __dao_mem_alloc(
-      size_of<T>() * new_cap, align_of<T>())
-    mode unsafe =>
+      let new_data_raw = __dao_mem_alloc(
+        size_of<T>() * new_cap, align_of<T>())
       let new_data = ptr_cast<T>(new_data_raw)
-      // Copy existing elements.
       let i: i64 = 0
       while i < self.len:
         *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
         i = i + 1
-      // Append the new element.
       *ptr_offset(new_data, self.len) = elem
-      return Vector(new_data, self.len + 1, new_cap)
+      let new_gen_raw = __dao_mem_alloc(size_of<i64>(), align_of<i64>())
+      let new_gen = ptr_cast<i64>(new_gen_raw)
+      *new_gen = self.len + 1
+      return Vector(new_data, self.len + 1, new_cap, new_gen)
     panic("unreachable")
 
   fn get(self, index: i64): T
@@ -47,7 +66,8 @@ class Vector<T>:
       panic("Vector.set: index out of bounds")
     if index >= self.len:
       panic("Vector.set: index out of bounds")
-    // Allocate a fresh copy — do not mutate self.data in place.
+    // Set always copies — it modifies existing data which aliases
+    // may still read from.
     let new_data_raw = __dao_mem_alloc(
       size_of<T>() * self.cap, align_of<T>())
     mode unsafe =>
@@ -57,7 +77,10 @@ class Vector<T>:
         *ptr_offset(new_data, i) = *ptr_offset(self.data, i)
         i = i + 1
       *ptr_offset(new_data, index) = elem
-      return Vector(new_data, self.len, self.cap)
+      let new_gen_raw = __dao_mem_alloc(size_of<i64>(), align_of<i64>())
+      let new_gen = ptr_cast<i64>(new_gen_raw)
+      *new_gen = self.len
+      return Vector(new_data, self.len, self.cap, new_gen)
     panic("unreachable")
 
   fn length(self): i64 -> self.len
@@ -71,4 +94,9 @@ class Vector<T>:
 
   fn new(): Vector<T>
     let zero: i64 = 0
-    return Vector(null_ptr<T>(), zero, zero)
+    mode unsafe =>
+      let gen_raw = __dao_mem_alloc(size_of<i64>(), align_of<i64>())
+      let gen = ptr_cast<i64>(gen_raw)
+      *gen = zero
+      return Vector(null_ptr<T>(), zero, zero, gen)
+    panic("unreachable")

--- a/testdata/ast/stdlib_core_vector.ast
+++ b/testdata/ast/stdlib_core_vector.ast
@@ -3,19 +3,128 @@ File
     Field data: *T
     Field len: i64
     Field cap: i64
+    Field gen: *i64
     FunctionDecl push
       Param self
       Param elem: T
       ReturnType: Vector<T>
-      IfStatement
-        Condition
-          BinaryExpr <
-            FieldExpr .len
-              Identifier self
-            FieldExpr .cap
-              Identifier self
-        Then
-          ModeBlock unsafe
+      ModeBlock unsafe
+        IfStatement
+          Condition
+            BinaryExpr <
+              FieldExpr .len
+                Identifier self
+              FieldExpr .cap
+                Identifier self
+          Then
+            IfStatement
+              Condition
+                BinaryExpr ==
+                  UnaryExpr *
+                    FieldExpr .gen
+                      Identifier self
+                  FieldExpr .len
+                    Identifier self
+              Then
+                Assignment
+                  Target
+                    UnaryExpr *
+                      CallExpr
+                        Callee
+                          Identifier ptr_offset
+                        Args
+                          FieldExpr .data
+                            Identifier self
+                          FieldExpr .len
+                            Identifier self
+                  Value
+                    Identifier elem
+                Assignment
+                  Target
+                    UnaryExpr *
+                      FieldExpr .gen
+                        Identifier self
+                  Value
+                    BinaryExpr +
+                      FieldExpr .len
+                        Identifier self
+                      IntLiteral 1
+                ReturnStatement
+                  CallExpr
+                    Callee
+                      Identifier Vector
+                    Args
+                      FieldExpr .data
+                        Identifier self
+                      BinaryExpr +
+                        FieldExpr .len
+                          Identifier self
+                        IntLiteral 1
+                      FieldExpr .cap
+                        Identifier self
+                      FieldExpr .gen
+                        Identifier self
+            LetStatement fork_cap: i64
+              FieldExpr .cap
+                Identifier self
+            LetStatement fork_raw
+              CallExpr
+                Callee
+                  Identifier __dao_mem_alloc
+                Args
+                  BinaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier size_of
+                      TypeArgs
+                        T
+                    Identifier fork_cap
+                  CallExpr
+                    Callee
+                      Identifier align_of
+                    TypeArgs
+                      T
+            LetStatement fork_data
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  T
+                Args
+                  Identifier fork_raw
+            LetStatement fi: i64
+              IntLiteral 0
+            WhileStatement
+              Condition
+                BinaryExpr <
+                  Identifier fi
+                  FieldExpr .len
+                    Identifier self
+              Assignment
+                Target
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        Identifier fork_data
+                        Identifier fi
+                Value
+                  UnaryExpr *
+                    CallExpr
+                      Callee
+                        Identifier ptr_offset
+                      Args
+                        FieldExpr .data
+                          Identifier self
+                        Identifier fi
+              Assignment
+                Target
+                  Identifier fi
+                Value
+                  BinaryExpr +
+                    Identifier fi
+                    IntLiteral 1
             Assignment
               Target
                 UnaryExpr *
@@ -23,66 +132,89 @@ File
                     Callee
                       Identifier ptr_offset
                     Args
-                      FieldExpr .data
-                        Identifier self
+                      Identifier fork_data
                       FieldExpr .len
                         Identifier self
               Value
                 Identifier elem
+            LetStatement fork_gen_raw
+              CallExpr
+                Callee
+                  Identifier __dao_mem_alloc
+                Args
+                  CallExpr
+                    Callee
+                      Identifier size_of
+                    TypeArgs
+                      i64
+                  CallExpr
+                    Callee
+                      Identifier align_of
+                    TypeArgs
+                      i64
+            LetStatement fork_gen
+              CallExpr
+                Callee
+                  Identifier ptr_cast
+                TypeArgs
+                  i64
+                Args
+                  Identifier fork_gen_raw
+            Assignment
+              Target
+                UnaryExpr *
+                  Identifier fork_gen
+              Value
+                BinaryExpr +
+                  FieldExpr .len
+                    Identifier self
+                  IntLiteral 1
             ReturnStatement
               CallExpr
                 Callee
                   Identifier Vector
                 Args
-                  FieldExpr .data
-                    Identifier self
+                  Identifier fork_data
                   BinaryExpr +
                     FieldExpr .len
                       Identifier self
                     IntLiteral 1
-                  FieldExpr .cap
-                    Identifier self
-          ExpressionStatement
-            CallExpr
-              Callee
-                Identifier panic
-              Args
-                StringLiteral "unreachable"
-      LetStatement new_cap: i64
-        BinaryExpr *
-          FieldExpr .cap
-            Identifier self
-          IntLiteral 2
-      IfStatement
-        Condition
-          BinaryExpr ==
+                  Identifier fork_cap
+                  Identifier fork_gen
+        LetStatement new_cap: i64
+          BinaryExpr *
             FieldExpr .cap
               Identifier self
-            IntLiteral 0
-        Then
-          Assignment
-            Target
-              Identifier new_cap
-            Value
-              IntLiteral 8
-      LetStatement new_data_raw
-        CallExpr
-          Callee
-            Identifier __dao_mem_alloc
-          Args
-            BinaryExpr *
+            IntLiteral 2
+        IfStatement
+          Condition
+            BinaryExpr ==
+              FieldExpr .cap
+                Identifier self
+              IntLiteral 0
+          Then
+            Assignment
+              Target
+                Identifier new_cap
+              Value
+                IntLiteral 8
+        LetStatement new_data_raw
+          CallExpr
+            Callee
+              Identifier __dao_mem_alloc
+            Args
+              BinaryExpr *
+                CallExpr
+                  Callee
+                    Identifier size_of
+                  TypeArgs
+                    T
+                Identifier new_cap
               CallExpr
                 Callee
-                  Identifier size_of
+                  Identifier align_of
                 TypeArgs
                   T
-              Identifier new_cap
-            CallExpr
-              Callee
-                Identifier align_of
-              TypeArgs
-                T
-      ModeBlock unsafe
         LetStatement new_data
           CallExpr
             Callee
@@ -136,6 +268,38 @@ File
                     Identifier self
           Value
             Identifier elem
+        LetStatement new_gen_raw
+          CallExpr
+            Callee
+              Identifier __dao_mem_alloc
+            Args
+              CallExpr
+                Callee
+                  Identifier size_of
+                TypeArgs
+                  i64
+              CallExpr
+                Callee
+                  Identifier align_of
+                TypeArgs
+                  i64
+        LetStatement new_gen
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              i64
+            Args
+              Identifier new_gen_raw
+        Assignment
+          Target
+            UnaryExpr *
+              Identifier new_gen
+          Value
+            BinaryExpr +
+              FieldExpr .len
+                Identifier self
+              IntLiteral 1
         ReturnStatement
           CallExpr
             Callee
@@ -147,6 +311,7 @@ File
                   Identifier self
                 IntLiteral 1
               Identifier new_cap
+              Identifier new_gen
       ExpressionStatement
         CallExpr
           Callee
@@ -299,6 +464,36 @@ File
                   Identifier index
           Value
             Identifier elem
+        LetStatement new_gen_raw
+          CallExpr
+            Callee
+              Identifier __dao_mem_alloc
+            Args
+              CallExpr
+                Callee
+                  Identifier size_of
+                TypeArgs
+                  i64
+              CallExpr
+                Callee
+                  Identifier align_of
+                TypeArgs
+                  i64
+        LetStatement new_gen
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              i64
+            Args
+              Identifier new_gen_raw
+        Assignment
+          Target
+            UnaryExpr *
+              Identifier new_gen
+          Value
+            FieldExpr .len
+              Identifier self
         ReturnStatement
           CallExpr
             Callee
@@ -309,6 +504,7 @@ File
                 Identifier self
               FieldExpr .cap
                 Identifier self
+              Identifier new_gen
       ExpressionStatement
         CallExpr
           Callee
@@ -353,15 +549,52 @@ File
       ReturnType: Vector<T>
       LetStatement zero: i64
         IntLiteral 0
-      ReturnStatement
+      ModeBlock unsafe
+        LetStatement gen_raw
+          CallExpr
+            Callee
+              Identifier __dao_mem_alloc
+            Args
+              CallExpr
+                Callee
+                  Identifier size_of
+                TypeArgs
+                  i64
+              CallExpr
+                Callee
+                  Identifier align_of
+                TypeArgs
+                  i64
+        LetStatement gen
+          CallExpr
+            Callee
+              Identifier ptr_cast
+            TypeArgs
+              i64
+            Args
+              Identifier gen_raw
+        Assignment
+          Target
+            UnaryExpr *
+              Identifier gen
+          Value
+            Identifier zero
+        ReturnStatement
+          CallExpr
+            Callee
+              Identifier Vector
+            Args
+              CallExpr
+                Callee
+                  Identifier null_ptr
+                TypeArgs
+                  T
+              Identifier zero
+              Identifier zero
+              Identifier gen
+      ExpressionStatement
         CallExpr
           Callee
-            Identifier Vector
+            Identifier panic
           Args
-            CallExpr
-              Callee
-                Identifier null_ptr
-              TypeArgs
-                T
-            Identifier zero
-            Identifier zero
+            StringLiteral "unreachable"


### PR DESCRIPTION
## Summary

Fixes the OOM that blocked all bootstrap subsystems larger than the lexer. Two complementary fixes eliminate O(n²) memory consumption.

## Highlights

- **COW Vector**: `Vector<T>` gains a generation counter (`gen: *i64`) for O(1) amortized push on linear usage. Forked values (two headers sharing a buffer) are detected and fall back to O(n) copy. This alone turns the bootstrap's 500-node parse from ~200MB leaked to ~5MB.
- **State threading refactor**: Parser split into PC (immutable: toks, src) + PS (mutable: pos, nodes, idx, diags). Resolver gains RC (immutable context). Eliminates ~72MB of redundant toks/src copies per parse.
- **Bootstrap enum class support**: `parse_enum_decl` now handles `enum class` keyword and named-field variant syntax (`name: Type`), required because bootstrap sources use `enum class Node`.
- **All 205 bootstrap tests pass**: lexer 105, parser 43, resolver 20, typecheck 21, HIR 16

## The OOM diagnosis

Every `Vector.push` allocated a fresh buffer and copied all elements (O(n) per push, O(n²) total). With 500 AST nodes, the parser leaked ~200MB. Combined with PS copying immutable toks (36KB × 2000 mutations = 72MB), the bootstrap exceeded available memory.

## Test plan

- [x] 12/12 C++ compiler tests pass
- [x] Lexer: 105/105
- [x] Parser: 43/43 (was OOM, now passes)
- [x] Resolver: 20/20 (was OOM, now passes)
- [x] Type checker: 21/21 (was OOM, now passes)
- [x] HIR: 16/16 (was OOM, now passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)