### PR TITLE
feat(bootstrap): ✨ add concept satisfaction checking

### DIFF
--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -662,7 +662,7 @@ fn resolve_concept_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, 
   let sr: ScopeR = rs_push_scope(rs, ScopeKind.BlockScope)
   let r: RS = sr.rs
   r = resolve_type_params(r, tparams_lp, node_idx)
-  // Resolve method signature types (ExternFnD nodes — no body)
+  // Resolve method types — signature-only (ExternFnD) or with default body
   if methods_lp >= 0:
     let methods: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
     let mi: i64 = 0
@@ -672,6 +672,10 @@ fn resolve_concept_decl(rs: RS, node_idx: i64, name_tidx: i64, tparams_lp: i64, 
       match meth_node:
         Node.ExternFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type):
           r = resolve_extern_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type)
+        Node.FnDeclD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp):
+          r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_lp)
+        Node.ExprFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, m_body_expr):
+          r = resolve_fn_decl(r, meth_idx, m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type, to_i64(-1))
       mi = mi + 1
   return rs_pop_scope(r)
 
@@ -788,6 +792,8 @@ fn collect_top_level(rs: RS, file_node_idx: i64): RS
                 match tnode:
                   Node.NamedT(t_tidx):
                     target_name = tok_name(r, t_tidx)
+                  Node.GenericT(t_name_tidx, t_args_lp, t_arg_count):
+                    target_name = tok_name(r, t_name_tidx)
               let meths: Vector<i64> = read_list(r.rc.idx_data, methods_lp)
               let mi: i64 = 0
               while mi < meths.length():

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2083,10 +2083,44 @@ fn parse_concept_decl(pc: PC, ps: PS): PR
           if sig_ty.node >= 0:
             sig_ret_type = sig_ty.node
           sig_cur = sig_ty.ps
-        sig_cur = match_tok(pc, sig_cur, TK.Newline)
-        let sig_r: PR = ps_add_node(sig_cur, Node.ExternFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type))
-        method_items = method_items.push(sig_r.node)
-        cur = sig_r.ps
+        // Check for default implementation: -> expr or NEWLINE INDENT body
+        if tk_name(peek_kind(pc, sig_cur)) == tk_name(TK.Arrow):
+          // Expression-bodied default: fn name(params): T -> expr
+          sig_cur = ps_advance(pc, sig_cur)
+          let body_expr: PR = parse_expr(pc, sig_cur)
+          if body_expr.node < 0:
+            cur = body_expr.ps
+          else:
+            sig_cur = match_tok(pc, body_expr.ps, TK.Newline)
+            let sig_r: PR = ps_add_node(sig_cur, Node.ExprFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type, body_expr.node))
+            method_items = method_items.push(sig_r.node)
+            cur = sig_r.ps
+        else:
+          if tk_name(peek_kind(pc, sig_cur)) == tk_name(TK.Newline):
+            // Check for block body (NEWLINE followed by INDENT)
+            let next_pos: i64 = sig_cur.pos + 1
+            let has_indent: bool = false
+            if next_pos < pc.toks.length():
+              let next_tok: Token = pc.toks.get(next_pos)
+              if tk_name(next_tok.kind) == tk_name(TK.Indent):
+                has_indent = true
+            if has_indent:
+              // Block-bodied default: parse as full fn decl
+              let body_suite: PR = parse_suite(pc, sig_cur)
+              let sig_r: PR = ps_add_node(body_suite.ps, Node.FnDeclD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type, body_suite.node))
+              method_items = method_items.push(sig_r.node)
+              cur = sig_r.ps
+            else:
+              // Signature only (no body)
+              sig_cur = match_tok(pc, sig_cur, TK.Newline)
+              let sig_r: PR = ps_add_node(sig_cur, Node.ExternFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type))
+              method_items = method_items.push(sig_r.node)
+              cur = sig_r.ps
+          else:
+            // Signature only (no newline — error recovery)
+            let sig_r: PR = ps_add_node(sig_cur, Node.ExternFnD(sig_name_tidx, sig_tparams.node, sig_params.node, sig_ret_type))
+            method_items = method_items.push(sig_r.node)
+            cur = sig_r.ps
       else:
         // Skip unexpected token
         let sp: Span = tok_span(pc, cur)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -693,6 +693,18 @@ fn tc_register_methods(ts: TS, decls: Vector<i64>): TS
     i = i + 1
   return r
 
+// Extract a type name from a NamedT or GenericT node.
+fn extract_type_name(ts: TS, type_node_idx: i64): string
+  if type_node_idx < 0:
+    return ""
+  let tnode: Node = ts.tc.nodes.get(type_node_idx)
+  match tnode:
+    Node.NamedT(t_tidx):
+      return ts_tok_name(ts, t_tidx)
+    Node.GenericT(t_name_tidx, t_args_lp, t_arg_count):
+      return ts_tok_name(ts, t_name_tidx)
+  return ""
+
 fn tc_register_concepts(ts: TS, decls: Vector<i64>): TS
   let r: TS = ts
   let i: i64 = 0
@@ -716,13 +728,33 @@ fn tc_register_concepts(ts: TS, decls: Vector<i64>): TS
             while mi < methods.length():
               let meth_idx: i64 = methods.get(mi)
               let meth_node: Node = r.tc.nodes.get(meth_idx)
+              // Handle signature-only (ExternFnD) and default-body methods
+              let cm_name_tidx: i64 = to_i64(-1)
+              let cm_params_lp: i64 = to_i64(-1)
+              let cm_ret_type: i64 = to_i64(-1)
+              let cm_valid: bool = false
               match meth_node:
-                Node.ExternFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type):
-                  let mtr: TypeR = tc_register_fn_sig_core(r, meth_idx, m_name_tidx, m_params_lp, m_ret_type)
-                  r = mtr.ts
-                  method_pairs = method_pairs.push(m_name_tidx)
-                  method_pairs = method_pairs.push(mtr.type_idx)
-                  method_count = method_count + 1
+                Node.ExternFnD(mn, mt, mp, mr):
+                  cm_name_tidx = mn
+                  cm_params_lp = mp
+                  cm_ret_type = mr
+                  cm_valid = true
+                Node.FnDeclD(mn, mt, mp, mr, mb):
+                  cm_name_tidx = mn
+                  cm_params_lp = mp
+                  cm_ret_type = mr
+                  cm_valid = true
+                Node.ExprFnD(mn, mt, mp, mr, mb):
+                  cm_name_tidx = mn
+                  cm_params_lp = mp
+                  cm_ret_type = mr
+                  cm_valid = true
+              if cm_valid:
+                let mtr: TypeR = tc_register_fn_sig_core(r, meth_idx, cm_name_tidx, cm_params_lp, cm_ret_type)
+                r = mtr.ts
+                method_pairs = method_pairs.push(cm_name_tidx)
+                method_pairs = method_pairs.push(mtr.type_idx)
+                method_count = method_count + 1
               mi = mi + 1
           // Flush concept method pairs to type_info contiguously.
           let info_start: i64 = r.type_info.length()
@@ -745,13 +777,7 @@ fn tc_register_extend_methods(ts: TS, decls: Vector<i64>): TS
     match node:
       Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
         if methods_lp >= 0:
-          // Get target type name from NamedT node
-          let target_name: string = ""
-          if target_type_node >= 0:
-            let tnode: Node = r.tc.nodes.get(target_type_node)
-            match tnode:
-              Node.NamedT(t_tidx):
-                target_name = ts_tok_name(r, t_tidx)
+          let target_name: string = extract_type_name(r, target_type_node)
           // Find the target type index
           let target_ti: i64 = to_i64(-1)
           let tsi: i64 = 0
@@ -825,13 +851,7 @@ fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
           i = i + 1
         else:
           let concept_type: DaoType = r.types.get(concept_ti)
-          // Get target type name for mangled symbol lookup
-          let target_name: string = ""
-          if target_type_node >= 0:
-            let tnode: Node = r.tc.nodes.get(target_type_node)
-            match tnode:
-              Node.NamedT(t_tidx):
-                target_name = ts_tok_name(r, t_tidx)
+          let target_name: string = extract_type_name(r, target_type_node)
           // Check each required concept method
           let req_mi: i64 = 0
           while req_mi < concept_type.info_count:
@@ -869,25 +889,33 @@ fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
                           let impl_param_ti: i64 = r.type_info.get(impl_type.info_lp + pi)
                           let req_param_ti: i64 = r.type_info.get(req_type.info_lp + pi)
                           if impl_param_ti != req_param_ti:
-                            // Check if req param is a concept self-type (skip comparison)
-                            // Otherwise diagnose the mismatch
+                            // Diagnose mismatch. Unresolved (-1) on either side
+                            // is also a mismatch when the other side resolved.
+                            let sp_p: Span = Span(to_i64(0), to_i64(1))
+                            if concept_name_tidx >= 0:
+                              let tok_p: Token = r.tc.toks.get(concept_name_tidx)
+                              sp_p = Span(tok_p.offset, tok_p.len)
+                            let impl_pname: string = "<unresolved>"
+                            if impl_param_ti >= 0:
+                              impl_pname = type_name(r, impl_param_ti)
+                            let req_pname: string = "<unresolved>"
                             if req_param_ti >= 0:
-                              if impl_param_ti >= 0:
-                                let sp_p: Span = Span(to_i64(0), to_i64(1))
-                                if concept_name_tidx >= 0:
-                                  let tok_p: Token = r.tc.toks.get(concept_name_tidx)
-                                  sp_p = Span(tok_p.offset, tok_p.len)
-                                r = ts_add_diag(r, sp_p, "extend method '" + req_name + "' param " + i64_to_string(pi) + " has type " + type_name(r, impl_param_ti) + ", concept requires " + type_name(r, req_param_ti))
+                              req_pname = type_name(r, req_param_ti)
+                            r = ts_add_diag(r, sp_p, "extend method '" + req_name + "' param " + i64_to_string(pi) + " has type " + impl_pname + ", concept requires " + req_pname)
                           pi = pi + 1
                       // Compare return types
                       if impl_type.ret_type != req_type.ret_type:
+                        let sp2: Span = Span(to_i64(0), to_i64(1))
+                        if concept_name_tidx >= 0:
+                          let tok2: Token = r.tc.toks.get(concept_name_tidx)
+                          sp2 = Span(tok2.offset, tok2.len)
+                        let impl_rname: string = "<unresolved>"
                         if impl_type.ret_type >= 0:
-                          if req_type.ret_type >= 0:
-                            let sp2: Span = Span(to_i64(0), to_i64(1))
-                            if concept_name_tidx >= 0:
-                              let tok2: Token = r.tc.toks.get(concept_name_tidx)
-                              sp2 = Span(tok2.offset, tok2.len)
-                            r = ts_add_diag(r, sp2, "extend method '" + req_name + "' returns " + type_name(r, impl_type.ret_type) + ", concept requires " + type_name(r, req_type.ret_type))
+                          impl_rname = type_name(r, impl_type.ret_type)
+                        let req_rname: string = "<unresolved>"
+                        if req_type.ret_type >= 0:
+                          req_rname = type_name(r, req_type.ret_type)
+                        r = ts_add_diag(r, sp2, "extend method '" + req_name + "' returns " + impl_rname + ", concept requires " + req_rname)
               si = si + 1
             if found_method == false:
               let sp3: Span = Span(to_i64(0), to_i64(1))
@@ -1569,11 +1597,7 @@ fn tc_check_extend_method_body(ts: TS, extend_decl_idx: i64, meth_idx: i64, m_na
   let extend_node: Node = r.tc.nodes.get(extend_decl_idx)
   match extend_node:
     Node.ExtendDeclD(target_type_node, cn_tidx, e_mlp):
-      if target_type_node >= 0:
-        let tnode: Node = r.tc.nodes.get(target_type_node)
-        match tnode:
-          Node.NamedT(t_tidx):
-            target_name = ts_tok_name(r, t_tidx)
+      target_name = extract_type_name(r, target_type_node)
   let mname: string = ts_tok_name(r, m_name_tidx)
   let mangled: string = target_name + "." + mname
   let fn_ti: i64 = to_i64(-1)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -847,7 +847,7 @@ fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
               if sym.name == mangled:
                 if symbol_kind_name(sym.kind) == "Function":
                   found_method = true
-                  // Check signature match (compare param count and return type)
+                  // Check full signature match: param count, each param type, return type.
                   let impl_ti: i64 = vec_i64_get(r.sym_types, si)
                   if impl_ti >= 0:
                     if req_fn_ti >= 0:
@@ -860,6 +860,25 @@ fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
                           let tok: Token = r.tc.toks.get(concept_name_tidx)
                           sp = Span(tok.offset, tok.len)
                         r = ts_add_diag(r, sp, "extend method '" + req_name + "' has " + i64_to_string(impl_type.info_count) + " param(s), concept requires " + i64_to_string(req_type.info_count))
+                      else:
+                        // Param counts match — compare each non-self param type.
+                        // Skip param 0 (self) since it differs by design
+                        // (impl has the concrete type, concept has Self placeholder).
+                        let pi: i64 = 1
+                        while pi < impl_type.info_count:
+                          let impl_param_ti: i64 = r.type_info.get(impl_type.info_lp + pi)
+                          let req_param_ti: i64 = r.type_info.get(req_type.info_lp + pi)
+                          if impl_param_ti != req_param_ti:
+                            // Check if req param is a concept self-type (skip comparison)
+                            // Otherwise diagnose the mismatch
+                            if req_param_ti >= 0:
+                              if impl_param_ti >= 0:
+                                let sp_p: Span = Span(to_i64(0), to_i64(1))
+                                if concept_name_tidx >= 0:
+                                  let tok_p: Token = r.tc.toks.get(concept_name_tidx)
+                                  sp_p = Span(tok_p.offset, tok_p.len)
+                                r = ts_add_diag(r, sp_p, "extend method '" + req_name + "' param " + i64_to_string(pi) + " has type " + type_name(r, impl_param_ti) + ", concept requires " + type_name(r, req_param_ti))
+                          pi = pi + 1
                       // Compare return types
                       if impl_type.ret_type != req_type.ret_type:
                         if impl_type.ret_type >= 0:
@@ -1686,7 +1705,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 23
+  let total: i32 = 24
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -1908,7 +1927,24 @@ fn main(): i32
   else:
     print("FAIL concept_satisfaction_correct: got false missing-method diagnostic")
 
-  // Test 23: self_typecheck_smoke
+  // Test 23: concept_satisfaction — param type mismatch detected
+  let src23c: string = "concept Eqable:\n  fn eq(self, other: i32): bool\n\nclass Baz:\n  val: i32\n\nextend Baz as Eqable:\n  fn eq(self, other: string): bool\n    return false\n"
+  let r23c: TypeCheckResult = typecheck(src23c)
+  let has_param_mismatch: bool = false
+  let di23: i64 = 0
+  while di23 < tc_count_diags(r23c):
+    let d23: Diagnostic = r23c.diags.get(di23)
+    // Check for param type mismatch diagnostic
+    if d23.severity == Severity.Error:
+      has_param_mismatch = true
+    di23 = di23 + 1
+  if has_param_mismatch:
+    print("PASS concept_satisfaction_param_mismatch")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL concept_satisfaction_param_mismatch: expected param type mismatch diagnostic")
+
+  // Test 24: self_typecheck_smoke
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"
   if file_exists(self_path):
     let self_src: string = read_file(self_path)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -41,6 +41,7 @@ enum TypeKind:
   TStruct
   TEnum
   TGenericParam
+  TConcept
 
 class DaoType:
   kind: TypeKind
@@ -700,11 +701,36 @@ fn tc_register_concepts(ts: TS, decls: Vector<i64>): TS
     let node: Node = r.tc.nodes.get(decl_idx)
     match node:
       Node.ConceptDeclD(name_tidx, tparams_lp, methods_lp):
-        // Register concept as a Type in sym_types
         let csym: i64 = find_sym_by_decl(r, decl_idx, "Type")
         if csym >= 0:
           let cname: string = ts_tok_name(r, name_tidx)
-          let tr: TypeR = ts_add_type(r, DaoType(TypeKind.TStruct, to_i64(-1), cname, decl_idx, to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
+          // Register concept method signatures. Collect pairs
+          // (name_tidx, fn_type_idx) locally first, then flush to
+          // type_info after all fn registrations are done (since
+          // tc_register_fn_sig_core also pushes to type_info).
+          let method_pairs: Vector<i64> = Vector<i64>::new()
+          let method_count: i64 = 0
+          if methods_lp >= 0:
+            let methods: Vector<i64> = read_list(r.tc.idx_data, methods_lp)
+            let mi: i64 = 0
+            while mi < methods.length():
+              let meth_idx: i64 = methods.get(mi)
+              let meth_node: Node = r.tc.nodes.get(meth_idx)
+              match meth_node:
+                Node.ExternFnD(m_name_tidx, m_tparams_lp, m_params_lp, m_ret_type):
+                  let mtr: TypeR = tc_register_fn_sig_core(r, meth_idx, m_name_tidx, m_params_lp, m_ret_type)
+                  r = mtr.ts
+                  method_pairs = method_pairs.push(m_name_tidx)
+                  method_pairs = method_pairs.push(mtr.type_idx)
+                  method_count = method_count + 1
+              mi = mi + 1
+          // Flush concept method pairs to type_info contiguously.
+          let info_start: i64 = r.type_info.length()
+          let pi: i64 = 0
+          while pi < method_pairs.length():
+            r = ts_push_type_info(r, method_pairs.get(pi))
+            pi = pi + 1
+          let tr: TypeR = ts_add_type(r, DaoType(TypeKind.TConcept, to_i64(-1), cname, decl_idx, info_start, method_count, to_i64(-1), to_i64(-1)))
           r = tr.ts
           r = ts_set_sym_type(r, csym, tr.type_idx)
     i = i + 1
@@ -769,6 +795,91 @@ fn tc_register_extend_methods(ts: TS, decls: Vector<i64>): TS
     i = i + 1
   return r
 
+// Validate that each extend Type as Concept: provides all required
+// methods with matching signatures. Emits diagnostics for missing
+// methods and signature mismatches.
+fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
+  let r: TS = ts
+  let i: i64 = 0
+  while i < decls.length():
+    let decl_idx: i64 = decls.get(i)
+    let node: Node = r.tc.nodes.get(decl_idx)
+    match node:
+      Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
+        // Look up the concept type
+        let concept_name: string = ts_tok_name(r, concept_name_tidx)
+        let concept_ti: i64 = to_i64(-1)
+        let ci: i64 = 0
+        while ci < r.tc.symbols.length():
+          let csym: Symbol = r.tc.symbols.get(ci)
+          if csym.name == concept_name:
+            if symbol_kind_name(csym.kind) == "Type":
+              let cti: i64 = vec_i64_get(r.sym_types, ci)
+              if cti >= 0:
+                let ct: DaoType = r.types.get(cti)
+                match ct.kind:
+                  TypeKind.TConcept:
+                    concept_ti = cti
+          ci = ci + 1
+        if concept_ti < 0:
+          i = i + 1
+        else:
+          let concept_type: DaoType = r.types.get(concept_ti)
+          // Get target type name for mangled symbol lookup
+          let target_name: string = ""
+          if target_type_node >= 0:
+            let tnode: Node = r.tc.nodes.get(target_type_node)
+            match tnode:
+              Node.NamedT(t_tidx):
+                target_name = ts_tok_name(r, t_tidx)
+          // Check each required concept method
+          let req_mi: i64 = 0
+          while req_mi < concept_type.info_count:
+            let req_name_tidx: i64 = r.type_info.get(concept_type.info_lp + req_mi * 2)
+            let req_fn_ti: i64 = r.type_info.get(concept_type.info_lp + req_mi * 2 + 1)
+            let req_name: string = ts_tok_name(r, req_name_tidx)
+            // Look for mangled symbol TargetName.methodName
+            let mangled: string = target_name + "." + req_name
+            let found_method: bool = false
+            let si: i64 = 0
+            while si < r.tc.symbols.length():
+              let sym: Symbol = r.tc.symbols.get(si)
+              if sym.name == mangled:
+                if symbol_kind_name(sym.kind) == "Function":
+                  found_method = true
+                  // Check signature match (compare param count and return type)
+                  let impl_ti: i64 = vec_i64_get(r.sym_types, si)
+                  if impl_ti >= 0:
+                    if req_fn_ti >= 0:
+                      let impl_type: DaoType = r.types.get(impl_ti)
+                      let req_type: DaoType = r.types.get(req_fn_ti)
+                      // Compare param counts (both include self)
+                      if impl_type.info_count != req_type.info_count:
+                        let sp: Span = Span(to_i64(0), to_i64(1))
+                        if concept_name_tidx >= 0:
+                          let tok: Token = r.tc.toks.get(concept_name_tidx)
+                          sp = Span(tok.offset, tok.len)
+                        r = ts_add_diag(r, sp, "extend method '" + req_name + "' has " + i64_to_string(impl_type.info_count) + " param(s), concept requires " + i64_to_string(req_type.info_count))
+                      // Compare return types
+                      if impl_type.ret_type != req_type.ret_type:
+                        if impl_type.ret_type >= 0:
+                          if req_type.ret_type >= 0:
+                            let sp2: Span = Span(to_i64(0), to_i64(1))
+                            if concept_name_tidx >= 0:
+                              let tok2: Token = r.tc.toks.get(concept_name_tidx)
+                              sp2 = Span(tok2.offset, tok2.len)
+                            r = ts_add_diag(r, sp2, "extend method '" + req_name + "' returns " + type_name(r, impl_type.ret_type) + ", concept requires " + type_name(r, req_type.ret_type))
+              si = si + 1
+            if found_method == false:
+              let sp3: Span = Span(to_i64(0), to_i64(1))
+              if concept_name_tidx >= 0:
+                let tok3: Token = r.tc.toks.get(concept_name_tidx)
+                sp3 = Span(tok3.offset, tok3.len)
+              r = ts_add_diag(r, sp3, "extend does not implement required method '" + req_name + "' from concept '" + concept_name + "'")
+            req_mi = req_mi + 1
+    i = i + 1
+  return r
+
 fn tc_pass1(ts: TS, file_node_idx: i64): TS
   let file_node: Node = ts.tc.nodes.get(file_node_idx)
   match file_node:
@@ -783,6 +894,7 @@ fn tc_pass1(ts: TS, file_node_idx: i64): TS
       r = tc_register_methods(r, decls)
       r = tc_register_concepts(r, decls)
       r = tc_register_extend_methods(r, decls)
+      r = tc_check_concept_satisfaction(r, decls)
       return r
   return ts
 
@@ -1574,7 +1686,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 21
+  let total: i32 = 23
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -1769,7 +1881,34 @@ fn main(): i32
   else:
     print("FAIL extend_method_typecheck: expected 0 diagnostics, got " + i64_to_string(tc_count_diags(r20e)))
 
-  // Test 21: self_typecheck_smoke (was test 20)
+  // Test 21: concept_satisfaction — missing method produces diagnostic
+  let src21c: string = "concept Showable:\n  fn show(self): string\n\nclass Foo:\n  x: i32\n\nextend Foo as Showable:\n  fn other(self): i32\n    return self.x\n"
+  let r21c: TypeCheckResult = typecheck(src21c)
+  if tc_count_diags(r21c) >= 1:
+    print("PASS concept_satisfaction_missing_method")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL concept_satisfaction_missing_method: expected diagnostic for missing 'show' method")
+
+  // Test 22: concept_satisfaction — correct extend has no extra diagnostics
+  let src22c: string = "concept Showable:\n  fn show(self): string\n\nclass Bar:\n  name: string\n\nextend Bar as Showable:\n  fn show(self): string\n    return self.name\n"
+  let r22c: TypeCheckResult = typecheck(src22c)
+  // May have some diagnostics from resolution, but should NOT have
+  // "does not implement required method" diagnostic
+  let has_missing: bool = false
+  let di22: i64 = 0
+  while di22 < tc_count_diags(r22c):
+    let d22: Diagnostic = r22c.diags.get(di22)
+    if d22.message == "extend does not implement required method 'show' from concept 'Showable'":
+      has_missing = true
+    di22 = di22 + 1
+  if has_missing == false:
+    print("PASS concept_satisfaction_correct")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL concept_satisfaction_correct: got false missing-method diagnostic")
+
+  // Test 23: self_typecheck_smoke
   let self_path: string = "examples/bootstrap_probe/expr_parser.dao"
   if file_exists(self_path):
     let self_src: string = read_file(self_path)


### PR DESCRIPTION
## Summary

Validates that `extend Type as Concept:` bodies actually implement all required concept methods with matching signatures. Addresses the review findings from PR #198.

## Highlights

- **`TConcept` type kind**: Concepts are now distinct from structs in the type system. Method signatures stored as (name_tidx, fn_type_idx) pairs in type_info.
- **`tc_check_concept_satisfaction`**: For each ExtendDeclD, looks up the concept type, iterates required methods, verifies each exists with matching param count and return type.
- **Missing method diagnostic**: `"does not implement required method 'show' from concept 'Showable'"`
- **Signature mismatch diagnostic**: param count and return type compared
- **23/23 typecheck tests pass**, including two new concept satisfaction tests

## Known limitation

The second review finding (concept self-type semantics — concept name in type position should mean "the conforming type") is not addressed in this PR. That requires a type-variable substitution mechanism that is a larger design concern.

## Test plan

- [x] All 207 bootstrap tests pass (105 + 43 + 20 + 23 + 16)
- [x] Missing method: `extend Foo as Showable: fn other(self): i32` — detected, diagnostic produced
- [x] Correct extend: `extend Bar as Showable: fn show(self): string` — no false missing-method diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)