### PR TITLE
docs(bootstrap): 📝 add multi-file compilation task specs (25–27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ The current frozen surface assumptions are:
 - `mode <name> =>` enters an execution/safety mode
 - `resource <kind> <name> =>` binds a scoped resource domain
 - `|>` is a first-class pipeline operator
+- `module a::b` declares a file's module identity
+- `import a::b` binds the last segment `b` as a local module name
 - `enum` declares fieldless closed variants (classification only)
 - `enum class` declares closed structured variants with named fields
   (see `docs/contracts/ADR_ENUM_CLASS.md`)

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -309,8 +309,59 @@ substrate consolidated in `bootstrap/shared/base.dao`; assembly
 via `bootstrap/assemble.sh`.
 
 The Tier A bootstrap pipeline (lex → parse → resolve → typecheck →
-HIR) is complete.  Next focus is Tier B expansion in vertical slices
-through all layers, then multi-file compilation.
+HIR) is complete.  Next focus is the multi-file substrate (Tasks
+25–27), then Tier B feature slices on top.
+
+### Task 25 — Bootstrap Multi-file Compilation + Imports (v1)
+
+**Objective**: Replace assembly-only single-file assumptions with a
+deterministic multi-file substrate and first import/module surface.
+
+See `docs/task_specs/TASK_25_BOOTSTRAP_MULTIFILE.md`.
+
+Deliverables:
+
+- `module` keyword added to bootstrap lexer (and `dao.lex`)
+- `ModuleDeclN` and `ImportDeclN` AST nodes
+- `FileN` extended with optional module decl and import list
+- program-level compilation layer above per-file parsing
+- file-to-module mapping with deterministic identity
+- module graph construction with cycle detection
+- diagnostics for missing/duplicate modules and import cycles
+
+### Task 26 — Bootstrap Cross-file Resolution
+
+**Objective**: Extend the bootstrap resolver from single-file scope
+chains to module-aware cross-file name resolution.
+
+See `docs/task_specs/TASK_26_BOOTSTRAP_CROSS_FILE_RESOLUTION.md`.
+
+Deliverables:
+
+- `Module` symbol kind in bootstrap resolver
+- per-module export tables populated in topo order
+- import bindings create Module symbols in importing scope
+- qualified names resolve through module export tables
+- diagnostics for missing exports and duplicate import bindings
+
+### Task 27 — Bootstrap Cross-file Typecheck + HIR Aggregation
+
+**Objective**: Extend bootstrap type checking and HIR lowering to
+operate over multiple resolved modules with canonical type identity.
+
+See `docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md`.
+
+Deliverables:
+
+- program-wide canonical type table spanning all modules
+- cross-file function call and nominal type checking
+- `HirProgram` root aggregating per-module `HirModule` nodes
+- deterministic topo-ordered lowering and HIR dump
+- end-to-end multi-file smoke test
+
+After Tasks 25–27, feature-oriented Tier B slices (methods/
+associated items, concepts/extend, richer patterns, deferred
+expressions) have a sane multi-file substrate to sit on.
 
 ### Task 14 — Numeric Type Expansion
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,12 +210,14 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
-Status: **Tier A frontend + HIR** — Tasks 19–24 complete.  Five
-bootstrap subsystems share a consolidated substrate
-(`bootstrap/shared/base.dao`): lexer (105 tests), parser (36 tests),
-resolver (17 tests), type checker (19 tests), and HIR lowering
-(14 tests).  Together they form a complete Tier A pipeline:
-lex → parse → resolve → typecheck → HIR.
+Status: **Tier A frontend + HIR complete; multi-file substrate next** —
+Tasks 19–24 complete.  Five bootstrap subsystems share a consolidated
+substrate (`bootstrap/shared/base.dao`): lexer (105 tests), parser
+(36 tests), resolver (17 tests), type checker (19 tests), and HIR
+lowering (14 tests).  Together they form a complete Tier A pipeline:
+lex → parse → resolve → typecheck → HIR.  Next: Tasks 25–27 replace
+the assembly/concatenation model with multi-file compilation, cross-
+file resolution, and program-level type checking/HIR.
 
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself

--- a/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
+++ b/docs/contracts/CONTRACT_SYNTAX_SURFACE.md
@@ -373,6 +373,20 @@ Rules:
 - `resource <kind> <name> =>` introduces a resource-binding context
 - `=>` is reserved for semantic-context entry, not structural blocks
 
+## Module Declarations
+
+```dao
+module app::math
+```
+
+Rules:
+- `module` is a reserved keyword
+- `module` declares the file's module identity using a qualified path
+- a file may contain at most one `module` declaration
+- `module` must appear before `import` and all other top-level
+  declarations
+- module identity comes from the declaration, not from file path
+
 ## Namespace Qualification
 
 ```dao

--- a/docs/task_specs/TASK_25_BOOTSTRAP_MULTIFILE.md
+++ b/docs/task_specs/TASK_25_BOOTSTRAP_MULTIFILE.md
@@ -1,0 +1,447 @@
+# Task 25 — Bootstrap Multi-file Compilation + Imports (v1)
+
+Status: implementation spec
+Phase: Phase 7 — Bootstrap Compiler
+Scope: replace assembly-only single-file assumptions with a
+deterministic multi-file substrate and first import/module surface
+
+## 1. Objective
+
+Enable the bootstrap compiler to compile a program spanning multiple
+Dao source files, with explicit module declarations and import
+parsing, while preserving current Tier A frontend semantics inside
+each file.
+
+This task does not attempt to solve the whole module system.  It
+establishes the minimum structural substrate required so bootstrap
+can stop pretending the world is one file.
+
+## 2. Primary design objective
+
+Break the single-file architectural bottleneck without prematurely
+designing package management, visibility modifiers, or stdlib
+distribution.
+
+## 3. Why this task exists now
+
+The current bootstrap pipeline is assembled by concatenation:
+
+* `bootstrap/shared/base.dao` is the shared substrate
+* `bootstrap/assemble.sh` produces `*.gen.dao`
+* all resolver/typecheck/HIR work assumes one file root
+
+That was the right move for Tier A.  It is now the main blocker.
+
+Tier B features become distorted if the compiler still has no notion
+of file identity, module identity, import edges, or deterministic
+cross-file ordering.
+
+Task 25 introduces that substrate first.
+
+## 4. In scope
+
+### 4.1 Source set / compilation model
+
+Introduce a bootstrap-facing compilation entrypoint that accepts:
+
+* one root file path, or
+* an explicit list of file paths
+
+and constructs a single program from multiple files.
+
+### 4.2 Module declarations
+
+Add parsing support for top-level module declarations:
+
+```dao
+module app::math
+```
+
+Module declarations give a file an explicit module identity.
+
+**Syntax note**: `module` is not currently a reserved keyword in
+`dao.lex`, `token.h`, or the bootstrap lexer.  Task 25 must add
+`KwModule` to the bootstrap lexer keyword table.  The host compiler
+lexer and `dao.lex` should be updated in the same diff or a
+coordinated follow-up to keep the token surface consistent.
+
+### 4.3 Import declarations
+
+Add parsing support for top-level imports:
+
+```dao
+import app::math
+import core::io
+```
+
+The bootstrap lexer already has `KwImport` and `ColonColon`.  No new
+tokens needed for imports.
+
+No aliasing, selective imports, glob imports, or re-export syntax
+in v1.
+
+### 4.4 Module graph construction
+
+Build a deterministic module/import graph from the parsed file set.
+
+### 4.5 File-to-module mapping
+
+Each source file maps to exactly one declared module identity.
+
+### 4.6 Cycle detection
+
+Detect import cycles at the module graph layer and emit explicit
+diagnostics.
+
+### 4.7 Deterministic processing order
+
+All graph walking, declaration collection, and later semantic phases
+must run in deterministic order independent of host filesystem
+traversal order.
+
+## 5. Non-goals
+
+### 5.1 Not in v1
+
+* package manager semantics
+* search paths beyond explicit file inputs and simple root-relative
+  lookup
+* visibility modifiers (`pub`, `internal`, etc.)
+* selective imports (`import a::b::{c, d}`)
+* alias imports (`import a::b as c`)
+* re-exports
+* incremental rebuilds / watch mode
+* stdlib auto-discovery
+* import lowering in generated code
+* bootstrap self-host replacement of `assemble.sh`
+
+### 5.2 Still intentionally deferred
+
+* generic/concept-aware import semantics
+* method/extension imports
+* name qualification beyond existing `::` chain semantics
+* package-level cycles involving future re-exports
+
+## 6. Syntax surface
+
+### 6.1 Grammar additions
+
+Top-level only:
+
+```ebnf
+module_decl := "module" qualified_name NEWLINE
+import_decl := "import" qualified_name NEWLINE
+```
+
+Where `qualified_name` reuses the existing `identifier ("::" identifier)*`
+production.
+
+### 6.2 Placement rules
+
+`module` and `import` declarations must appear before other top-level
+declarations in v1.
+
+Valid:
+
+```dao
+module app::math
+import core::fmt
+
+fn add(a: i32, b: i32): i32 -> a + b
+```
+
+Invalid:
+
+```dao
+fn f(): void
+    pass
+import core::fmt
+```
+
+### 6.3 Module declaration cardinality
+
+Per file in v1:
+
+* exactly zero or one `module` declaration while parsing
+* semantically, exactly one module identity is required by
+  compilation
+
+If omitted, the driver may infer module identity from file path only
+if the command explicitly opts into path-based inference.  Default
+bootstrap v1 behavior should prefer an explicit module declaration
+to avoid ambiguity.
+
+Recommendation: require explicit module declarations in multi-file
+mode; permit omission only for legacy single-file tests.
+
+## 7. AST changes
+
+Extend the bootstrap AST with:
+
+```
+ModuleDeclN { path_lp: i64 }
+ImportDeclN { path_lp: i64 }
+```
+
+Where `path_lp` points into the shared child index list holding the
+qualified-name segment token indices.
+
+Extend the file root representation:
+
+```
+FileN { module_decl: i64, import_list_lp: i64, decl_list_lp: i64 }
+```
+
+`module_decl` is `-1` when absent.  `import_list_lp` and
+`decl_list_lp` point into the index data list as in existing AST
+nodes.
+
+## 8. Compilation model
+
+### 8.1 New input/output layer
+
+Introduce a program-level bootstrap compilation layer above the
+current per-file parse/resolve/typecheck/lower calls.
+
+Suggested structures:
+
+```
+class SourceFile:
+  file_id: i64
+  path: string
+  module_name: string   // canonical joined form for display
+  module_segs: i64      // segment count
+  source_text: string
+  ast_root: i64
+
+class ProgramInput:
+  files: Vector<SourceFile>
+
+class ProgramGraph:
+  modules: Vector<SourceFile>
+  edges: Vector<i64>        // flat pairs: [from_id, to_id, ...]
+  topo_order: Vector<i64>   // file_ids in dependency order
+  diags: Vector<Diagnostic>
+```
+
+### 8.2 Deterministic file identity
+
+Assign stable numeric file IDs in lexical path order after path
+normalization.
+
+### 8.3 Deterministic module identity
+
+Store module identity canonically as segment lists, not ad hoc
+joined strings, though a joined display form may be cached for
+diagnostics.
+
+## 9. Module loading model
+
+### 9.1 v1 loading rules
+
+The bootstrap driver accepts either:
+
+* **explicit file list mode** — all files enumerated by the caller
+* **root file mode** — import-driven discovery inside a bounded
+  source root
+
+For v1, explicit file list mode is simpler and should be the
+required test path.
+
+Optional root-file discovery may be added if it stays deterministic.
+
+### 9.2 Path-to-module consistency
+
+If path-based conventions are used, they must only validate
+consistency, not define semantics.
+
+Example: `src/app/math.dao` declares `module app::math`.  If the
+implementation checks this convention, mismatches should diagnose
+clearly.  Semantic identity comes from the module declaration, not
+the folder name.
+
+## 10. Module graph rules
+
+### 10.1 Graph node
+
+Each module is a graph node.
+
+### 10.2 Graph edge
+
+`import a::b` in module `x::y` creates a directed edge from `x::y`
+to `a::b`.
+
+### 10.3 Missing target
+
+If an imported module is not present in the provided compilation
+set, emit a diagnostic during graph construction.
+
+### 10.4 Duplicate module declarations
+
+If multiple files declare the same module identity in v1, diagnose
+as an error.  Do not merge partial modules.
+
+### 10.5 Cycle policy
+
+Import cycles are rejected in v1.
+
+Even though future Dao may support some cyclic visibility model,
+bootstrap v1 should stay strict:
+
+* detect cycle
+* report cycle path
+* abort semantic phases for the strongly connected component
+
+## 11. Parser behavior
+
+### 11.1 Minimal parser change
+
+Do not redesign the parser architecture.
+
+Extend the existing top-level declaration loop to:
+
+1. consume optional leading `module`
+2. consume zero or more leading `import`
+3. then parse existing top-level declarations as before
+
+### 11.2 Recovery behavior
+
+If `module` or `import` syntax is malformed, recover to newline or
+next top-level starter where possible, emit a normal parser
+diagnostic, and continue building the file AST.
+
+## 12. Diagnostics
+
+Task 25 diagnostics must cover at least:
+
+* missing module declaration in required-explicit mode
+* duplicate module declaration within one file
+* `module` after non-import top-level declaration
+* `import` after non-import top-level declaration
+* malformed module path
+* malformed import path
+* duplicate module identity across files
+* imported module not found
+* import cycle with explicit cycle trace
+* nondeterministic or invalid file list input normalization errors
+
+Examples:
+
+```
+module declaration must appear before top-level declarations
+import declaration must appear before top-level declarations
+duplicate module 'app::math' declared in 'a.dao' and 'b.dao'
+imported module 'core::fmt' not found in compilation set
+import cycle detected: app::main -> core::fmt -> app::main
+```
+
+## 13. Public API additions
+
+Current per-file API:
+
+```
+fn parse(src: string): ParseResult
+fn resolve(src: string): ResolveResult
+fn typecheck(src: string): TypeCheckResult
+fn lower_to_hir(src: string): HirResult
+```
+
+Add program-level APIs rather than mutating all existing test
+helpers at once.
+
+Suggested additions:
+
+```
+fn parse_file(path: string, src: string): ParseResult
+fn build_program(files: Vector<SourceInput>): ProgramBuildResult
+```
+
+Where `ProgramBuildResult` contains:
+
+* parsed files
+* module table
+* graph edges
+* topological order
+* diagnostics
+
+## 14. Test strategy
+
+### 14.1 Parser tests (~8)
+
+* `module` declaration parses
+* single `import` parses
+* multiple imports parse
+* module + imports + declarations parse in correct root shape
+* malformed import path reports diagnostic
+* malformed module path reports diagnostic
+* import after function reports diagnostic
+* duplicate module in one file reports diagnostic
+
+### 14.2 Graph tests (~8)
+
+* two files with one import build correctly
+* three-module chain topo-sorts correctly
+* missing imported module reports error
+* duplicate module across files reports error
+* self-import cycle reports error
+* two-node cycle reports error
+* cycle trace is deterministic
+* file ordering is deterministic independent of input order
+
+### 14.3 Smoke test
+
+Compile a tiny two-file bootstrap fixture and verify:
+
+* both files parsed
+* graph built
+* topo order stable
+* no semantic work yet beyond graph construction
+
+## 15. Acceptance criteria
+
+1. Bootstrap parser accepts top-level `module` and `import`
+   declarations.
+2. File AST preserves module declaration and ordered import list.
+3. Program-level build layer exists above per-file parsing.
+4. Compilation set maps files to unique module identities.
+5. Imported modules are resolved at graph-build time.
+6. Duplicate modules are rejected.
+7. Import cycles are rejected with readable diagnostics.
+8. Deterministic file/module ordering is enforced.
+9. Existing single-file tests still pass or have explicit
+   compatibility shims.
+10. At least one two-file smoke fixture passes graph construction.
+
+## 16. Risks
+
+### 16.1 Overreaching into full module design
+
+Task 25 must stop at structural graph formation.  Do not smuggle in
+export semantics, visibility, or symbol import rules.
+
+### 16.2 Breaking current single-file tests
+
+Keep current single-file helper paths intact.  Add a program-level
+layer in parallel.
+
+### 16.3 Path semantics creep
+
+Avoid turning folder layout into language semantics.  Use paths for
+loading, module declarations for meaning.
+
+### 16.4 Keyword introduction
+
+`module` is new syntax surface.  Per AGENTS.md, frozen syntax
+decisions require contract awareness.  The keyword must be added to
+`dao.lex` and the syntax contract in the same changeset that lands
+bootstrap support, or in a coordinated predecessor.
+
+## 17. Explicit deferrals
+
+* exported declaration marking
+* imported symbol binding
+* cross-file name lookup
+* cross-file type lookup
+* HIR aggregation
+* monomorphization across modules
+* stdlib/module search path policy

--- a/docs/task_specs/TASK_25_BOOTSTRAP_MULTIFILE.md
+++ b/docs/task_specs/TASK_25_BOOTSTRAP_MULTIFILE.md
@@ -59,10 +59,10 @@ module app::math
 
 Module declarations give a file an explicit module identity.
 
-**Syntax note**: `module` is not currently a reserved keyword in
-`dao.lex`, `token.h`, or the bootstrap lexer.  Task 25 must add
+**Syntax note**: `module` is now a reserved keyword in `dao.lex`
+and frozen in `CONTRACT_SYNTAX_SURFACE.md`.  Task 25 must add
 `KwModule` to the bootstrap lexer keyword table.  The host compiler
-lexer and `dao.lex` should be updated in the same diff or a
+lexer (`token.h`) should be updated in the same diff or a
 coordinated follow-up to keep the token surface consistent.
 
 ### 4.3 Import declarations
@@ -209,27 +209,60 @@ Suggested structures:
 class SourceFile:
   file_id: i64
   path: string
-  module_name: string   // canonical joined form for display
-  module_segs: i64      // segment count
   source_text: string
   ast_root: i64
+  module_id: i64        // index into ProgramGraph.modules; -1 until assigned
+
+class ModuleEntry:
+  module_id: i64        // canonical module identity, stable across tasks
+  file_id: i64          // owning file
+  segments: Vector<string>
+  display_name: string  // cached "a::b::c" form for diagnostics
 
 class ProgramInput:
   files: Vector<SourceFile>
 
 class ProgramGraph:
-  modules: Vector<SourceFile>
-  edges: Vector<i64>        // flat pairs: [from_id, to_id, ...]
-  topo_order: Vector<i64>   // file_ids in dependency order
+  files: Vector<SourceFile>
+  modules: Vector<ModuleEntry>  // indexed by module_id
+  file_to_module: Vector<i64>   // file_id -> module_id
+  edges: Vector<i64>            // flat pairs: [from_module_id, to_module_id, ...]
+  topo_order: Vector<i64>       // module_ids in dependency order
   diags: Vector<Diagnostic>
 ```
 
-### 8.2 Deterministic file identity
+### 8.2 Identity model: file_id vs module_id
+
+`file_id` and `module_id` are distinct concepts:
+
+* `file_id` is a loading/source artifact — assigned in lexical path
+  order after normalization.  It indexes into `ProgramGraph.files`.
+* `module_id` is a semantic identity — assigned when the module
+  table is built from parsed module declarations.  It indexes into
+  `ProgramGraph.modules`.
+
+In v1 the mapping is 1:1 (one file = one module), but they are
+separate indices because:
+
+* file_id is assigned before parsing (load order)
+* module_id is assigned after parsing (declaration order)
+* future partial modules or generated files may break the 1:1 mapping
+
+All downstream tasks (26, 27) use `module_id` for semantic
+operations (export tables, import bindings, topo order, type
+registration).  `file_id` is used only for source lookup and
+diagnostic file context.
+
+### 8.3 Deterministic file identity
 
 Assign stable numeric file IDs in lexical path order after path
 normalization.
 
-### 8.3 Deterministic module identity
+### 8.4 Deterministic module identity
+
+Assign module IDs in the order modules are registered during graph
+construction (deterministic because file processing order is
+deterministic per §8.3).
 
 Store module identity canonically as segment lists, not ad hoc
 joined strings, though a joined display form may be cached for
@@ -431,10 +464,10 @@ loading, module declarations for meaning.
 
 ### 16.4 Keyword introduction
 
-`module` is new syntax surface.  Per AGENTS.md, frozen syntax
-decisions require contract awareness.  The keyword must be added to
-`dao.lex` and the syntax contract in the same changeset that lands
-bootstrap support, or in a coordinated predecessor.
+`module` was added to `dao.lex`, `dao.ebnf`, and
+`CONTRACT_SYNTAX_SURFACE.md` as a normative prerequisite for this
+task.  The bootstrap lexer and host compiler `token.h` still need
+the corresponding `KwModule` token kind added during implementation.
 
 ## 17. Explicit deferrals
 

--- a/docs/task_specs/TASK_26_BOOTSTRAP_CROSS_FILE_RESOLUTION.md
+++ b/docs/task_specs/TASK_26_BOOTSTRAP_CROSS_FILE_RESOLUTION.md
@@ -142,7 +142,10 @@ unqualified, exactly as they are now in single-file bootstrap.
 ### 7.1 New symbol kind
 
 Add `Module` to the bootstrap `SymbolKind` enum.  Module symbols
-carry a reference to the target module's ID for export-table lookup.
+carry a `target_module_id` referencing the `module_id` from Task 25's
+`ModuleEntry` table (`ProgramGraph.modules`).  This is the stable
+cross-task identity: export table lookup, type registration, and HIR
+provenance all key on `module_id`, not `file_id`.
 
 ### 7.2 New program-level resolve input
 
@@ -236,24 +239,26 @@ Suggested additions:
 
 ```
 class ResolvedModule:
-  module_id: i64
-  file_id: i64
-  path_segments: Vector<string>
-  exports: HashMap<i64>      // name -> symbol_idx
-  imports: Vector<i64>       // module binding symbol indices
+  module_id: i64              // from Task 25 ModuleEntry.module_id
+  file_id: i64                // from Task 25 SourceFile.file_id
+  exports: HashMap<i64>       // name -> symbol_idx
+  imports: Vector<i64>        // module binding symbol indices
 
 class ModuleBinding:
   local_name: string
-  target_module_id: i64
+  target_module_id: i64       // indexes ProgramGraph.modules
   import_node_idx: i64
 
 class ProgramResolveResult:
-  modules: Vector<ResolvedModule>
+  modules: Vector<ResolvedModule>  // indexed by module_id
   symbols: Vector<Symbol>
   scopes: Vector<Scope>
   uses: Vector<i64>
   diags: Vector<Diagnostic>
 ```
+
+`ResolvedModule` does not duplicate `path_segments` — it references
+`ModuleEntry` via `module_id` for display name and segment data.
 
 The existing `uses` map should now store symbol references with
 file/module provenance where needed.

--- a/docs/task_specs/TASK_26_BOOTSTRAP_CROSS_FILE_RESOLUTION.md
+++ b/docs/task_specs/TASK_26_BOOTSTRAP_CROSS_FILE_RESOLUTION.md
@@ -1,0 +1,351 @@
+# Task 26 — Bootstrap Cross-file Resolution
+
+Status: implementation spec
+Phase: Phase 7 — Bootstrap Compiler
+Scope: extend the bootstrap resolver from single-file scope chains to
+module-aware cross-file name resolution
+
+## 1. Objective
+
+Allow bootstrap resolution to bind names across files/modules using
+the module graph established in Task 25.
+
+Task 26 answers:
+
+> When a file imports another module, what names become available
+> locally, and how are qualified references resolved deterministically?
+
+## 2. Primary design objective
+
+Preserve the current resolver's simplicity — two-pass declaration
+collection plus body resolution — while extending it to operate over
+a graph of files rather than a single monolith.
+
+## 3. Resolver baseline
+
+The existing bootstrap resolver (Task 22) already has the right
+spine:
+
+* two-pass: collect top-level declarations, then resolve bodies
+* scope chains with parent-linked lookups
+* `QualNameE` first-segment resolution against scope
+* forward references within one file
+* `SymbolKind` enum with Function, Type, Local, Param, Field,
+  LambdaParam, GenericParam
+
+The host compiler resolver already implements Module symbol kind and
+opaque import binding (Task 6).  Task 26 graduates this to the
+bootstrap with full cross-file resolution.
+
+## 4. In scope
+
+### 4.1 Module-level symbol tables
+
+Each module gets a top-level declaration table containing its
+directly declared symbols.
+
+### 4.2 Export model
+
+In v1, every top-level declaration in a module is exported by
+default.  No explicit `pub` syntax yet.
+
+### 4.3 Import binding rule
+
+`import a::b` binds the final segment `b` in the importing module's
+top-level scope as a Module symbol.
+
+Example:
+
+```dao
+module app::main
+import core::fmt
+
+fn main(): void
+    fmt::print("hi")
+```
+
+`fmt` is a bound module symbol referring to `core::fmt`.
+
+This matches the rule frozen in `CONTRACT_SYNTAX_SURFACE.md`:
+
+> `import a::b` binds the last segment `b` as the local name;
+> qualified references use `b::member` not the full import path
+
+### 4.4 Qualified resolution
+
+Qualified names resolve segment-by-segment:
+
+* first segment resolves in lexical scope
+* if it resolves to a Module symbol, subsequent segments resolve
+  inside that module's exported symbol table
+* if it resolves to a Type/Enum declaration, continue with existing
+  member/variant rules where already supported
+
+### 4.5 Cross-file type resolution
+
+Named types may resolve to declarations defined in imported modules
+via qualified references (e.g. `math::Vec2`).
+
+### 4.6 Duplicate and ambiguous import diagnostics
+
+Reject conflicting imported module bindings at a scope level that
+would make the first segment ambiguous.
+
+## 5. Non-goals
+
+* overload resolution
+* alias imports
+* selective imports
+* wildcard imports
+* visibility modifiers
+* re-export chains
+* method-set lookup across modules
+* generic/concept-aware lookup rules
+* implicit prelude/module injection beyond existing builtins
+
+## 6. Semantic model
+
+### 6.1 Module namespace
+
+Each module has a namespace containing:
+
+* functions
+* structs/classes
+* enums
+* type aliases
+
+### 6.2 Imported module exposure
+
+An import exposes the imported module name, not all contained
+declarations directly.
+
+```dao
+import core::fmt
+fmt::print("x")   // valid
+print("x")        // invalid unless print is in lexical scope
+```
+
+This keeps resolution simple and avoids implicit glob semantics.
+
+### 6.3 Default export rule
+
+All top-level declarations are exported from their declaring module
+in v1.
+
+### 6.4 Same-module unqualified access
+
+Inside a module, its own top-level declarations are visible
+unqualified, exactly as they are now in single-file bootstrap.
+
+## 7. Resolver architecture changes
+
+### 7.1 New symbol kind
+
+Add `Module` to the bootstrap `SymbolKind` enum.  Module symbols
+carry a reference to the target module's ID for export-table lookup.
+
+### 7.2 New program-level resolve input
+
+Introduce `ProgramResolveInput` containing:
+
+* parsed files/modules from Task 25
+* graph topo order
+* per-file AST roots
+
+### 7.3 Pass 1: module declaration collection
+
+For each module in deterministic topo order:
+
+1. create module scope
+2. collect top-level declarations into that module's export table
+3. register imported module bindings in the module's top-level scope
+
+Since cycles are rejected by Task 25, topo order guarantees
+imported module symbol tables exist before dependent module
+collection begins.
+
+### 7.4 Pass 2: body resolution
+
+Resolve bodies using existing scope chain, extended with:
+
+* local/block scope
+* function scope
+* file/module top-level scope (includes import bindings)
+* imported module export tables for qualified-second-segment lookup
+* builtin types/symbols
+
+### 7.5 Module export table
+
+Suggested structure:
+
+```
+class ModuleExports:
+  module_id: i64
+  symbols: HashMap<i64>   // name -> symbol_idx
+```
+
+## 8. Resolution rules
+
+### 8.1 Unqualified identifier
+
+Unqualified identifiers do **not** search imported modules.  They
+search only lexical/module-local scope and builtins.
+
+### 8.2 Qualified identifier: imported module prefix
+
+If the first segment resolves to a Module symbol, the remaining
+path is resolved against that module's exported declaration table.
+
+### 8.3 Qualified identifier: local type/enum prefix
+
+Existing behavior remains (e.g. `Color::Red` for enum variants).
+
+### 8.4 Imported type names in annotations
+
+Type positions follow the same rule set:
+
+```dao
+import app::math
+let x: math::Vec2
+```
+
+Valid if `Vec2` is exported from `app::math`.
+
+### 8.5 Missing export
+
+If the imported module exists but the requested symbol does not:
+
+```
+module 'app::math' has no exported symbol 'Vec3'
+```
+
+### 8.6 Duplicate imported local binding
+
+If two imports would bind the same final segment locally:
+
+```dao
+import a::fmt
+import b::fmt
+```
+
+Reject in v1 as a duplicate binding.  No shadowing through imports.
+
+## 9. Data structures
+
+Suggested additions:
+
+```
+class ResolvedModule:
+  module_id: i64
+  file_id: i64
+  path_segments: Vector<string>
+  exports: HashMap<i64>      // name -> symbol_idx
+  imports: Vector<i64>       // module binding symbol indices
+
+class ModuleBinding:
+  local_name: string
+  target_module_id: i64
+  import_node_idx: i64
+
+class ProgramResolveResult:
+  modules: Vector<ResolvedModule>
+  symbols: Vector<Symbol>
+  scopes: Vector<Scope>
+  uses: Vector<i64>
+  diags: Vector<Diagnostic>
+```
+
+The existing `uses` map should now store symbol references with
+file/module provenance where needed.
+
+## 10. Diagnostics
+
+Task 26 diagnostics must cover at least:
+
+* unknown imported module binding in qualified lookup
+* requested symbol missing from imported module
+* duplicate imported local name
+* duplicate exported declaration inside a module
+* ambiguous or invalid first-segment category for qualified lookup
+* cross-file unknown type name in annotation
+
+Examples:
+
+```
+duplicate imported name 'fmt' from modules 'a::fmt' and 'b::fmt'
+module 'core::fmt' has no exported symbol 'println'
+unknown name 'fmt'
+unknown type 'math::Vec3'
+```
+
+## 11. Test strategy
+
+### 11.1 Resolution tests (~12)
+
+* import binds final segment as Module symbol
+* qualified function call into imported module resolves
+* qualified type annotation into imported module resolves
+* missing imported module symbol diagnoses correctly
+* duplicate import final segment diagnoses correctly
+* unqualified imported declaration remains unresolved
+* same-module unqualified access still works
+* imported enum variant qualification resolves
+* imported struct field type reference resolves (if supported by
+  current type resolver)
+* topo-order-independent result stability
+* diagnostics include source module/file context
+* existing single-file resolver tests still pass
+
+### 11.2 Cross-file smoke fixture
+
+Two or three files:
+
+* `core::fmt` exports a function
+* `app::main` imports it
+* resolver binds `fmt::print`
+
+Verify: symbols, scopes, uses table populated across files.
+
+## 12. Acceptance criteria
+
+1. Bootstrap resolver accepts a program-level input with multiple
+   files/modules.
+2. Module symbol kind exists with target-module reference.
+3. Import bindings create Module symbols in importing scope.
+4. Qualified names resolve through module export tables.
+5. Missing exports produce targeted diagnostics.
+6. Duplicate import bindings are rejected.
+7. Unqualified lookup does not leak across module boundaries.
+8. Per-module export tables are populated in topo order.
+9. Existing single-file resolver tests still pass.
+10. Cross-file smoke fixture passes.
+
+## 13. Risks
+
+### 13.1 Scope chain complexity
+
+Adding module export tables to the lookup chain must not break
+existing local/block/function scope resolution.  Module exports are
+only consulted through qualified names, never unqualified.
+
+### 13.2 Symbol provenance
+
+Symbols now have cross-file identity.  Diagnostic spans must carry
+file context or risk confusing "line 5" messages across different
+files.
+
+### 13.3 State threading
+
+The bootstrap uses value-threaded state (RS, TS, etc.).  Program-
+level resolution means threading state across multiple file
+resolutions.  Keep per-file state isolated where possible and
+aggregate only export tables and diagnostics.
+
+## 14. Explicit deferrals
+
+* visibility modifiers (`pub` / `internal`)
+* selective or aliased imports
+* re-export chains
+* method/extension resolution across modules
+* generic/concept-aware import semantics
+* cross-file overload resolution

--- a/docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md
+++ b/docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md
@@ -143,7 +143,7 @@ Add:
 
 ```
 HirProgram { module_list_lp: i64 }
-HirModule  { name_tok: i64, decl_list_lp: i64, file_id: i64 }
+HirModule  { name_tok: i64, decl_list_lp: i64, module_id: i64 }
 ```
 
 Preserve the existing `HirFile` internally if it is deeply embedded;
@@ -169,6 +169,24 @@ Each `HirModule` preserves its own declaration list.  Methods
 continue to be emitted as flat top-level `HirFunction` nodes within
 their declaring module.
 
+### 7.5 Token and source ownership model
+
+Tokens and source text are owned **per-module**, not concatenated
+into a single global buffer.  This is a binding design choice:
+
+* Each module retains its own `Vector<Token>` and source string.
+* Token indices (used in HIR nodes for span recovery) are
+  module-local.
+* Diagnostic consumers must carry `module_id` to look up the
+  correct token/source buffer from `ProgramHirResult.sources`.
+
+Rationale: concatenated tokens would require a global offset
+remapping layer and break the existing assumption that token
+indices are dense starting from 0.  Per-module ownership preserves
+the current single-file token model inside each module and keeps
+cross-file diagnostics explicit (Task 26 §13 already requires file
+context in diagnostics).
+
 ## 8. Public API additions
 
 Suggested new APIs:
@@ -189,14 +207,20 @@ class ProgramTypeCheckResult:
   modules: Vector<ModuleCheckResult>
   diags: Vector<Diagnostic>
 
+class ModuleSource:
+  module_id: i64
+  file_id: i64
+  toks: Vector<Token>
+  src: string
+
 class ProgramHirResult:
   hir_nodes: Vector<HirNode>
   hir_idx: Vector<i64>
   types: Vector<DaoType>
   type_info: Vector<i64>
-  toks: Vector<Token>       // concatenated or per-module
+  sources: Vector<ModuleSource>  // per-module, indexed by module_id
   diags: Vector<Diagnostic>
-  root: i64                 // HirProgram node index
+  root: i64                      // HirProgram node index
 ```
 
 Preserve existing single-file helper APIs for tests and bootstrap

--- a/docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md
+++ b/docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md
@@ -1,0 +1,313 @@
+# Task 27 — Bootstrap Cross-file Typecheck + HIR Aggregation
+
+Status: implementation spec
+Phase: Phase 7 — Bootstrap Compiler
+Scope: extend bootstrap type checking and HIR lowering from single-file
+to program-wide operation over the resolved module graph
+
+## 1. Objective
+
+Enable bootstrap type checking and HIR lowering to operate over
+multiple resolved modules, producing a unified program-level HIR
+suitable for downstream consumption.
+
+Task 27 answers:
+
+> When a function in one module calls a function or uses a type from
+> another module, how does type checking validate the usage and how
+> does HIR represent the cross-module reference?
+
+## 2. Primary design objective
+
+Lift the existing single-file type checker and HIR builder to
+program scope without redesigning their internals.  The per-file
+logic stays; a program-level orchestration layer runs it in
+dependency order and stitches results.
+
+## 3. Baseline
+
+### 3.1 Type checker (Task 23)
+
+* two-pass: register declaration types, then check bodies
+* type universe: `DaoType` with `TypeKind` enum stored in
+  `Vector<DaoType>`
+* expression types in `HashMap<i64>` (node_idx → type_idx)
+* symbol types in `Vector<i64>` (sym_idx → type_idx)
+
+### 3.2 HIR builder (Task 24)
+
+* single `lower_to_hir(src)` entrypoint
+* produces `HirFile` root with flat declaration list
+* every HIR expression carries resolved type index
+* class/extend methods emitted as flat top-level `HirFunction`
+  with `class_owner` tracking
+
+Both currently operate on one file at a time.
+
+## 4. In scope
+
+### 4.1 Program-wide type registration
+
+Type tables must be canonical across the whole program, not one
+table per file.
+
+When module `app::main` references `math::Vec2`, the type index
+used in `app::main` must be the same canonical index registered by
+`app::math`.
+
+### 4.2 Cross-file function call checking
+
+If `app::main` calls `fmt::print("x")`, the checker uses the
+function signature from `core::fmt`'s resolved and typed declaration.
+
+### 4.3 Cross-file nominal type use
+
+If `math::Vec2` appears in a type annotation, constructor call, or
+field access, it type checks against the declaration in `app::math`.
+
+### 4.4 Cross-file enum variant use
+
+Qualified imported enum variants type check using the originating
+enum declaration.
+
+### 4.5 Duplicate names across modules
+
+Distinct modules may export the same final symbol name.  No conflict
+exists unless local imports create a duplicate binding (already
+rejected by Task 26).
+
+### 4.6 HIR program root
+
+Add a program-level HIR container above the per-file root.
+
+### 4.7 Deterministic lowering order
+
+Type check and lower modules in topological order, breaking ties
+lexically by canonical module path.
+
+## 5. Non-goals
+
+* cross-module monomorphization strategy
+* binary interface serialization
+* incremental compilation caches
+* backend object/link unit partitioning
+* visibility modifiers
+* cross-module optimization passes
+* method dispatch across modules (Tier B feature slice)
+
+## 6. Type checking changes
+
+### 6.1 Canonical type table
+
+A single program-level type table accumulates types across all
+modules.  When module B depends on module A, A's types are already
+registered before B's checking begins (guaranteed by topo order).
+
+Suggested approach: the program-level orchestrator creates one
+shared type table.  Each per-module checking pass reads from and
+appends to this shared table.
+
+### 6.2 Cross-file symbol type lookup
+
+The per-module checker needs access to symbol types from imported
+modules.  The program-level `sym_types` vector (or equivalent)
+must span all modules.
+
+When a qualified name `fmt::print` resolves through the module
+export table (Task 26), the checker looks up `print`'s type index
+in the program-wide sym_types.
+
+### 6.3 Cross-file checking rules
+
+* **Imported function call**: checker uses imported function
+  signature; arity and argument types validated normally
+* **Imported nominal type**: annotation or constructor position
+  resolves to the canonical type registered by the declaring module
+* **Imported enum variant**: qualified variant checked against
+  originating enum's variant list and payload types
+* **Return type from imported call**: flows into local type
+  checking as the call expression's result type
+
+### 6.4 What does NOT change
+
+Per-module body checking logic stays the same.  The checker already
+resolves identifiers via symbol lookup and types via type indices.
+Program-level scope means those indices now span multiple modules,
+but the per-expression checking logic is unchanged.
+
+## 7. HIR model changes
+
+### 7.1 Program-level root
+
+Add:
+
+```
+HirProgram { module_list_lp: i64 }
+HirModule  { name_tok: i64, decl_list_lp: i64, file_id: i64 }
+```
+
+Preserve the existing `HirFile` internally if it is deeply embedded;
+the key addition is `HirProgram` above the per-module roots.
+
+### 7.2 Cross-module references
+
+HIR identifiers and call targets continue to carry resolved symbol
+identity (sym_idx + type_idx).  With program-wide symbol and type
+tables, these indices are already cross-module.
+
+No string-based rebinding in HIR.  No inter-module link table.
+
+### 7.3 Deterministic lowering order
+
+Lower modules in topological order, breaking ties lexically by
+canonical module path.  The HIR dump must be deterministic for
+golden testing.
+
+### 7.4 Per-module declaration preservation
+
+Each `HirModule` preserves its own declaration list.  Methods
+continue to be emitted as flat top-level `HirFunction` nodes within
+their declaring module.
+
+## 8. Public API additions
+
+Suggested new APIs:
+
+```
+fn typecheck_program(input: ProgramResolveResult): ProgramTypeCheckResult
+fn lower_program_to_hir(input: ProgramTypeCheckResult): ProgramHirResult
+```
+
+Where:
+
+```
+class ProgramTypeCheckResult:
+  types: Vector<DaoType>
+  type_info: Vector<i64>
+  expr_types: HashMap<i64>
+  sym_types: Vector<i64>
+  modules: Vector<ModuleCheckResult>
+  diags: Vector<Diagnostic>
+
+class ProgramHirResult:
+  hir_nodes: Vector<HirNode>
+  hir_idx: Vector<i64>
+  types: Vector<DaoType>
+  type_info: Vector<i64>
+  toks: Vector<Token>       // concatenated or per-module
+  diags: Vector<Diagnostic>
+  root: i64                 // HirProgram node index
+```
+
+Preserve existing single-file helper APIs for tests and bootstrap
+development convenience.
+
+## 9. Diagnostics
+
+Task 27 diagnostics must cover at least:
+
+* imported function call argument type mismatch
+* imported function call arity mismatch
+* imported return type mismatch in local context
+* unknown imported type that escaped resolver due to prior recovery
+* imported nominal constructor misuse
+* incompatible cross-module assignment
+* duplicate canonical type registration errors if invariants break
+
+Examples:
+
+```
+expected argument of type 'string' for 'fmt::print', got 'i32'
+cannot assign 'math::Vec2' to 'physics::Vec2'
+enum variant 'Option::Some' expects 1 argument, got 0
+```
+
+## 10. Test strategy
+
+### 10.1 Type check tests (~12)
+
+* imported function call type checks
+* imported function call arg mismatch diagnoses
+* imported struct type annotation checks
+* imported nominal type mismatch diagnoses
+* imported enum variant constructor checks
+* imported type alias use checks
+* cross-file return statement type checks
+* deterministic multi-module checking order
+* existing single-file typecheck tests still pass
+* one module depends on another without textual concatenation
+* duplicate canonical type registration is rejected if triggered
+* recovered parser/resolver errors do not crash program checker
+
+### 10.2 HIR tests (~8)
+
+* multi-file program lowers to HirProgram
+* module count in HIR matches source set
+* imported call lowers with correct resolved target/type
+* imported nominal type is preserved in HIR typing
+* deterministic HIR dump ordering
+* per-module declarations preserved
+* single-file lowering compatibility still works
+* unsupported deferred feature still fails intentionally
+
+### 10.3 End-to-end smoke test
+
+A tiny three-file program:
+
+* `core::fmt` exports a print-like function
+* `app::math` exports a struct or function
+* `app::main` imports both and type checks + lowers successfully
+
+Verify: program HIR root exists, module count is 3, cross-module
+call types are correct, HIR dump is deterministic.
+
+## 11. Acceptance criteria
+
+1. Program-wide type registration exists above the single-file
+   checker.
+2. Imported declarations participate in type checking.
+3. Imported function calls and nominal types check correctly.
+4. Type identity is canonical across the whole program.
+5. HIR gains a program-level root aggregating modules.
+6. Lowering order is deterministic.
+7. Multi-file HIR dump/golden tests exist.
+8. Existing single-file typecheck/HIR helpers still work or have
+   explicit wrappers.
+9. At least one end-to-end multi-file smoke test passes through
+   typecheck and HIR.
+
+## 12. Risks
+
+### 12.1 Type table unification
+
+Some current side tables may assume one file root.  Lift these
+carefully.  The key invariant: type indices are global, not
+per-file.
+
+### 12.2 Premature separate-compilation design
+
+Task 27 is whole-program bootstrap semantics, not a module ABI
+project.  Do not introduce compilation-unit boundaries or object
+interfaces.
+
+### 12.3 HIR root churn
+
+Keep the HIR shape change minimal: add `HirProgram` above the
+existing root rather than rewriting all node shapes.
+
+### 12.4 State threading across modules
+
+The bootstrap's value-threaded state pattern (TS, HS) must
+accumulate across modules without losing earlier module state.
+Ensure type/symbol vectors grow monotonically through the topo-
+ordered checking sequence.
+
+## 13. Explicit deferrals
+
+* cross-module monomorphization strategy
+* binary interface serialization
+* incremental compilation caches
+* backend object/link unit partitioning
+* visibility modifiers
+* cross-module optimization passes
+* method/extend dispatch across modules

--- a/spec/grammar/dao.ebnf
+++ b/spec/grammar/dao.ebnf
@@ -3,7 +3,10 @@
 # docs/contracts/CONTRACT_SYNTAX_SURFACE.md.
 
 file :=
-    import* declaration*
+    module_decl? import* declaration*
+
+module_decl :=
+    "module" module_path NEWLINE
 
 import :=
     "import" module_path NEWLINE

--- a/spec/grammar/dao.lex
+++ b/spec/grammar/dao.lex
@@ -1,6 +1,7 @@
 # Dao lexical surface (early reference)
 
 Reserved keywords:
+- module
 - import
 - extern
 - fn


### PR DESCRIPTION
## Summary

Add sequenced implementation specs for the bootstrap multi-file compilation substrate (Tasks 25–27), replacing the vague "Tier B expansion" placeholder with concrete, dependency-ordered task specs anchored to the repo's current bootstrap shape.

## Highlights

- **Task 25** — multi-file skeleton: `module`/`import` parsing, module graph construction, cycle detection, deterministic file ordering
- **Task 26** — cross-file resolution: `Module` symbol kind, per-module export tables, qualified lookup through import bindings
- **Task 27** — program-wide typecheck + HIR: canonical type table spanning modules, `HirProgram` root, topo-ordered lowering
- Updates `IMPLEMENTATION_PLAN.md` with task summaries and deliverables
- Updates `ROADMAP.md` Phase 7 status to reflect multi-file as the next milestone
- Flags that `module` is not yet a reserved keyword and must be added to `dao.lex` + syntax contract

## Test plan

- [ ] Specs are internally consistent with existing task spec format (Tasks 22–24)
- [ ] Deliverables reference correct existing structures (FileN, SymbolKind, HirFile, etc.)
- [ ] Deferrals are explicit and don't overlap with in-scope work
- [ ] IMPLEMENTATION_PLAN.md and ROADMAP.md updates are consistent with spec content

🤖 Generated with [Claude Code](https://claude.com/claude-code)