### PR TITLE
fix(test): 🩹 skip // comments when detecting leading module in parser_test

### DIFF
--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -36,10 +36,29 @@ struct ParseOutput {
 // `module` declaration (e.g. the module_tests suite) are passed through
 // unchanged so their own module header remains authoritative.
 auto parse_string(std::string_view src) -> ParseOutput {
+  // Skip whitespace and `//` line comments when detecting an existing
+  // leading `module` declaration, to match the comment-aware skip
+  // used by the strip/blank helpers in the driver and playground
+  // (see compiler/driver/main.cpp and
+  // tools/playground/compiler_service/pipeline.cpp). Dao only has
+  // `//` line comments (see spec/grammar/dao.ebnf).
   auto starts_with_module = [](std::string_view s) {
     size_t i = 0;
-    while (i < s.size() && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r')) {
-      ++i;
+    while (i < s.size()) {
+      char ch = s[i];
+      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+        ++i;
+        continue;
+      }
+      if (ch == '/' && i + 1 < s.size() && s[i + 1] == '/') {
+        auto nl = s.find('\n', i);
+        if (nl == std::string_view::npos) {
+          return false;
+        }
+        i = nl + 1;
+        continue;
+      }
+      break;
     }
     if (i + 6 >= s.size() || s.substr(i, 6) != "module") {
       return false;


### PR DESCRIPTION
## Summary

Small follow-up to #205 noted in review. The `parse_string` helper in `compiler/frontend/parser/parser_test.cpp` is idempotent for fixtures whose leading `module` declaration is preceded only by whitespace, but did not skip `//` line comments when looking for the declaration. A future fixture shaped like `// comment\nmodule foo\n...` would therefore still get a synthetic `module test` prepended and hit a duplicate-module parse error.

## Highlights

- Teach the detection loop in `parse_string` to also skip `//` line comments, matching the comment-aware skip already used by `strip_leading_module` / `blank_leading_module` in the driver and playground pipelines.
- Dao only has `//` line comments per `spec/grammar/dao.ebnf`, so this is the only comment form to handle.
- No behavior change for any existing fixture; purely closes a test-helper edge case for future fixtures.

## Test plan

- [x] `task test` — all 12 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)