### PR TITLE
feat(bootstrap): ✨ Task 27 D0 — Program wrapper and service helpers

### DIFF
--- a/bootstrap/graph/tests.dao
+++ b/bootstrap/graph/tests.dao
@@ -10,7 +10,7 @@ fn diag_starts_with(msg: string, prefix: string): bool
     return false
   return substring(msg, to_i64(0), plen) == prefix
 
-fn main(): void
+fn main(): i32
   let pass_count: i64 = 0
   let total: i64 = 12
 
@@ -285,3 +285,4 @@ fn main(): void
   if pass_count == total:
     print("ALL TESTS PASSED")
   print("")
+  return 0

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -922,12 +922,20 @@ fn resolve(src: string): ResolveResult
 // Program uses store triples: [file_id, tok_idx, sym_idx, ...] so
 // consumers can distinguish which file a token index belongs to.
 // (Single-file ResolveResult.uses keeps the old pair format.)
+//
+// `extend_concept_bindings` is the Task 27 D3 side table: each
+// `extend T as C:` / `as C:` block gets a binding from
+// `extend_binding_key(file_id, extend_decl_node_idx)` to the
+// concept's resolver-bound sym_idx.  Typecheck reads this via
+// `program_extend_concept_sym` instead of scanning symbols by name.
+// D0 leaves this empty; D3 populates it.
 class ProgramResolveResult:
   symbols: Vector<Symbol>
   scopes: Vector<Scope>
   uses: Vector<i64>       // flat triples: [file_id, tok_idx, sym_idx, ...]
   diags: Vector<FileDiagnostic>
   module_exports: ExportTables
+  extend_concept_bindings: HashMap<i64>
 
 // Build export table by walking the file's declarations and looking up
 // each declared name in the scope.  This exports only the module's own
@@ -1108,7 +1116,121 @@ fn resolve_program(pg: ProgramGraph): ProgramResolveResult
       pdi = pdi + 1
     ti = ti + 1
 
-  return ProgramResolveResult(all_symbols, all_scopes, all_uses_triples, all_diags, ExportTables(export_tables))
+  // D3 populates `extend_concept_bindings` with resolver-bound
+  // concept identities for each `extend T as C:` block.  Empty until
+  // D3 lands.
+  return ProgramResolveResult(all_symbols, all_scopes, all_uses_triples, all_diags, ExportTables(export_tables), HashMap<i64>::new())
+
+// =========================================================================
+// Section 30: Task 27 — Program wrapper and service helpers (D0)
+// =========================================================================
+//
+// Placement note: the `Program` value and its `program_*` service
+// helpers live in this file (the resolver) rather than in
+// `shared/base.dao` because `Program.resolve` references
+// `ProgramResolveResult`, and the bootstrap build is linear
+// concatenation (`shared/base.dao` is assembled before every
+// subsystem file, so shared types cannot reference resolver types).
+// Long-term, `Program` and its dependents should migrate to a
+// dedicated program-substrate layer by moving resolver core types
+// (`Symbol`, `Scope`, `ExportTable`, `ExportTables`,
+// `ProgramResolveResult`) into `shared/base.dao` — see the Task 27
+// plan's deferred (B)-option restructure.  Until then this is the
+// correct home given the current assembly order.
+
+class Program:
+  graph: ProgramGraph
+  resolve: ProgramResolveResult
+  typecheck: TypeCheckData
+  hir: HirData
+  diags: Vector<FileDiagnostic>
+
+// Build the stringified composite key used by
+// `ProgramResolveResult.extend_concept_bindings`.  Both the resolver
+// write side (D3) and the typecheck read side (`program_extend_concept_sym`)
+// go through this helper so the key format stays in one place.
+fn extend_binding_key(file_id: i64, extend_decl_idx: i64): string
+  return i64_to_string(file_id) + ":" + i64_to_string(extend_decl_idx)
+
+// Construct a `Program` from a graph with empty resolve/typecheck/hir
+// payloads.  Does not run any passes.
+fn program_from_graph(pg: ProgramGraph): Program
+  let empty_resolve: ProgramResolveResult = ProgramResolveResult(
+    Vector<Symbol>::new(),
+    Vector<Scope>::new(),
+    Vector<i64>::new(),
+    Vector<FileDiagnostic>::new(),
+    ExportTables(Vector<ExportTable>::new()),
+    HashMap<i64>::new())
+  let empty_tc: TypeCheckData = TypeCheckData(false)
+  let empty_hir: HirData = HirData(false)
+  return Program(pg, empty_resolve, empty_tc, empty_hir, Vector<FileDiagnostic>::new())
+
+// Run `resolve_program` and fold the result into the `Program`
+// value.  `p.diags` mirrors the resolve pass's diagnostics; later
+// passes append to it.
+fn program_run_resolve(p: Program): Program
+  let rr: ProgramResolveResult = resolve_program(p.graph)
+  return Program(p.graph, rr, p.typecheck, p.hir, rr.diags)
+
+// Fetch a module entry by program-wide module id.
+fn program_module(p: Program, mid: i64): ModuleEntry
+  return p.graph.modules.get(mid)
+
+// Fetch the source file owning a module.  Intended access path for
+// later passes (typecheck/HIR) that need a module's tokens/source/AST —
+// goes through here instead of reaching into `p.graph.files` directly.
+fn program_file_of_module(p: Program, mid: i64): SourceFile
+  let m: ModuleEntry = p.graph.modules.get(mid)
+  return p.graph.files.get(m.file_id)
+
+// Fetch a symbol by program-wide sym_idx.
+fn program_symbol(p: Program, sym_idx: i64): Symbol
+  return p.resolve.symbols.get(sym_idx)
+
+// Look up an exported symbol by name in module `mid`.  Returns the
+// program-wide sym_idx, or -1 if the module id is out of range or
+// the name is not exported.
+fn program_exported_symbol(p: Program, mid: i64, name: string): i64
+  let tables: ExportTables = p.resolve.module_exports
+  if mid < 0:
+    return to_i64(-1)
+  if mid >= tables.tables.length():
+    return to_i64(-1)
+  let table: ExportTable = tables.tables.get(mid)
+  let found: Option<i64> = table.entries.get(name)
+  match found:
+    Option.Some(sym_idx):
+      return sym_idx
+    Option.None:
+      return to_i64(-1)
+
+// Resolve a use site to its target symbol index.  The resolver emits
+// program-level uses as a flat triple stream
+// `[file_id, tok_idx, sym_idx, ...]`; this helper is the only place
+// typecheck/HIR should consult that stream.  Returns -1 if no
+// matching triple exists.
+fn program_resolved_use(p: Program, file_id: i64, tok_idx: i64): i64
+  let uses: Vector<i64> = p.resolve.uses
+  let i: i64 = 0
+  while i + 2 < uses.length():
+    if uses.get(i) == file_id:
+      if uses.get(i + 1) == tok_idx:
+        return uses.get(i + 2)
+    i = i + 3
+  return to_i64(-1)
+
+// Look up the concept sym_idx bound to an `extend T as C:` block.
+// Returns -1 until D3 populates the binding table (D0 is the
+// placeholder step).
+fn program_extend_concept_sym(p: Program, file_id: i64, extend_decl_idx: i64): i64
+  let key: string = extend_binding_key(file_id, extend_decl_idx)
+  let found: Option<i64> = p.resolve.extend_concept_bindings.get(key)
+  match found:
+    Option.Some(sym_idx):
+      return sym_idx
+    Option.None:
+      return to_i64(-1)
 
 // BEGIN_RESOLVER_TESTS
 // =========================================================================
@@ -1141,7 +1263,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 33
+  let total: i32 = 34
 
   // -----------------------------------------------------------------
   // Test 1: forward_ref — fn calls fn defined later in file; no diagnostic
@@ -1699,6 +1821,67 @@ fn main(): i32
     pass_count = pass_count + 1
   else:
     print("FAIL uses_file_provenance: uses not in triple format or missing main.dao file_id")
+
+  // -----------------------------------------------------------------
+  // Task 27 D0: Program wrapper and service helpers
+  // -----------------------------------------------------------------
+  // Verify `program_from_graph` + `program_run_resolve` produce a
+  // Program whose service helpers agree with the underlying resolver
+  // data. This is D0's acceptance check — it proves that every
+  // typecheck/HIR access path routes through the helpers correctly
+  // before those passes are built on top.
+  let p_inputs: Vector<SourceInput> = Vector<SourceInput>::new()
+  p_inputs = p_inputs.push(SourceInput("fmt.dao", "module core::fmt\nfn print_line(s: string): void\n  print(s)\n"))
+  p_inputs = p_inputs.push(SourceInput("main.dao", "module app::main\nimport core::fmt\nfn f(): i32\n  return 0\n"))
+  let p_pg: ProgramGraph = build_program(p_inputs)
+  let p0_val: Program = program_from_graph(p_pg)
+  let p1_val: Program = program_run_resolve(p0_val)
+
+  let d0_ok: bool = true
+
+  // program_exported_symbol must find the fmt::print_line export.
+  let fmt_mid: i64 = find_module_by_name(p1_val.graph.modules, "core::fmt")
+  if fmt_mid < 0:
+    d0_ok = false
+  let print_sym: i64 = program_exported_symbol(p1_val, fmt_mid, "print_line")
+  if print_sym < 0:
+    d0_ok = false
+
+  // program_module / program_file_of_module must agree on the module.
+  let fmt_mod: ModuleEntry = program_module(p1_val, fmt_mid)
+  if fmt_mod.name != "core::fmt":
+    d0_ok = false
+  let fmt_file: SourceFile = program_file_of_module(p1_val, fmt_mid)
+  if fmt_file.file_id != fmt_mod.file_id:
+    d0_ok = false
+
+  // program_extend_concept_sym returns -1 until D3 populates the table.
+  let d0_extend_sym: i64 = program_extend_concept_sym(p1_val, to_i64(0), to_i64(0))
+  if d0_extend_sym != to_i64(-1):
+    d0_ok = false
+
+  // program_resolved_use must agree with the raw triple stream.
+  if p1_val.resolve.uses.length() >= 3:
+    let probe_file: i64 = p1_val.resolve.uses.get(0)
+    let probe_tok: i64 = p1_val.resolve.uses.get(1)
+    let probe_sym: i64 = p1_val.resolve.uses.get(2)
+    let via_helper: i64 = program_resolved_use(p1_val, probe_file, probe_tok)
+    if via_helper != probe_sym:
+      d0_ok = false
+
+  // Missing lookups return -1.
+  let miss_sym: i64 = program_exported_symbol(p1_val, fmt_mid, "nonexistent_symbol")
+  if miss_sym != to_i64(-1):
+    d0_ok = false
+  let miss_use: i64 = program_resolved_use(p1_val, to_i64(999), to_i64(999))
+  if miss_use != to_i64(-1):
+    d0_ok = false
+
+  if d0_ok:
+    print("PASS d0_program_wrapper")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL d0_program_wrapper")
 
   // -----------------------------------------------------------------
   // Summary

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2522,6 +2522,20 @@ class SourceInput:
   path: string
   source_text: string
 
+// --- Task 27: Program-level pass payloads ---
+//
+// `TypeCheckData` and `HirData` are stub classes that live in
+// `shared/base.dao` so the `Program` value (defined in
+// `bootstrap/resolver/impl.dao` because of linear assembly order)
+// can reference them without depending on the typecheck or HIR
+// subsystem files.  D1a (typecheck substrate) and D7 (HIR
+// substrate) fill these in place with their real fields.
+class TypeCheckData:
+  initialized: bool
+
+class HirData:
+  initialized: bool
+
 // --- Graph construction ---
 
 // Find a module by name in the module list.  Returns module_id or -1.


### PR DESCRIPTION
## Summary

First step of Task 27 (cross-file typecheck + HIR aggregation): introduce the `Program` value that will thread through `resolve → typecheck → HIR`, plus the service helpers every future pass queries. D0 is a pure additive wrapper around the existing `ProgramGraph` and `resolve_program` from Tasks 25/26 — typecheck and HIR still run their single-file paths unchanged.

Also includes a small pre-existing fix for `bootstrap/graph/tests.dao` that was blocking `task bootstrap-test` end-to-end.

## Highlights

### Pre-existing fix (separate commit)

- `bootstrap/graph/tests.dao`'s `main()` was declared `void` with no explicit `return 0`, so the compiled binary returned non-zero exit status even on full pass. The test runner treated this as failure and stopped the bootstrap chain after graph, even though graph printed `12 / 12 passed` and `ALL TESTS PASSED`. Every other bootstrap subsystem's `main()` returns `i32` with explicit `return 0` — brought graph in line.

### Task 27 D0

- **`TypeCheckData` / `HirData` stubs** in `bootstrap/shared/base.dao`. Empty bodies for D0; D1a (typecheck substrate) and D7 (HIR substrate) fill them in place.
- **`Program` class** in `bootstrap/resolver/impl.dao` holding `graph`, `resolve`, `typecheck`, `hir`, `diags`. Placement-debt comment included: `Program` lives in the resolver file temporarily because its `resolve` field references `ProgramResolveResult`, and the bootstrap build is linear concatenation (`shared/base.dao` is assembled first and cannot reference resolver types). Long-term home is a dedicated program-substrate layer — deferred to a later cleanup commit.
- **`ProgramResolveResult.extend_concept_bindings: HashMap<i64>`** — D3's side table for resolver-bound `extend T as C:` concept identity, so typecheck never has to scan symbols by name. Empty in D0; D3 populates it.
- **`extend_binding_key(file_id, extend_decl_idx): string`** — shared helper used by both the D3 resolver write side and the typecheck read side, so the key format stays in one place.
- **Service helpers** (all in `resolver/impl.dao`, namespaced `program_*`):
  - `program_from_graph(pg)` — construct Program from a graph with empty pass payloads
  - `program_run_resolve(p)` — calls `resolve_program` and folds the result into Program
  - `program_module(p, mid)` / `program_file_of_module(p, mid)` — module lookups
  - `program_symbol(p, sym_idx)` — symbol lookup by program-wide index
  - `program_exported_symbol(p, mid, name)` — module export lookup, returns `-1` if absent
  - `program_resolved_use(p, file_id, tok_idx)` — the only intended access path for resolved uses; consults the flat triple stream, returns `-1` if absent
  - `program_extend_concept_sym(p, file_id, extend_decl_idx)` — reads the D3 side table, returns `-1` until D3 populates it

All future passes query the Program through these helpers; no pass should read `p.resolve.uses` triples or `p.resolve.module_exports` tables directly. That invariant is the whole point of D0.

- **New regression test `d0_program_wrapper`** in `bootstrap/resolver/impl.dao` verifies every helper end-to-end against a two-module fixture (`core::fmt` + `app::main`). Asserts:
  - `program_exported_symbol` finds the `core::fmt::print_line` export
  - `program_resolved_use` agrees with the raw triple stream
  - `program_extend_concept_sym` returns `-1` before D3 populates it
  - `program_module` / `program_file_of_module` agree on module identity
  - Missing-export and missing-use lookups both return `-1`

## What D0 does NOT do

- Does not touch `resolve_program` internals.
- Does not change `typecheck(src)` or `lower_to_hir(src)` behavior.
- Does not move any types between files.
- Does not populate `extend_concept_bindings` (D3).
- Does not introduce program-wide type tables (D1a).
- Does not fix the cross-module typing bug in `check_qualname_expr` (D4).
- Does not add cross-module method/extend scoping (D2).

Each of those lands in its own commit on top of D0. The plan is D0 → D1a → D1b → D3 → D2 → D4 → D5 → D6 → D7 → D8 → D9 → D10, each independently commitable.

## Test plan

- [x] `task bootstrap-test` passes end-to-end (was broken on main by the graph exit-code bug)
- [x] Bootstrap resolver: 34/34 (+1 new `d0_program_wrapper`)
- [x] Bootstrap lexer 105/105, parser 51/51, graph 12/12, typecheck 24/24, HIR 16/16 — all unchanged
- [x] Host C++ tests: 12/12 unchanged
- [ ] Manual review of the placement-debt comment to confirm the long-term home decision

## References

- Task 27 spec: `docs/task_specs/TASK_27_BOOTSTRAP_PROGRAM_TYPECHECK_AND_HIR.md`
- Tasks 25/26 substrate this builds on: #203, #204
- `CONTRACT_SYNTAX_SURFACE.md` module rules: #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)