### PR TITLE
feat(bootstrap): ✨ Task 27 D1a — program-wide typecheck substrate

### DIFF
--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -1162,7 +1162,7 @@ fn program_from_graph(pg: ProgramGraph): Program
     Vector<FileDiagnostic>::new(),
     ExportTables(Vector<ExportTable>::new()),
     HashMap<i64>::new())
-  let empty_tc: TypeCheckData = TypeCheckData(false)
+  let empty_tc: TypeCheckData = TypeCheckData(false, Vector<DaoType>::new(), Vector<i64>::new(), Vector<i64>::new(), HashMap<i64>::new())
   let empty_hir: HirData = HirData(false)
   return Program(pg, empty_resolve, empty_tc, empty_hir, Vector<FileDiagnostic>::new())
 

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2522,19 +2522,77 @@ class SourceInput:
   path: string
   source_text: string
 
+// --- Task 27: Type universe (shared across passes) ---
+//
+// `TypeKind` and `DaoType` were originally in `typecheck/impl.dao`.
+// Promoted to `shared/base.dao` in D1a so that `TypeCheckData` can
+// carry `types: Vector<DaoType>` and every pass assembled after
+// `shared/base.dao` can reference the type universe without depending
+// on the typecheck subsystem file.  These types are self-contained —
+// they depend only on primitives.
+
+enum TypeKind:
+  TBuiltin
+  TVoid
+  TString
+  TPointer
+  TFunction
+  TStruct
+  TEnum
+  TGenericParam
+  TConcept
+
+class DaoType:
+  kind: TypeKind
+  builtin_id: i64
+  name: string
+  decl_node: i64
+  info_lp: i64
+  info_count: i64
+  ret_type: i64
+  pointee: i64
+
 // --- Task 27: Program-level pass payloads ---
 //
-// `TypeCheckData` and `HirData` are stub classes that live in
-// `shared/base.dao` so the `Program` value (defined in
-// `bootstrap/resolver/impl.dao` because of linear assembly order)
-// can reference them without depending on the typecheck or HIR
-// subsystem files.  D1a (typecheck substrate) and D7 (HIR
-// substrate) fill these in place with their real fields.
+// `TypeCheckData` lives here so the `Program` value (in
+// `bootstrap/resolver/impl.dao`) can reference it.  `HirData` is
+// still a stub; D7 fills it with real fields.
+
 class TypeCheckData:
   initialized: bool
+  types: Vector<DaoType>
+  type_info: Vector<i64>
+  sym_types: Vector<i64>
+  expr_types: HashMap<i64>       // key: expr_id_key(module_id, node_idx)
 
 class HirData:
   initialized: bool
+
+// --- Task 27: ExprId keying ---
+//
+// Typed composite key for program-wide expression identity. Bootstrap
+// uses stringified keys in HashMaps (the standard bootstrap pattern).
+// Both the typecheck write side and any downstream read side
+// (HIR, future MIR) go through this helper so the key format stays
+// in one place.
+
+fn expr_id_key(module_id: i64, node_idx: i64): string
+  return i64_to_string(module_id) + ":" + i64_to_string(node_idx)
+
+// Read helpers for TypeCheckData.expr_types.
+
+fn tc_get_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64): i64
+  let key: string = expr_id_key(module_id, node_idx)
+  let found: Option<i64> = td.expr_types.get(key)
+  match found:
+    Option.Some(ty):
+      return ty
+    Option.None:
+      return to_i64(-1)
+
+fn tc_set_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64, ty: i64): TypeCheckData
+  let key: string = expr_id_key(module_id, node_idx)
+  return TypeCheckData(td.initialized, td.types, td.type_info, td.sym_types, td.expr_types.set(key, ty))
 
 // --- Graph construction ---
 

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -245,6 +245,13 @@ fn register_builtins(ts: TS): TS
 // (indices 0–12 are i8, i16, i32, i64, u8, u16, u32, u64, f32, f64,
 // bool, void, string) so all modules share a canonical type table.
 fn program_init_typecheck(p: Program): Program
+  // Guard: if TypeCheckData is already initialized (builtins seeded),
+  // return unchanged.  A second call must not discard accumulated
+  // canonical types, type_info, sym_types, or expr_types — the
+  // program-level type table is shared and accumulates across modules
+  // per Task 27 §4.1.
+  if p.typecheck.initialized:
+    return p
   // Build a throwaway TC/TS just to drive register_builtins, then
   // harvest the resulting types/type_info/sym_types into
   // TypeCheckData.  This avoids duplicating the builtin registration
@@ -1753,7 +1760,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 26
+  let total: i32 = 27
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -2043,6 +2050,24 @@ fn main(): i32
     pass_count = pass_count + 1
   else:
     print("FAIL d1a_program_init_typecheck")
+
+  // Test d1a_1b: double-init is a no-op (preserves accumulated state).
+  let td_with_expr: TypeCheckData = tc_set_expr_type(p_tc.typecheck, to_i64(0), to_i64(7), to_i64(2))
+  let p_tc_with_expr: Program = Program(p_tc.graph, p_tc.resolve, td_with_expr, p_tc.hir, p_tc.diags)
+  let p_tc2: Program = program_init_typecheck(p_tc_with_expr)
+  let d1a_1b_ok: bool = true
+  // expr_types entry should survive the second init call.
+  let preserved: i64 = tc_get_expr_type(p_tc2.typecheck, to_i64(0), to_i64(7))
+  if preserved != 2:
+    d1a_1b_ok = false
+  // types count should still be 13 (not doubled).
+  if p_tc2.typecheck.types.length() != 13:
+    d1a_1b_ok = false
+  if d1a_1b_ok:
+    print("PASS d1a_double_init_noop")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL d1a_double_init_noop")
 
   // Test d1a_2: expr_id_key and tc_get/set_expr_type round-trip.
   let td0: TypeCheckData = p_tc.typecheck

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -33,26 +33,9 @@ module bootstrap::typecheck
 // and TS (mutable type checker state, 8 fields) to stay under the Dao
 // compiler's limit for reliable class field access in function arguments.
 
-enum TypeKind:
-  TBuiltin
-  TVoid
-  TString
-  TPointer
-  TFunction
-  TStruct
-  TEnum
-  TGenericParam
-  TConcept
-
-class DaoType:
-  kind: TypeKind
-  builtin_id: i64
-  name: string
-  decl_node: i64
-  info_lp: i64
-  info_count: i64
-  ret_type: i64
-  pointee: i64
+// TypeKind and DaoType promoted to shared/base.dao in D1a so that
+// TypeCheckData can carry `types: Vector<DaoType>` and every pass
+// can reference the type universe.  See the comment in shared/base.dao.
 
 // =========================================================================
 // Section 34: Type checker state
@@ -251,6 +234,46 @@ fn register_builtins(ts: TS): TS
   let r11: TypeR = ts_add_type(r10.ts, DaoType(TypeKind.TVoid, to_i64(-1), "void", to_i64(-1), to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
   let r12: TypeR = ts_add_type(r11.ts, DaoType(TypeKind.TString, to_i64(-1), "string", to_i64(-1), to_i64(-1), to_i64(0), to_i64(-1), to_i64(-1)))
   return r12.ts
+
+// =========================================================================
+// Section 34a: Program-level typecheck initialization (Task 27 D1a)
+// =========================================================================
+
+// Seed the program's `TypeCheckData` with canonical builtin types.
+// Called exactly once per `Program` before any per-module pass runs.
+// Produces the same builtin layout as single-file `register_builtins`
+// (indices 0–12 are i8, i16, i32, i64, u8, u16, u32, u64, f32, f64,
+// bool, void, string) so all modules share a canonical type table.
+fn program_init_typecheck(p: Program): Program
+  // Build a throwaway TC/TS just to drive register_builtins, then
+  // harvest the resulting types/type_info/sym_types into
+  // TypeCheckData.  This avoids duplicating the builtin registration
+  // logic — register_builtins is the single source of truth.
+  let dummy_tc: TC = TC(
+    Vector<Node>::new(),
+    Vector<i64>::new(),
+    Vector<Token>::new(),
+    "",
+    Vector<Symbol>::new(),
+    Vector<Scope>::new(),
+    HashMap<i64>::new())
+  let dummy_ts: TS = TS(
+    dummy_tc,
+    Vector<DaoType>::new(),
+    Vector<i64>::new(),
+    Vector<i64>::new(),
+    Vector<Diagnostic>::new(),
+    to_i64(-1),
+    to_i64(0),
+    HashMap<i64>::new())
+  let seeded: TS = register_builtins(dummy_ts)
+  let td: TypeCheckData = TypeCheckData(
+    true,
+    seeded.types,
+    seeded.type_info,
+    seeded.sym_types,
+    HashMap<i64>::new())
+  return Program(p.graph, p.resolve, td, p.hir, p.diags)
 
 // =========================================================================
 // Section 39: Type query helpers
@@ -1730,7 +1753,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 24
+  let total: i32 = 26
 
   // Test 1: correct_arithmetic
   let src1: string = "fn main(): i32\n  return 1 + 2\n"
@@ -1988,6 +2011,65 @@ fn main(): i32
     print("SKIP self_typecheck_smoke: file not found at " + self_path)
 
   print("")
+  // -----------------------------------------------------------------
+  // Task 27 D1a: Program-level typecheck substrate
+  // -----------------------------------------------------------------
+
+  // Test d1a_1: program_init_typecheck seeds canonical builtins.
+  let p_inputs: Vector<SourceInput> = Vector<SourceInput>::new()
+  p_inputs = p_inputs.push(SourceInput("a.dao", "module a\nfn f(): i32 -> 0\n"))
+  let p_pg: ProgramGraph = build_program(p_inputs)
+  let p_val: Program = program_from_graph(p_pg)
+  let p_r: Program = program_run_resolve(p_val)
+  let p_tc: Program = program_init_typecheck(p_r)
+  let d1a_1_ok: bool = true
+  // Builtins: 13 types (i8..u64, f32, f64, bool, void, string).
+  if p_tc.typecheck.types.length() != 13:
+    d1a_1_ok = false
+  if p_tc.typecheck.initialized != true:
+    d1a_1_ok = false
+  // i32 should be at index 2 with name "i32".
+  if p_tc.typecheck.types.length() > 2:
+    let i32_type: DaoType = p_tc.typecheck.types.get(2)
+    if i32_type.name != "i32":
+      d1a_1_ok = false
+  // void at index 11.
+  if p_tc.typecheck.types.length() > 11:
+    let void_type: DaoType = p_tc.typecheck.types.get(11)
+    if void_type.name != "void":
+      d1a_1_ok = false
+  if d1a_1_ok:
+    print("PASS d1a_program_init_typecheck")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL d1a_program_init_typecheck")
+
+  // Test d1a_2: expr_id_key and tc_get/set_expr_type round-trip.
+  let td0: TypeCheckData = p_tc.typecheck
+  let td1: TypeCheckData = tc_set_expr_type(td0, to_i64(0), to_i64(42), to_i64(2))
+  let td2: TypeCheckData = tc_set_expr_type(td1, to_i64(1), to_i64(42), to_i64(11))
+  let d1a_2_ok: bool = true
+  // Same node_idx 42 in two different modules should be distinct.
+  let ty0: i64 = tc_get_expr_type(td2, to_i64(0), to_i64(42))
+  let ty1: i64 = tc_get_expr_type(td2, to_i64(1), to_i64(42))
+  if ty0 != 2:
+    d1a_2_ok = false
+  if ty1 != 11:
+    d1a_2_ok = false
+  // Missing entry returns -1.
+  let ty_miss: i64 = tc_get_expr_type(td2, to_i64(99), to_i64(99))
+  if ty_miss != to_i64(-1):
+    d1a_2_ok = false
+  if d1a_2_ok:
+    print("PASS d1a_expr_id_round_trip")
+    pass_count = pass_count + 1
+  else:
+    print("FAIL d1a_expr_id_round_trip")
+
+  // -----------------------------------------------------------------
+  // Summary
+  // -----------------------------------------------------------------
+
   print("--- results ---")
   print(i32_to_string(pass_count) + " / " + i32_to_string(total) + " passed")
   print("")


### PR DESCRIPTION
## Summary

Second step of Task 27 (D1a): introduce the program-level typecheck data structures and helpers that D1b (adapter migration), D5 (program typecheck orchestration), and downstream passes will build on. D1a is a pure addition — the legacy single-file `typecheck(src)` path is completely untouched.

## Highlights

- **`TypeKind` / `DaoType` promoted** from `bootstrap/typecheck/impl.dao` to `bootstrap/shared/base.dao`. These types are self-contained (depend only on primitives) and describe the type universe that every pass needs to reference. Moving them allows `TypeCheckData.types: Vector<DaoType>` without a cross-subsystem dependency.
- **`TypeCheckData` extended** (was a stub with `initialized: bool`) with the real fields: `types`, `type_info`, `sym_types`, `expr_types`.
- **`expr_id_key(module_id, node_idx): string`** — the typed composite key for program-wide expression identity, matching bootstrap's standard stringified-key HashMap pattern. Single source of truth for the key format.
- **`tc_get_expr_type` / `tc_set_expr_type`** — read/write helpers that route all expr_types access through `expr_id_key`. D1b will migrate every `ts.expr_types.set(node_idx, …)` callsite to use these with an explicit module_id.
- **`program_init_typecheck(p: Program): Program`** — seeds canonical builtins (indices 0–12) into `p.typecheck.types` exactly once per Program by driving `register_builtins` through a throwaway TS. No builtin registration logic duplicated.
- **`program_from_graph`** updated to construct `TypeCheckData` with empty typed vectors.

## What D1a does NOT do

- Does not touch the legacy `typecheck(src)` code path (that's D1b).
- Does not migrate any existing `expr_types` callsite (that's D1b).
- Does not introduce `owner_module_id` on Symbol (that's D2).
- Does not add concept binding lookup (that's D3).
- Does not add cross-module qualified name typing (that's D4).

## Test plan

- [x] `task bootstrap-test` — all subsystems green: lexer 105/105, parser 51/51, graph 12/12, resolver 34/34, typecheck 26/26 (+2 new), HIR 16/16
- [x] `task test` — host C++ 12/12 unchanged
- [x] New test `d1a_program_init_typecheck`: builtins seeded correctly (count=13, i32 at idx 2, void at idx 11)
- [x] New test `d1a_expr_id_round_trip`: same node_idx in different modules produces distinct entries; missing entries return -1

🤖 Generated with [Claude Code](https://claude.com/claude-code)