### PR TITLE
chore(build): 🔧 cap cmake build parallelism via DAO_BUILD_JOBS

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,7 +36,7 @@ tasks:
     desc: Build all targets
     deps: [configure]
     cmds:
-      - cmake --build {{.BUILD_DIR}}
+      - cmake --build {{.BUILD_DIR}} -- -j${DAO_BUILD_JOBS:-4}
 
   test:
     desc: Run all tests


### PR DESCRIPTION
## Summary

Add explicit `-j${DAO_BUILD_JOBS:-4}` to the Taskfile build command. mise.toml already sets the env var, but the explicit flag ensures the cap holds when task is invoked outside mise.

## Test plan

- [x] Verified command passes through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)