### PR TITLE
refactor(support): ♻️ extract shared read_file test utility

### DIFF
--- a/compiler/analysis/semantic_tokens_test.cpp
+++ b/compiler/analysis/semantic_tokens_test.cpp
@@ -2,11 +2,11 @@
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
 #include "frontend/resolve/resolve.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <string>
 #include <unordered_set>
 
@@ -14,11 +14,6 @@ using namespace boost::ut;
 using namespace dao;
 
 namespace {
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
 
 struct ClassifiedSource {
   SourceBuffer source;

--- a/compiler/frontend/ast/ast_printer_test.cpp
+++ b/compiler/frontend/ast/ast_printer_test.cpp
@@ -1,12 +1,12 @@
 #include "frontend/ast/ast_printer.h"
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
+#include "support/test_utils.h"
 
 #define BOOST_UT_DISABLE_MODULE
 #include <boost/ut.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <sstream>
 #include <string>
 
@@ -14,11 +14,6 @@ namespace {
 
 using namespace boost::ut;
 using namespace dao;
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
 
 auto ast_string(const std::filesystem::path& source_path) -> std::string {
   auto contents = read_file(source_path);

--- a/compiler/frontend/lexer/lexer_test.cpp
+++ b/compiler/frontend/lexer/lexer_test.cpp
@@ -1,10 +1,10 @@
 #include "frontend/lexer/lexer.h"
+#include "support/test_utils.h"
 
 #define BOOST_UT_DISABLE_MODULE
 #include <boost/ut.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -12,11 +12,6 @@ namespace {
 
 using namespace boost::ut;
 using namespace dao;
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
 
 // Holds both the source buffer and lex result so string_view tokens
 // remain valid for the lifetime of the returned object.

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -1,11 +1,11 @@
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
+#include "support/test_utils.h"
 
 #define BOOST_UT_DISABLE_MODULE
 #include <boost/ut.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -13,11 +13,6 @@ namespace {
 
 using namespace boost::ut;
 using namespace dao;
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
 
 struct ParseOutput {
   std::unique_ptr<SourceBuffer> source;

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -1,22 +1,17 @@
 #include "frontend/resolve/resolve.h"
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <string>
 
 using namespace boost::ut;
 using namespace dao;
 
 namespace {
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
 
 // Strip a leading `module <path>\n` line from the supplied source, if
 // present. Used when concatenating multiple real Dao files into a

--- a/compiler/support/test_utils.h
+++ b/compiler/support/test_utils.h
@@ -1,0 +1,19 @@
+#ifndef DAO_SUPPORT_TEST_UTILS_H
+#define DAO_SUPPORT_TEST_UTILS_H
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace dao {
+
+/// Read the entire contents of a file into a string.
+/// Shared across test binaries to eliminate copy-pasted helpers.
+inline auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+} // namespace dao
+
+#endif // DAO_SUPPORT_TEST_UTILS_H


### PR DESCRIPTION
## Summary

Extract the identical `read_file` helper from 5 test files into `compiler/support/test_utils.h`. Removes 30 lines of duplication, adds 24 lines (net -6).

## Test plan

- [x] `task test` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)