### PR TITLE
refactor(support): ♻️ deduplicate op_str across AST, HIR, and MIR printers

### DIFF
--- a/compiler/frontend/ast/ast_printer.cpp
+++ b/compiler/frontend/ast/ast_printer.cpp
@@ -1,5 +1,6 @@
 #include "frontend/ast/ast_printer.h"
 
+#include "support/op_str.h"
 #include "support/variant.h"
 
 #include <string>
@@ -406,51 +407,7 @@ private:
   // Expressions
   // -----------------------------------------------------------------------
 
-  static auto binary_op_str(BinaryOp op) -> const char* {
-    switch (op) {
-    case BinaryOp::Add:
-      return "+";
-    case BinaryOp::Sub:
-      return "-";
-    case BinaryOp::Mul:
-      return "*";
-    case BinaryOp::Div:
-      return "/";
-    case BinaryOp::Mod:
-      return "%";
-    case BinaryOp::EqEq:
-      return "==";
-    case BinaryOp::BangEq:
-      return "!=";
-    case BinaryOp::Lt:
-      return "<";
-    case BinaryOp::LtEq:
-      return "<=";
-    case BinaryOp::Gt:
-      return ">";
-    case BinaryOp::GtEq:
-      return ">=";
-    case BinaryOp::And:
-      return "and";
-    case BinaryOp::Or:
-      return "or";
-    }
-    return "?";
-  }
-
-  static auto unary_op_str(UnaryOp op) -> const char* {
-    switch (op) {
-    case UnaryOp::Negate:
-      return "-";
-    case UnaryOp::Not:
-      return "!";
-    case UnaryOp::Deref:
-      return "*";
-    case UnaryOp::AddrOf:
-      return "&";
-    }
-    return "?";
-  }
+  // binary_op_str / unary_op_str: see support/op_str.h
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   void print_expr(const Expr& expr) {

--- a/compiler/ir/hir/hir_printer.cpp
+++ b/compiler/ir/hir/hir_printer.cpp
@@ -1,6 +1,7 @@
 #include "ir/hir/hir_printer.h"
 
 #include "frontend/types/type_printer.h"
+#include "support/op_str.h"
 #include "support/variant.h"
 
 #include <string>
@@ -236,34 +237,7 @@ private:
 
   // --- Expressions ---
 
-  static auto binary_op_str(BinaryOp op) -> const char* {
-    switch (op) {
-    case BinaryOp::Add:    return "+";
-    case BinaryOp::Sub:    return "-";
-    case BinaryOp::Mul:    return "*";
-    case BinaryOp::Div:    return "/";
-    case BinaryOp::Mod:    return "%";
-    case BinaryOp::EqEq:   return "==";
-    case BinaryOp::BangEq: return "!=";
-    case BinaryOp::Lt:     return "<";
-    case BinaryOp::LtEq:   return "<=";
-    case BinaryOp::Gt:     return ">";
-    case BinaryOp::GtEq:   return ">=";
-    case BinaryOp::And:    return "and";
-    case BinaryOp::Or:     return "or";
-    }
-    return "?";
-  }
-
-  static auto unary_op_str(UnaryOp op) -> const char* {
-    switch (op) {
-    case UnaryOp::Negate: return "-";
-    case UnaryOp::Not:    return "!";
-    case UnaryOp::Deref:  return "*";
-    case UnaryOp::AddrOf: return "&";
-    }
-    return "?";
-  }
+  // binary_op_str / unary_op_str: see support/op_str.h
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   void print_expr(const HirExpr& expr) {

--- a/compiler/ir/mir/mir_printer.cpp
+++ b/compiler/ir/mir/mir_printer.cpp
@@ -1,6 +1,7 @@
 #include "ir/mir/mir_printer.h"
 
 #include "frontend/types/type_printer.h"
+#include "support/op_str.h"
 
 namespace dao {
 
@@ -271,34 +272,7 @@ private:
     }
   }
 
-  static auto binary_op_str(BinaryOp op) -> const char* {
-    switch (op) {
-    case BinaryOp::Add:    return "+";
-    case BinaryOp::Sub:    return "-";
-    case BinaryOp::Mul:    return "*";
-    case BinaryOp::Div:    return "/";
-    case BinaryOp::Mod:    return "%";
-    case BinaryOp::EqEq:   return "==";
-    case BinaryOp::BangEq: return "!=";
-    case BinaryOp::Lt:     return "<";
-    case BinaryOp::LtEq:   return "<=";
-    case BinaryOp::Gt:     return ">";
-    case BinaryOp::GtEq:   return ">=";
-    case BinaryOp::And:    return "and";
-    case BinaryOp::Or:     return "or";
-    }
-    return "?";
-  }
-
-  static auto unary_op_str(UnaryOp op) -> const char* {
-    switch (op) {
-    case UnaryOp::Negate: return "-";
-    case UnaryOp::Not:    return "!";
-    case UnaryOp::Deref:  return "*";
-    case UnaryOp::AddrOf: return "&";
-    }
-    return "?";
-  }
+  // binary_op_str / unary_op_str: see support/op_str.h
 };
 
 // NOLINTEND(readability-identifier-length)

--- a/compiler/support/op_str.h
+++ b/compiler/support/op_str.h
@@ -1,0 +1,41 @@
+#ifndef DAO_SUPPORT_OP_STR_H
+#define DAO_SUPPORT_OP_STR_H
+
+#include "frontend/ast/ast.h"
+
+namespace dao {
+
+/// Convert a BinaryOp enum to its source-level string representation.
+inline auto binary_op_str(BinaryOp op) -> const char* {
+  switch (op) {
+  case BinaryOp::Add:    return "+";
+  case BinaryOp::Sub:    return "-";
+  case BinaryOp::Mul:    return "*";
+  case BinaryOp::Div:    return "/";
+  case BinaryOp::Mod:    return "%";
+  case BinaryOp::EqEq:   return "==";
+  case BinaryOp::BangEq: return "!=";
+  case BinaryOp::Lt:     return "<";
+  case BinaryOp::LtEq:   return "<=";
+  case BinaryOp::Gt:     return ">";
+  case BinaryOp::GtEq:   return ">=";
+  case BinaryOp::And:    return "and";
+  case BinaryOp::Or:     return "or";
+  }
+  return "?";
+}
+
+/// Convert a UnaryOp enum to its source-level string representation.
+inline auto unary_op_str(UnaryOp op) -> const char* {
+  switch (op) {
+  case UnaryOp::Negate: return "-";
+  case UnaryOp::Not:    return "!";
+  case UnaryOp::Deref:  return "*";
+  case UnaryOp::AddrOf: return "&";
+  }
+  return "?";
+}
+
+} // namespace dao
+
+#endif // DAO_SUPPORT_OP_STR_H


### PR DESCRIPTION
## Summary

Extract identical `binary_op_str` / `unary_op_str` from 3 printer files into `compiler/support/op_str.h`. Removes ~160 lines of duplication.

## Test plan

- [x] `task test` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)