### PR TITLE
refactor(support): ♻️ consolidate module-stripping and test-wrapping helpers

### DIFF
--- a/compiler/analysis/analysis_test.cpp
+++ b/compiler/analysis/analysis_test.cpp
@@ -6,6 +6,7 @@
 #include "frontend/resolve/resolve.h"
 #include "frontend/typecheck/type_checker.h"
 #include "frontend/types/type_context.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 #include <string>
@@ -14,24 +15,6 @@ using namespace boost::ut;
 using namespace dao;
 
 namespace {
-
-// Test helper: every source file must begin with a `module` declaration
-// per CONTRACT_SYNTAX_SURFACE.md. Fixtures focus on analysis behavior
-// below the module layer, so we prepend a canonical `module test` line
-// and expose a `pipe.at(raw)` helper that rebases raw fixture offsets
-// to the wrapped source. Raw offsets in the fixtures are written as if
-// no wrapper existed; all offset-bearing query calls pass through
-// `pipe.at(...)`.
-inline constexpr const char* kModulePrefix = "module test\n";
-inline constexpr uint32_t kModulePrefixBytes = 12;
-static_assert(kModulePrefixBytes == sizeof("module test\n") - 1,
-              "kModulePrefixBytes must match strlen(kModulePrefix)");
-
-inline auto wrap_with_test_module(std::string_view src) -> std::string {
-  std::string wrapped = kModulePrefix;
-  wrapped.append(src);
-  return wrapped;
-}
 
 struct AnalysisPipeline {
   SourceBuffer source;
@@ -54,7 +37,7 @@ struct AnalysisPipeline {
 
   /// Rebase a raw fixture-relative offset to the wrapped source.
   [[nodiscard]] static auto at(uint32_t raw) -> uint32_t {
-    return raw + kModulePrefixBytes;
+    return raw + kTestModulePrefixBytes;
   }
 };
 

--- a/compiler/analysis/semantic_tokens_test.cpp
+++ b/compiler/analysis/semantic_tokens_test.cpp
@@ -23,16 +23,6 @@ struct ClassifiedSource {
   std::vector<SemanticToken> tokens;
 };
 
-// Test helper: every source file must begin with a `module` declaration
-// per CONTRACT_SYNTAX_SURFACE.md. Inline fixtures in this test file
-// focus on semantic-token behavior below the module layer, so we
-// prepend a canonical `module test` line before lexing.
-auto wrap_with_test_module(std::string contents) -> std::string {
-  std::string wrapped = "module test\n";
-  wrapped.append(contents);
-  return wrapped;
-}
-
 // Classify without resolver (structural + lexical only).
 auto classify_source(const std::string& name, std::string contents) -> ClassifiedSource {
   SourceBuffer source(name, wrap_with_test_module(std::move(contents)));

--- a/compiler/backend/llvm/llvm_backend_test.cpp
+++ b/compiler/backend/llvm/llvm_backend_test.cpp
@@ -11,6 +11,7 @@
 #include "ir/hir/hir_context.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
+#include "support/test_utils.h"
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
@@ -29,15 +30,6 @@ namespace {
 
 // Sentinel declaration identity for testing.
 const int kDeclSentinel = 1;
-
-// Test helper: every source file must begin with a `module` declaration
-// per CONTRACT_SYNTAX_SURFACE.md. Fixtures focus on backend behavior
-// below the module layer, so we prepend a canonical `module test` line.
-inline auto wrap_with_test_module(std::string_view src) -> std::string {
-  std::string wrapped = "module test\n";
-  wrapped.append(src);
-  return wrapped;
-}
 
 /// Full pipeline: source → MIR → LLVM IR.
 struct LlvmTestPipeline {

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -13,6 +13,7 @@
 #include "ir/mir/mir_context.h"
 #include "ir/mir/mir_monomorphize.h"
 #include "ir/mir/mir_printer.h"
+#include "support/module_utils.h"
 
 #include <llvm/IR/LLVMContext.h>
 
@@ -128,52 +129,6 @@ auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
 // so prelude symbols are available without explicit import.
 // ---------------------------------------------------------------------------
 
-// Blank a leading `module <path>` line in place — overwrite the
-// `module` keyword and its path segments with spaces, preserving the
-// terminating newline and total byte count. The transitional driver
-// concatenates stdlib and user sources into a single synthetic
-// compilation unit and injects one top-level `module` declaration of
-// its own; per-file module headers on the inputs would otherwise
-// violate the "exactly one module declaration at the start" rule in
-// CONTRACT_SYNTAX_SURFACE.md. Blanking (rather than stripping)
-// preserves all downstream byte offsets, which keeps spans in error
-// messages pointing at the original source positions. Real
-// multi-file compilation lands with Task 25+.
-void blank_leading_module(std::string& src) {
-  size_t i = 0;
-  // Skip whitespace and `//` line comments until we reach either the
-  // leading `module` keyword or the first non-comment token. Dao only
-  // has `//` line comments (see spec/grammar/dao.ebnf).
-  while (i < src.size()) {
-    char ch = src[i];
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-      ++i;
-      continue;
-    }
-    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
-      auto nl = src.find('\n', i);
-      if (nl == std::string::npos) {
-        return;
-      }
-      i = nl + 1;
-      continue;
-    }
-    break;
-  }
-  if (i + 6 >= src.size() || src.compare(i, 6, "module") != 0) {
-    return;
-  }
-  char after = src[i + 6];
-  if (after != ' ' && after != '\t') {
-    return;
-  }
-  auto nl = src.find('\n', i);
-  auto end = (nl == std::string::npos) ? src.size() : nl;
-  for (size_t j = i; j < end; ++j) {
-    src[j] = ' ';
-  }
-}
-
 auto load_prelude_source() -> std::string {
   std::filesystem::path root(DAO_SOURCE_DIR);
   std::string prelude;
@@ -200,7 +155,7 @@ auto load_prelude_source() -> std::string {
     std::sort(paths.begin(), paths.end());
     for (const auto& p : paths) {
       auto contents = read_file(p);
-      blank_leading_module(contents);
+      dao::blank_leading_module(contents);
       prelude.append(contents);
       prelude += '\n';
     }
@@ -225,7 +180,7 @@ auto lex_and_parse_with_prelude(const std::filesystem::path& path)
   // original file positions. This is transitional until Task 25+
   // introduces real multi-file compilation where each file keeps its
   // own module identity.
-  blank_leading_module(user_source);
+  dao::blank_leading_module(user_source);
 
   // Synthetic leading module declaration for the combined compilation
   // unit. Per CONTRACT_SYNTAX_SURFACE.md every source file must begin

--- a/compiler/frontend/parser/parser_test.cpp
+++ b/compiler/frontend/parser/parser_test.cpp
@@ -31,39 +31,8 @@ struct ParseOutput {
 // `module` declaration (e.g. the module_tests suite) are passed through
 // unchanged so their own module header remains authoritative.
 auto parse_string(std::string_view src) -> ParseOutput {
-  // Skip whitespace and `//` line comments when detecting an existing
-  // leading `module` declaration, to match the comment-aware skip
-  // used by the strip/blank helpers in the driver and playground
-  // (see compiler/driver/main.cpp and
-  // tools/playground/compiler_service/pipeline.cpp). Dao only has
-  // `//` line comments (see spec/grammar/dao.ebnf).
-  auto starts_with_module = [](std::string_view s) {
-    size_t i = 0;
-    while (i < s.size()) {
-      char ch = s[i];
-      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-        ++i;
-        continue;
-      }
-      if (ch == '/' && i + 1 < s.size() && s[i + 1] == '/') {
-        auto nl = s.find('\n', i);
-        if (nl == std::string_view::npos) {
-          return false;
-        }
-        i = nl + 1;
-        continue;
-      }
-      break;
-    }
-    if (i + 6 >= s.size() || s.substr(i, 6) != "module") {
-      return false;
-    }
-    char after = s[i + 6];
-    return after == ' ' || after == '\t';
-  };
-
   std::string wrapped;
-  if (starts_with_module(src)) {
+  if (dao::starts_with_module(src)) {
     wrapped.assign(src);
   } else {
     wrapped = "module test\n";

--- a/compiler/frontend/resolve/resolve_test.cpp
+++ b/compiler/frontend/resolve/resolve_test.cpp
@@ -13,48 +13,6 @@ using namespace dao;
 
 namespace {
 
-// Strip a leading `module <path>\n` line from the supplied source, if
-// present. Used when concatenating multiple real Dao files into a
-// single synthetic test compilation unit — each real file declares its
-// own module per CONTRACT_SYNTAX_SURFACE.md, but the concatenation is
-// treated as one synthetic module for resolver corpus testing.
-auto strip_leading_module(std::string_view src) -> std::string_view {
-  size_t i = 0;
-  // Skip whitespace and `//` line comments until we reach either the
-  // leading `module` keyword or the first non-comment token. Dao only
-  // has `//` line comments (see spec/grammar/dao.ebnf).
-  while (i < src.size()) {
-    char ch = src[i];
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-      ++i;
-      continue;
-    }
-    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
-      auto nl = src.find('\n', i);
-      if (nl == std::string_view::npos) {
-        return src.substr(0, 0);
-      }
-      i = nl + 1;
-      continue;
-    }
-    break;
-  }
-  if (i + 6 >= src.size() || src.substr(i, 6) != "module") {
-    return src;
-  }
-  // Require `module` to be followed by whitespace (not part of an
-  // identifier).
-  char after = src[i + 6];
-  if (after != ' ' && after != '\t') {
-    return src;
-  }
-  auto nl = src.find('\n', i);
-  if (nl == std::string_view::npos) {
-    return src.substr(0, 0);
-  }
-  return src.substr(nl + 1);
-}
-
 struct ResolvedSource {
   SourceBuffer source;
   LexResult lex_result;

--- a/compiler/frontend/typecheck/typecheck_test.cpp
+++ b/compiler/frontend/typecheck/typecheck_test.cpp
@@ -5,6 +5,7 @@
 #include "frontend/typecheck/type_checker.h"
 #include "frontend/types/type_context.h"
 #include "frontend/types/type_printer.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 #include <string>
@@ -15,16 +16,6 @@ using namespace dao;
 // NOLINTBEGIN(readability-magic-numbers)
 
 namespace {
-
-// Test helper: CONTRACT_SYNTAX_SURFACE.md requires every source file to
-// begin with a `module` declaration. The inline fixtures in this test
-// file focus on type-checking behavior below the module layer, so we
-// prepend a canonical `module test` line to the source before lexing.
-auto wrap_with_test_module(std::string_view src) -> std::string {
-  std::string wrapped = "module test\n";
-  wrapped.append(src);
-  return wrapped;
-}
 
 /// Parse, resolve, and typecheck a source string. Returns TypeCheckResult.
 auto check_source(const std::string& source) -> TypeCheckResult {
@@ -51,43 +42,9 @@ auto check_source(const std::string& source) -> TypeCheckResult {
 auto check_with_prelude(const std::string& user_source,
                         std::span<const std::string> prelude_sources)
     -> TypeCheckResult {
-  auto strip_module = [](std::string_view src) -> std::string_view {
-    size_t i = 0;
-    // Skip whitespace and `//` line comments. Dao only has `//` line
-    // comments (see spec/grammar/dao.ebnf).
-    while (i < src.size()) {
-      char ch = src[i];
-      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-        ++i;
-        continue;
-      }
-      if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
-        auto nl = src.find('\n', i);
-        if (nl == std::string_view::npos) {
-          return src.substr(0, 0);
-        }
-        i = nl + 1;
-        continue;
-      }
-      break;
-    }
-    if (i + 6 >= src.size() || src.substr(i, 6) != "module") {
-      return src;
-    }
-    char after = src[i + 6];
-    if (after != ' ' && after != '\t') {
-      return src;
-    }
-    auto nl = src.find('\n', i);
-    if (nl == std::string_view::npos) {
-      return src.substr(0, 0);
-    }
-    return src.substr(nl + 1);
-  };
-
   std::string combined = "module test\n";
   for (const auto& pre : prelude_sources) {
-    combined.append(strip_module(pre));
+    combined.append(strip_leading_module(pre));
     combined += '\n';
   }
   auto prelude_bytes = static_cast<uint32_t>(combined.size());

--- a/compiler/ir/hir/hir_test.cpp
+++ b/compiler/ir/hir/hir_test.cpp
@@ -8,6 +8,7 @@
 #include "ir/hir/hir_builder.h"
 #include "ir/hir/hir_context.h"
 #include "ir/hir/hir_printer.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 #include <sstream>
@@ -19,16 +20,6 @@ using namespace dao;
 // NOLINTBEGIN(readability-magic-numbers)
 
 namespace {
-
-// Test helper: every source file must begin with a `module` declaration
-// per CONTRACT_SYNTAX_SURFACE.md. Fixtures in this test file focus on
-// HIR behavior below the module layer, so we prepend a canonical
-// `module test` line before lexing.
-inline auto wrap_with_test_module(std::string_view src) -> std::string {
-  std::string wrapped = "module test\n";
-  wrapped.append(src);
-  return wrapped;
-}
 
 /// Owns all pipeline state so HIR nodes remain valid.
 struct HirTestPipeline {

--- a/compiler/ir/mir/mir_test.cpp
+++ b/compiler/ir/mir/mir_test.cpp
@@ -9,6 +9,7 @@
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
 #include "ir/mir/mir_printer.h"
+#include "support/test_utils.h"
 
 #include <boost/ut.hpp>
 #include <sstream>
@@ -20,15 +21,6 @@ using namespace dao;
 // NOLINTBEGIN(readability-magic-numbers)
 
 namespace {
-
-// Test helper: every source file must begin with a `module` declaration
-// per CONTRACT_SYNTAX_SURFACE.md. Fixtures focus on MIR behavior below
-// the module layer, so we prepend a canonical `module test` line.
-inline auto wrap_with_test_module(std::string_view src) -> std::string {
-  std::string wrapped = "module test\n";
-  wrapped.append(src);
-  return wrapped;
-}
 
 /// Owns all pipeline state so MIR nodes remain valid.
 struct MirTestPipeline {

--- a/compiler/support/module_utils.h
+++ b/compiler/support/module_utils.h
@@ -1,0 +1,115 @@
+#ifndef DAO_SUPPORT_MODULE_UTILS_H
+#define DAO_SUPPORT_MODULE_UTILS_H
+
+#include <string>
+#include <string_view>
+
+namespace dao {
+
+/// Blank a leading `module <path>` line in place — overwrite the
+/// `module` keyword and path segments with spaces, preserving the
+/// terminating newline and total byte count. Skips leading whitespace
+/// and `//` line comments (Dao's only comment form per
+/// spec/grammar/dao.ebnf). Used by the driver and playground to fold
+/// per-file module headers into a single synthetic `module` declaration
+/// without shifting any byte offsets.
+inline void blank_leading_module(std::string& src) {
+  size_t i = 0;
+  while (i < src.size()) {
+    char ch = src[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      ++i;
+      continue;
+    }
+    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+      auto nl = src.find('\n', i);
+      if (nl == std::string::npos) {
+        return;
+      }
+      i = nl + 1;
+      continue;
+    }
+    break;
+  }
+  if (i + 6 >= src.size() || src.compare(i, 6, "module") != 0) {
+    return;
+  }
+  char after = src[i + 6];
+  if (after != ' ' && after != '\t') {
+    return;
+  }
+  auto nl = src.find('\n', i);
+  auto end = (nl == std::string::npos) ? src.size() : nl;
+  for (size_t j = i; j < end; ++j) {
+    src[j] = ' ';
+  }
+}
+
+/// Strip a leading `module <path>` line (and any preceding blank/comment
+/// lines) from a source snippet. Returns a view past the stripped line.
+/// Same skip logic as blank_leading_module but returns a substring
+/// instead of modifying in place. Used by test helpers that concatenate
+/// prelude sources.
+inline auto strip_leading_module(std::string_view src) -> std::string_view {
+  size_t i = 0;
+  while (i < src.size()) {
+    char ch = src[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      ++i;
+      continue;
+    }
+    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+      auto nl = src.find('\n', i);
+      if (nl == std::string_view::npos) {
+        return src.substr(0, 0);
+      }
+      i = nl + 1;
+      continue;
+    }
+    break;
+  }
+  if (i + 6 >= src.size() || src.substr(i, 6) != "module") {
+    return src;
+  }
+  char after = src[i + 6];
+  if (after != ' ' && after != '\t') {
+    return src;
+  }
+  auto nl = src.find('\n', i);
+  if (nl == std::string_view::npos) {
+    return src.substr(0, 0);
+  }
+  return src.substr(nl + 1);
+}
+
+/// Detect whether source begins with a `module` declaration (after
+/// optional whitespace and `//` comments). Used by test helpers to
+/// decide whether to auto-wrap with `module test`.
+inline auto starts_with_module(std::string_view src) -> bool {
+  size_t i = 0;
+  while (i < src.size()) {
+    char ch = src[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      ++i;
+      continue;
+    }
+    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+      auto nl = src.find('\n', i);
+      if (nl == std::string_view::npos) {
+        return false;
+      }
+      i = nl + 1;
+      continue;
+    }
+    break;
+  }
+  if (i + 6 >= src.size() || src.substr(i, 6) != "module") {
+    return false;
+  }
+  char after = src[i + 6];
+  return after == ' ' || after == '\t';
+}
+
+} // namespace dao
+
+#endif // DAO_SUPPORT_MODULE_UTILS_H

--- a/compiler/support/test_utils.h
+++ b/compiler/support/test_utils.h
@@ -1,9 +1,12 @@
 #ifndef DAO_SUPPORT_TEST_UTILS_H
 #define DAO_SUPPORT_TEST_UTILS_H
 
+#include "support/module_utils.h"
+
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 
 namespace dao {
 
@@ -12,6 +15,22 @@ namespace dao {
 inline auto read_file(const std::filesystem::path& path) -> std::string {
   std::ifstream file(path);
   return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+/// Prefix for the synthetic module declaration injected by test helpers.
+inline constexpr const char* kTestModulePrefix = "module test\n";
+inline constexpr uint32_t kTestModulePrefixBytes = 12;
+
+/// Wrap a test source string with a synthetic `module test` declaration.
+/// Idempotent: sources that already begin with `module` (after optional
+/// whitespace/comments) are returned unchanged.
+inline auto wrap_with_test_module(std::string_view src) -> std::string {
+  if (starts_with_module(src)) {
+    return std::string(src);
+  }
+  std::string wrapped = kTestModulePrefix;
+  wrapped.append(src);
+  return wrapped;
 }
 
 } // namespace dao

--- a/tools/playground/compiler_service/pipeline.cpp
+++ b/tools/playground/compiler_service/pipeline.cpp
@@ -1,66 +1,11 @@
 #include "pipeline.h"
+#include "support/module_utils.h"
 
 #include <algorithm>
 #include <fstream>
 
 namespace dao::playground {
 
-namespace {
-
-// Blank a leading `module <path>` line in place — overwrite the
-// `module` keyword and its path segments with spaces, preserving the
-// terminating newline, total byte count, and all offsets past the
-// blanked region. The transitional playground/driver pipelines
-// concatenate stdlib files and user source into a single synthetic
-// compilation unit with exactly one `module` declaration at the top
-// (the injected header), per CONTRACT_SYNTAX_SURFACE.md. Blanking
-// (rather than stripping) is load-bearing for the playground: frontend
-// editor offsets and backend source offsets must stay byte-identical
-// so hover/goto/completion/references/diagnostics positions line up
-// with the editor buffer the user sees. Real multi-file compilation
-// lands with Task 25+.
-void blank_leading_module(std::string& src) {
-  size_t i = 0;
-  // Skip whitespace and `//` line comments until we reach either the
-  // leading `module` keyword or the first non-comment token. Dao only
-  // has `//` line comments (see spec/grammar/dao.ebnf).
-  while (i < src.size()) {
-    char ch = src[i];
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-      ++i;
-      continue;
-    }
-    if (ch == '/' && i + 1 < src.size() && src[i + 1] == '/') {
-      auto nl = src.find('\n', i);
-      if (nl == std::string::npos) {
-        return;
-      }
-      i = nl + 1;
-      continue;
-    }
-    break;
-  }
-  if (i + 6 >= src.size() || src.compare(i, 6, "module") != 0) {
-    return;
-  }
-  char after = src[i + 6];
-  if (after != ' ' && after != '\t') {
-    return;
-  }
-  auto nl = src.find('\n', i);
-  auto end = (nl == std::string::npos) ? src.size() : nl;
-  for (size_t j = i; j < end; ++j) {
-    src[j] = ' ';
-  }
-}
-
-} // namespace
-
-// Exposed to run.cpp / analyze.cpp so request handlers can blank a
-// user-provided leading `module` header before concatenation without
-// shifting any byte offsets. See the blank_leading_module rationale
-// above for why blanking (not stripping) is required for editor/
-// backend offset alignment.
 void blank_user_leading_module(std::string& src) {
   blank_leading_module(src);
 }


### PR DESCRIPTION
## Summary

Consolidate 5 copies of module-stripping logic and 6 copies of `wrap_with_test_module` into `compiler/support/module_utils.h` and `compiler/support/test_utils.h`. Net -134 lines across 12 files.

## Highlights

- **`module_utils.h`**: `blank_leading_module`, `strip_leading_module`, `starts_with_module` — shared between driver, playground, and test files
- **`test_utils.h`**: `wrap_with_test_module` (idempotent), `kTestModulePrefix`, `kTestModulePrefixBytes`
- Removed local copies from 8 test files, driver/main.cpp, and playground/pipeline.cpp

## Test plan

- [x] `task test` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)