### PR TITLE
refactor(ir): ♻️ unify HirContext and MirContext into shared IrContext

### DIFF
--- a/compiler/ir/hir/hir_context.h
+++ b/compiler/ir/hir/hir_context.h
@@ -1,35 +1,11 @@
 #ifndef DAO_IR_HIR_HIR_CONTEXT_H
 #define DAO_IR_HIR_HIR_CONTEXT_H
 
-#include "ir/hir/hir.h"
-#include "support/arena.h"
-
-#include <utility>
+#include "support/ir_context.h"
 
 namespace dao {
 
-// ---------------------------------------------------------------------------
-// HirContext — arena owner for all HIR nodes.
-// ---------------------------------------------------------------------------
-
-class HirContext {
-public:
-  HirContext() = default;
-  ~HirContext() = default;
-
-  HirContext(const HirContext&) = delete;
-  auto operator=(const HirContext&) -> HirContext& = delete;
-  HirContext(HirContext&&) noexcept = default;
-  auto operator=(HirContext&&) noexcept -> HirContext& = default;
-
-  template <typename T, typename... Args>
-  auto alloc(Args&&... args) -> T* {
-    return arena_.alloc<T>(std::forward<Args>(args)...);
-  }
-
-private:
-  Arena arena_;
-};
+using HirContext = IrContext;
 
 } // namespace dao
 

--- a/compiler/ir/mir/mir_context.h
+++ b/compiler/ir/mir/mir_context.h
@@ -1,34 +1,11 @@
 #ifndef DAO_IR_MIR_MIR_CONTEXT_H
 #define DAO_IR_MIR_MIR_CONTEXT_H
 
-#include "support/arena.h"
-
-#include <utility>
+#include "support/ir_context.h"
 
 namespace dao {
 
-// ---------------------------------------------------------------------------
-// MirContext — arena owner for all MIR nodes.
-// ---------------------------------------------------------------------------
-
-class MirContext {
-public:
-  MirContext() = default;
-  ~MirContext() = default;
-
-  MirContext(const MirContext&) = delete;
-  auto operator=(const MirContext&) -> MirContext& = delete;
-  MirContext(MirContext&&) noexcept = default;
-  auto operator=(MirContext&&) noexcept -> MirContext& = default;
-
-  template <typename T, typename... Args>
-  auto alloc(Args&&... args) -> T* {
-    return arena_.alloc<T>(std::forward<Args>(args)...);
-  }
-
-private:
-  Arena arena_;
-};
+using MirContext = IrContext;
 
 } // namespace dao
 

--- a/compiler/support/ir_context.h
+++ b/compiler/support/ir_context.h
@@ -1,0 +1,33 @@
+#ifndef DAO_SUPPORT_IR_CONTEXT_H
+#define DAO_SUPPORT_IR_CONTEXT_H
+
+#include "support/arena.h"
+
+#include <utility>
+
+namespace dao {
+
+/// Shared arena-owning context for IR nodes (HIR, MIR, or any future IR).
+/// Each context owns an Arena that outlives all nodes allocated through it.
+class IrContext {
+public:
+  IrContext() = default;
+  ~IrContext() = default;
+
+  IrContext(const IrContext&) = delete;
+  auto operator=(const IrContext&) -> IrContext& = delete;
+  IrContext(IrContext&&) noexcept = default;
+  auto operator=(IrContext&&) noexcept -> IrContext& = default;
+
+  template <typename T, typename... Args>
+  auto alloc(Args&&... args) -> T* {
+    return arena_.alloc<T>(std::forward<Args>(args)...);
+  }
+
+private:
+  Arena arena_;
+};
+
+} // namespace dao
+
+#endif // DAO_SUPPORT_IR_CONTEXT_H


### PR DESCRIPTION
## Summary

HirContext and MirContext were identical Arena wrappers. Extract into `compiler/support/ir_context.h` as `IrContext`. Both original headers now contain `using XxxContext = IrContext;`, preserving all include paths. Net -14 lines.

## Test plan

- [x] `task test` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)