### PR TITLE
refactor(typecheck): ⚡️ ConceptSelfMapGuard saves/restores single key instead of full map

### DIFF
--- a/compiler/frontend/typecheck/type_checker.cpp
+++ b/compiler/frontend/typecheck/type_checker.cpp
@@ -2494,7 +2494,7 @@ void TypeChecker::build_method_table(const FileNode& file) {
   for (const auto& [type, concepts] : derived_conformances_) {
     for (const auto* concept_decl : concepts) {
       const auto& cpt = concept_decl->as<ConceptDecl>();
-      ConceptSelfMapGuard guard(concept_self_map_);
+      ConceptSelfMapGuard guard(concept_self_map_, cpt.name);
       concept_self_map_[cpt.name] = type;
       for (const auto* cpt_method_decl : cpt.methods) {
         const auto& method = cpt_method_decl->as<FunctionDecl>();
@@ -2603,7 +2603,7 @@ auto TypeChecker::lookup_method(const Type* obj_type,
           for (const auto* method_decl : cpt.methods) {
             const auto& method = method_decl->as<FunctionDecl>();
             if (method.name == name) {
-              ConceptSelfMapGuard guard(concept_self_map_);
+              ConceptSelfMapGuard guard(concept_self_map_, cpt.name);
               concept_self_map_[cpt.name] = obj_type;
               return build_method_fn_type(method);
             }

--- a/compiler/frontend/typecheck/type_checker.h
+++ b/compiler/frontend/typecheck/type_checker.h
@@ -98,15 +98,33 @@ private:
   // conforming type).
   std::unordered_map<std::string_view, const Type*> concept_self_map_;
 
-  // RAII guard for concept_self_map_ save/restore.
+  // RAII guard that saves and restores a single key in concept_self_map_.
+  // Each guard scope inserts exactly one concept→type binding; on
+  // destruction the prior state of that key is restored. O(1) instead
+  // of copying the entire map.
   struct ConceptSelfMapGuard {
-    std::unordered_map<std::string_view, const Type*>& map;
-    std::unordered_map<std::string_view, const Type*> saved;
-    ConceptSelfMapGuard(std::unordered_map<std::string_view, const Type*>& m) : map(m), saved(m) {
+    using Map = std::unordered_map<std::string_view, const Type*>;
+    Map& map;
+    std::string_view key;
+    const Type* old_value = nullptr;
+    bool had_key = false;
+
+    ConceptSelfMapGuard(Map& m, std::string_view k) : map(m), key(k) { // NOLINT(readability-identifier-length)
+      auto iter = map.find(key);
+      if (iter != map.end()) {
+        had_key = true;
+        old_value = iter->second;
+      }
     }
     ~ConceptSelfMapGuard() {
-      map = saved;
+      if (had_key) {
+        map[key] = old_value;
+      } else {
+        map.erase(key);
+      }
     }
+    ConceptSelfMapGuard(const ConceptSelfMapGuard&) = delete;
+    auto operator=(const ConceptSelfMapGuard&) -> ConceptSelfMapGuard& = delete;
   };
 
   // Pre-built method lookup table: (type*, method_name) -> {fn_type, decl}.


### PR DESCRIPTION
## Summary

ConceptSelfMapGuard copied the entire `concept_self_map_` on construction (O(n)) and restored on destruction. Since each guard scope inserts exactly one key, the guard now saves only that key's prior state. O(1) instead of O(n).

## Test plan

- [x] `task test` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)