### PR TITLE
refactor(driver): extract pipeline stages into driver/pipeline.h

### DIFF
--- a/compiler/driver/CMakeLists.txt
+++ b/compiler/driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(daoc main.cpp)
+add_executable(daoc main.cpp pipeline.cpp)
 target_link_libraries(daoc PRIVATE dao_analysis dao_backend_llvm dao_ir dao_frontend)
 
 # Bake the path to the runtime static library so `daoc build` can link it.

--- a/compiler/driver/main.cpp
+++ b/compiler/driver/main.cpp
@@ -1,29 +1,19 @@
+#include "driver/pipeline.h"
+
 #include "analysis/semantic_tokens.h"
 #include "frontend/ast/ast_printer.h"
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
 #include "frontend/resolve/resolve.h"
-#include "frontend/typecheck/type_checker.h"
-#include "frontend/types/type_context.h"
-#include "ir/hir/hir_builder.h"
-#include "ir/hir/hir_context.h"
-#include "ir/hir/hir_printer.h"
 #include "backend/llvm/llvm_backend.h"
-#include "ir/mir/mir_builder.h"
-#include "ir/mir/mir_context.h"
-#include "ir/mir/mir_monomorphize.h"
+#include "ir/hir/hir_printer.h"
 #include "ir/mir/mir_printer.h"
-#include "support/module_utils.h"
-
-#include <llvm/IR/LLVMContext.h>
 
 #include <llvm/Support/Program.h>
 
-#include <algorithm>
 #include <array>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <span>
 #include <string>
@@ -33,340 +23,13 @@
 namespace {
 
 // ---------------------------------------------------------------------------
-// File I/O
-// ---------------------------------------------------------------------------
-
-auto read_file(const std::filesystem::path& path) -> std::string {
-  std::ifstream file(path);
-  if (!file) {
-    std::cerr << "error: could not open: " << path << "\n";
-    std::exit(EXIT_FAILURE);
-  }
-  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
-}
-
-// ---------------------------------------------------------------------------
-// Diagnostic helpers
-// ---------------------------------------------------------------------------
-
-// Print all diagnostics as errors. Returns true if any were printed.
-auto print_error_diagnostics(std::string_view filename,
-                             const dao::SourceBuffer& source,
-                             std::span<const dao::Diagnostic> diags,
-                             uint32_t line_offset = 0) -> bool {
-  for (const auto& diag : diags) {
-    auto loc = source.line_col(diag.span.offset);
-    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
-    std::cerr << filename << ":" << line << ":" << loc.col
-              << ": error: " << diag.message << "\n";
-  }
-  return !diags.empty();
-}
-
-// Print diagnostics with severity labels. Returns true if any errors.
-auto print_diagnostics(std::string_view filename,
-                       const dao::SourceBuffer& source,
-                       std::span<const dao::Diagnostic> diags,
-                       uint32_t line_offset = 0) -> bool {
-  bool has_errors = false;
-  for (const auto& diag : diags) {
-    auto loc = source.line_col(diag.span.offset);
-    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
-    const auto* severity = diag.severity == dao::Severity::Error ? "error" : "warning";
-    std::cerr << filename << ":" << line << ":" << loc.col
-              << ": " << severity << ": " << diag.message << "\n";
-    if (diag.severity == dao::Severity::Error) {
-      has_errors = true;
-    }
-  }
-  return has_errors;
-}
-
-// ---------------------------------------------------------------------------
-// Pipeline stages
-// ---------------------------------------------------------------------------
-
-struct LexedFile {
-  dao::SourceBuffer source;
-  dao::LexResult lex_result;
-};
-
-auto lex_file(const std::filesystem::path& path) -> LexedFile {
-  auto contents = read_file(path);
-  dao::SourceBuffer source(path.filename().string(), std::move(contents));
-  auto lex_result = dao::lex(source);
-
-  if (print_error_diagnostics(path.filename().string(), source,
-                              lex_result.diagnostics)) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return {.source = std::move(source), .lex_result = std::move(lex_result)};
-}
-
-struct ParsedFile {
-  dao::SourceBuffer source;
-  dao::LexResult lex_result;
-  dao::ParseResult parse_result;
-};
-
-auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
-  auto lexed = lex_file(path);
-  auto parse_result = dao::parse(lexed.lex_result.tokens);
-
-  if (print_error_diagnostics(path.filename().string(), lexed.source,
-                              parse_result.diagnostics)) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return {.source = std::move(lexed.source),
-          .lex_result = std::move(lexed.lex_result),
-          .parse_result = std::move(parse_result)};
-}
-
-// ---------------------------------------------------------------------------
-// Prelude loading — stdlib/core/*.dao source is prepended to user source
-// so prelude symbols are available without explicit import.
-// ---------------------------------------------------------------------------
-
-auto load_prelude_source() -> std::string {
-  std::filesystem::path root(DAO_SOURCE_DIR);
-  std::string prelude;
-
-  // Load stdlib directories in order: core first, then io.
-  // concepts/ is not auto-loaded yet (Iterable needs more infra).
-  const std::filesystem::path dirs[] = {
-      root / "stdlib" / "core",
-      root / "stdlib" / "io",
-  };
-
-  for (const auto& dir : dirs) {
-    if (!std::filesystem::exists(dir)) {
-      continue;
-    }
-    // Collect and sort entries so prelude loading order is stable
-    // and dependency-aware (e.g. option.dao before overflow.dao).
-    std::vector<std::filesystem::path> paths;
-    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-      if (entry.path().extension() == ".dao") {
-        paths.push_back(entry.path());
-      }
-    }
-    std::sort(paths.begin(), paths.end());
-    for (const auto& p : paths) {
-      auto contents = read_file(p);
-      dao::blank_leading_module(contents);
-      prelude.append(contents);
-      prelude += '\n';
-    }
-  }
-  return prelude;
-}
-
-struct PreludeParsedFile {
-  ParsedFile parsed;
-  uint32_t prelude_lines = 0;
-  uint32_t prelude_bytes = 0;
-};
-
-auto lex_and_parse_with_prelude(const std::filesystem::path& path)
-    -> PreludeParsedFile {
-  auto prelude_source = load_prelude_source();
-  auto user_source = read_file(path);
-  // Blank the user file's own `module` header in place; the driver
-  // injects a single synthetic `module main` at the top of the
-  // combined source. Blanking (rather than stripping) preserves user
-  // source byte offsets so diagnostic spans still point at the
-  // original file positions. This is transitional until Task 25+
-  // introduces real multi-file compilation where each file keeps its
-  // own module identity.
-  dao::blank_leading_module(user_source);
-
-  // Synthetic leading module declaration for the combined compilation
-  // unit. Per CONTRACT_SYNTAX_SURFACE.md every source file must begin
-  // with exactly one `module` declaration.
-  const std::string module_header = "module main\n";
-
-  std::string combined;
-  combined.reserve(module_header.size() + prelude_source.size() + user_source.size());
-  combined.append(module_header);
-  combined.append(prelude_source);
-
-  uint32_t prelude_lines = 0;
-  for (char chr : combined) {
-    if (chr == '\n') {
-      ++prelude_lines;
-    }
-  }
-  auto prelude_bytes = static_cast<uint32_t>(combined.size());
-
-  combined.append(user_source);
-  dao::SourceBuffer source(path.filename().string(), std::move(combined));
-  auto lex_result = dao::lex(source);
-
-  if (print_error_diagnostics(path.filename().string(), source,
-                              lex_result.diagnostics, prelude_lines)) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  auto parse_result = dao::parse(lex_result.tokens);
-  if (print_error_diagnostics(path.filename().string(), source,
-                              parse_result.diagnostics, prelude_lines)) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return {.parsed = {.source = std::move(source),
-                     .lex_result = std::move(lex_result),
-                     .parse_result = std::move(parse_result)},
-          .prelude_lines = prelude_lines,
-          .prelude_bytes = prelude_bytes};
-}
-
-struct FrontendResult {
-  ParsedFile parsed;
-  dao::ResolveResult resolve;
-  dao::TypeContext types;
-  dao::TypeCheckResult typecheck;
-  uint32_t prelude_lines = 0;
-  uint32_t prelude_bytes = 0;
-};
-
-// Run lex → parse → resolve → typecheck. Exits on error.
-auto run_frontend(const std::filesystem::path& path) -> FrontendResult {
-  auto preparsed = lex_and_parse_with_prelude(path);
-
-  if (preparsed.parsed.parse_result.file == nullptr) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  auto filename = path.filename().string();
-  auto resolve_result = dao::resolve(*preparsed.parsed.parse_result.file,
-                                     preparsed.prelude_bytes);
-  bool has_errors = print_error_diagnostics(
-      filename, preparsed.parsed.source, resolve_result.diagnostics,
-      preparsed.prelude_lines);
-
-  dao::TypeContext types;
-  auto check_result = dao::typecheck(*preparsed.parsed.parse_result.file,
-                                     resolve_result, types);
-  has_errors |= print_diagnostics(filename, preparsed.parsed.source,
-                                  check_result.diagnostics,
-                                  preparsed.prelude_lines);
-
-  if (has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return {.parsed = std::move(preparsed.parsed),
-          .resolve = std::move(resolve_result),
-          .types = std::move(types),
-          .typecheck = std::move(check_result),
-          .prelude_lines = preparsed.prelude_lines,
-          .prelude_bytes = preparsed.prelude_bytes};
-}
-
-struct HirResult {
-  FrontendResult frontend;
-  dao::HirContext hir_ctx;
-  dao::HirBuildResult hir;
-};
-
-auto run_through_hir(const std::filesystem::path& path) -> HirResult {
-  auto frontend = run_frontend(path);
-  dao::HirContext hir_ctx;
-  auto hir = dao::build_hir(*frontend.parsed.parse_result.file,
-                            frontend.resolve, frontend.typecheck, hir_ctx);
-
-  auto filename = path.filename().string();
-  bool has_errors = print_error_diagnostics(filename, frontend.parsed.source,
-                                            hir.diagnostics,
-                                            frontend.prelude_lines);
-
-  if (hir.module == nullptr || has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return {.frontend = std::move(frontend),
-          .hir_ctx = std::move(hir_ctx),
-          .hir = std::move(hir)};
-}
-
-struct MirResult {
-  HirResult hir_result;
-  dao::MirContext mir_ctx;
-  dao::MirBuildResult mir;
-};
-
-auto run_through_mir(const std::filesystem::path& path) -> MirResult {
-  auto hir_result = run_through_hir(path);
-  dao::MirContext mir_ctx;
-  auto mir = dao::build_mir(*hir_result.hir.module, mir_ctx,
-                            hir_result.frontend.types);
-
-  auto filename = path.filename().string();
-  bool has_errors = print_error_diagnostics(
-      filename, hir_result.frontend.parsed.source, mir.diagnostics,
-      hir_result.frontend.prelude_lines);
-
-  if (mir.module == nullptr || has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  // Monomorphize generic functions before LLVM lowering.
-  auto mono_result =
-      dao::monomorphize(*mir.module, mir_ctx, hir_result.frontend.types);
-  if (!mono_result.diagnostics.empty()) {
-    print_error_diagnostics(filename, hir_result.frontend.parsed.source,
-                            mono_result.diagnostics,
-                            hir_result.frontend.prelude_lines);
-  }
-
-  return {.hir_result = std::move(hir_result),
-          .mir_ctx = std::move(mir_ctx),
-          .mir = std::move(mir)};
-}
-
-// Lower MIR to LLVM IR, check diagnostics, and exit on error.
-auto lower_to_llvm(const MirResult& mir, llvm::LLVMContext& llvm_ctx,
-                   const std::filesystem::path& path) -> dao::LlvmBackendResult {
-  dao::LlvmBackend backend(llvm_ctx);
-  auto result = backend.lower(*mir.mir.module,
-                               mir.hir_result.frontend.prelude_bytes);
-
-  // Filter out prelude-origin warnings — they are expected (e.g. range's
-  // generator return type can't be lowered yet) and not actionable by
-  // the user. Prelude errors were already downgraded to warnings by the
-  // backend, so any warning in the prelude region is safe to suppress.
-  auto prelude_bytes = mir.hir_result.frontend.prelude_bytes;
-  std::vector<dao::Diagnostic> user_diags;
-  for (const auto& diag : result.diagnostics) {
-    if (diag.severity == dao::Severity::Warning &&
-        diag.span.offset < prelude_bytes) {
-      continue;
-    }
-    user_diags.push_back(diag);
-  }
-
-  auto filename = path.filename().string();
-  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
-                                      user_diags,
-                                      mir.hir_result.frontend.prelude_lines);
-
-  if (result.module == nullptr || has_errors) {
-    std::exit(EXIT_FAILURE);
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
 // Command handlers
 // ---------------------------------------------------------------------------
 
 // Debug-only token dump. Output format is not stable and must not be
 // relied upon by tests, tooling, or documentation.
 void cmd_lex(const std::filesystem::path& path) {
-  auto contents = read_file(path);
+  auto contents = dao::read_file(path);
   dao::SourceBuffer source(path.filename().string(), std::move(contents));
   auto result = dao::lex(source);
 
@@ -384,7 +47,7 @@ void cmd_lex(const std::filesystem::path& path) {
     std::cout << "\n";
   }
 
-  if (print_error_diagnostics(path.filename().string(), source,
+  if (dao::print_error_diagnostics(path.filename().string(), source,
                               result.diagnostics)) {
     std::exit(EXIT_FAILURE);
   }
@@ -392,7 +55,7 @@ void cmd_lex(const std::filesystem::path& path) {
 
 // Debug-only parse diagnostic dump. Output format is not stable.
 void cmd_parse(const std::filesystem::path& path) {
-  auto result = lex_and_parse(path);
+  auto result = dao::lex_and_parse(path);
   if (result.parse_result.file != nullptr) {
     std::cout << "File: " << result.parse_result.file->imports.size() << " imports, "
               << result.parse_result.file->declarations.size() << " declarations\n";
@@ -401,7 +64,7 @@ void cmd_parse(const std::filesystem::path& path) {
 
 // Pretty-print AST. Output is deterministic and suitable for golden-file testing.
 void cmd_ast(const std::filesystem::path& path) {
-  auto result = lex_and_parse(path);
+  auto result = dao::lex_and_parse(path);
   if (result.parse_result.file != nullptr) {
     dao::print_ast(std::cout, *result.parse_result.file);
   }
@@ -409,7 +72,7 @@ void cmd_ast(const std::filesystem::path& path) {
 
 // Emit semantic token classification. Output is deterministic.
 void cmd_tokens(const std::filesystem::path& path) {
-  auto result = lex_and_parse_with_prelude(path);
+  auto result = dao::lex_and_parse_with_prelude(path);
 
   // Run name resolution for resolve-driven classifications.
   dao::ResolveResult resolve_result;
@@ -435,7 +98,7 @@ void cmd_tokens(const std::filesystem::path& path) {
 
 // Run name resolution and print results.
 void cmd_resolve(const std::filesystem::path& path) {
-  auto result = lex_and_parse_with_prelude(path);
+  auto result = dao::lex_and_parse_with_prelude(path);
   if (result.parsed.parse_result.file == nullptr) {
     return;
   }
@@ -483,7 +146,7 @@ void cmd_resolve(const std::filesystem::path& path) {
     std::cout << "\n";
   }
 
-  // Print diagnostics in user region (to stdout — this is a debug dump command).
+  // Print diagnostics in user region (to stdout -- this is a debug dump command).
   bool has_user_diags = false;
   for (const auto& diag : resolve_result.diagnostics) {
     if (diag.span.offset < result.prelude_bytes) {
@@ -502,13 +165,13 @@ void cmd_resolve(const std::filesystem::path& path) {
 
 // Run type checking and print diagnostics.
 void cmd_check(const std::filesystem::path& path) {
-  run_frontend(path);
+  dao::run_frontend(path);
   std::cout << "ok\n";
 }
 
 // Build and print HIR. Output is deterministic.
 void cmd_hir(const std::filesystem::path& path) {
-  auto result = run_through_hir(path);
+  auto result = dao::run_through_hir(path);
   if (result.hir.module != nullptr) {
     dao::print_hir(std::cout, *result.hir.module);
   }
@@ -516,7 +179,7 @@ void cmd_hir(const std::filesystem::path& path) {
 
 // Build and print MIR. Output is deterministic.
 void cmd_mir(const std::filesystem::path& path) {
-  auto result = run_through_mir(path);
+  auto result = dao::run_through_mir(path);
   if (result.mir.module != nullptr) {
     dao::print_mir(std::cout, *result.mir.module);
   }
@@ -528,9 +191,9 @@ void cmd_llvm_ir(const std::filesystem::path& path) {
   // for ABI-sensitive lowering (struct coercion, alignment).
   dao::LlvmBackend::initialize_targets();
 
-  auto mir = run_through_mir(path);
+  auto mir = dao::run_through_mir(path);
   llvm::LLVMContext llvm_ctx;
-  auto llvm_result = lower_to_llvm(mir, llvm_ctx, path);
+  auto llvm_result = dao::lower_to_llvm(mir, llvm_ctx, path);
   dao::LlvmBackend::print_ir(std::cout, *llvm_result.module);
 }
 
@@ -543,9 +206,9 @@ void cmd_build(const std::filesystem::path& path,
   // DataLayout for ABI-sensitive struct coercion.
   dao::LlvmBackend::initialize_targets();
 
-  auto mir = run_through_mir(path);
+  auto mir = dao::run_through_mir(path);
   llvm::LLVMContext llvm_ctx;
-  auto llvm_result = lower_to_llvm(mir, llvm_ctx, path);
+  auto llvm_result = dao::lower_to_llvm(mir, llvm_ctx, path);
 
   auto obj_path = std::filesystem::temp_directory_path() /
                   (path.stem().string() + ".o");
@@ -556,7 +219,7 @@ void cmd_build(const std::filesystem::path& path,
     std::exit(EXIT_FAILURE);
   }
 
-  // Link with system cc: object + runtime library → executable.
+  // Link with system cc: object + runtime library -> executable.
   auto output_path = path.parent_path() / path.stem();
 
   auto cc_path = llvm::sys::findProgramByName("cc");
@@ -567,7 +230,7 @@ void cmd_build(const std::filesystem::path& path,
     std::exit(EXIT_FAILURE);
   }
 
-  // StringRef does not own data — keep string temporaries alive.
+  // StringRef does not own data -- keep string temporaries alive.
   auto obj_str = obj_path.string();
   auto out_str = output_path.string();
   std::vector<llvm::StringRef> args = {
@@ -651,7 +314,7 @@ auto main(int argc, char* argv[]) -> int {
     }
   }
 
-  // build — accepts extra link inputs after the source file.
+  // build -- accepts extra link inputs after the source file.
   if (arg1 == "build") {
     if (argc < 3) {
       std::cerr << "usage: daoc build <file> [link-inputs...]\n";
@@ -670,12 +333,12 @@ auto main(int argc, char* argv[]) -> int {
     return EXIT_SUCCESS;
   }
 
-  // daoc <file> — read and exit (Task 0 compat)
+  // daoc <file> -- read and exit (Task 0 compat)
   std::filesystem::path path(arg1);
   if (!std::filesystem::exists(path)) {
     std::cerr << "error: file not found: " << path << "\n";
     return EXIT_FAILURE;
   }
-  read_file(path);
+  dao::read_file(path);
   return EXIT_SUCCESS;
 }

--- a/compiler/driver/pipeline.cpp
+++ b/compiler/driver/pipeline.cpp
@@ -1,0 +1,283 @@
+#include "driver/pipeline.h"
+
+#include "ir/hir/hir_builder.h"
+#include "ir/mir/mir_builder.h"
+#include "ir/mir/mir_monomorphize.h"
+#include "support/module_utils.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+auto read_file(const std::filesystem::path& path) -> std::string {
+  std::ifstream file(path);
+  if (!file) {
+    std::cerr << "error: could not open: " << path << "\n";
+    std::exit(EXIT_FAILURE);
+  }
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic helpers
+// ---------------------------------------------------------------------------
+
+auto print_error_diagnostics(std::string_view filename,
+                             const SourceBuffer& source,
+                             std::span<const Diagnostic> diags,
+                             uint32_t line_offset) -> bool {
+  for (const auto& diag : diags) {
+    auto loc = source.line_col(diag.span.offset);
+    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
+    std::cerr << filename << ":" << line << ":" << loc.col
+              << ": error: " << diag.message << "\n";
+  }
+  return !diags.empty();
+}
+
+auto print_diagnostics(std::string_view filename,
+                       const SourceBuffer& source,
+                       std::span<const Diagnostic> diags,
+                       uint32_t line_offset) -> bool {
+  bool has_errors = false;
+  for (const auto& diag : diags) {
+    auto loc = source.line_col(diag.span.offset);
+    auto line = loc.line > line_offset ? loc.line - line_offset : loc.line;
+    const auto* severity = diag.severity == Severity::Error ? "error" : "warning";
+    std::cerr << filename << ":" << line << ":" << loc.col
+              << ": " << severity << ": " << diag.message << "\n";
+    if (diag.severity == Severity::Error) {
+      has_errors = true;
+    }
+  }
+  return has_errors;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stages
+// ---------------------------------------------------------------------------
+
+auto lex_file(const std::filesystem::path& path) -> LexedFile {
+  auto contents = read_file(path);
+  SourceBuffer source(path.filename().string(), std::move(contents));
+  auto lex_result = lex(source);
+
+  if (print_error_diagnostics(path.filename().string(), source,
+                              lex_result.diagnostics)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.source = std::move(source), .lex_result = std::move(lex_result)};
+}
+
+auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile {
+  auto lexed = lex_file(path);
+  auto parse_result = parse(lexed.lex_result.tokens);
+
+  if (print_error_diagnostics(path.filename().string(), lexed.source,
+                              parse_result.diagnostics)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.source = std::move(lexed.source),
+          .lex_result = std::move(lexed.lex_result),
+          .parse_result = std::move(parse_result)};
+}
+
+// ---------------------------------------------------------------------------
+// Prelude loading
+// ---------------------------------------------------------------------------
+
+auto load_prelude_source() -> std::string {
+  std::filesystem::path root(DAO_SOURCE_DIR);
+  std::string prelude;
+
+  const std::filesystem::path dirs[] = {
+      root / "stdlib" / "core",
+      root / "stdlib" / "io",
+  };
+
+  for (const auto& dir : dirs) {
+    if (!std::filesystem::exists(dir)) {
+      continue;
+    }
+    std::vector<std::filesystem::path> paths;
+    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+      if (entry.path().extension() == ".dao") {
+        paths.push_back(entry.path());
+      }
+    }
+    std::sort(paths.begin(), paths.end());
+    for (const auto& p : paths) {
+      auto contents = read_file(p);
+      blank_leading_module(contents);
+      prelude.append(contents);
+      prelude += '\n';
+    }
+  }
+  return prelude;
+}
+
+auto lex_and_parse_with_prelude(const std::filesystem::path& path)
+    -> PreludeParsedFile {
+  auto prelude_source = load_prelude_source();
+  auto user_source = read_file(path);
+  blank_leading_module(user_source);
+
+  const std::string module_header = "module main\n";
+
+  std::string combined;
+  combined.reserve(module_header.size() + prelude_source.size() + user_source.size());
+  combined.append(module_header);
+  combined.append(prelude_source);
+
+  uint32_t prelude_lines = 0;
+  for (char chr : combined) {
+    if (chr == '\n') {
+      ++prelude_lines;
+    }
+  }
+  auto prelude_bytes = static_cast<uint32_t>(combined.size());
+
+  combined.append(user_source);
+  SourceBuffer source(path.filename().string(), std::move(combined));
+  auto lex_result = lex(source);
+
+  if (print_error_diagnostics(path.filename().string(), source,
+                              lex_result.diagnostics, prelude_lines)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  auto parse_result = parse(lex_result.tokens);
+  if (print_error_diagnostics(path.filename().string(), source,
+                              parse_result.diagnostics, prelude_lines)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.parsed = {.source = std::move(source),
+                     .lex_result = std::move(lex_result),
+                     .parse_result = std::move(parse_result)},
+          .prelude_lines = prelude_lines,
+          .prelude_bytes = prelude_bytes};
+}
+
+auto run_frontend(const std::filesystem::path& path) -> FrontendResult {
+  auto preparsed = lex_and_parse_with_prelude(path);
+
+  if (preparsed.parsed.parse_result.file == nullptr) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  auto filename = path.filename().string();
+  auto resolve_result = resolve(*preparsed.parsed.parse_result.file,
+                                preparsed.prelude_bytes);
+  bool has_errors = print_error_diagnostics(
+      filename, preparsed.parsed.source, resolve_result.diagnostics,
+      preparsed.prelude_lines);
+
+  TypeContext types;
+  auto check_result = typecheck(*preparsed.parsed.parse_result.file,
+                                resolve_result, types);
+  has_errors |= print_diagnostics(filename, preparsed.parsed.source,
+                                  check_result.diagnostics,
+                                  preparsed.prelude_lines);
+
+  if (has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.parsed = std::move(preparsed.parsed),
+          .resolve = std::move(resolve_result),
+          .types = std::move(types),
+          .typecheck = std::move(check_result),
+          .prelude_lines = preparsed.prelude_lines,
+          .prelude_bytes = preparsed.prelude_bytes};
+}
+
+auto run_through_hir(const std::filesystem::path& path) -> HirResult {
+  auto frontend = run_frontend(path);
+  HirContext hir_ctx;
+  auto hir = build_hir(*frontend.parsed.parse_result.file,
+                       frontend.resolve, frontend.typecheck, hir_ctx);
+
+  auto filename = path.filename().string();
+  bool has_errors = print_error_diagnostics(filename, frontend.parsed.source,
+                                            hir.diagnostics,
+                                            frontend.prelude_lines);
+
+  if (hir.module == nullptr || has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return {.frontend = std::move(frontend),
+          .hir_ctx = std::move(hir_ctx),
+          .hir = std::move(hir)};
+}
+
+auto run_through_mir(const std::filesystem::path& path) -> MirResult {
+  auto hir_result = run_through_hir(path);
+  MirContext mir_ctx;
+  auto mir = build_mir(*hir_result.hir.module, mir_ctx,
+                       hir_result.frontend.types);
+
+  auto filename = path.filename().string();
+  bool has_errors = print_error_diagnostics(
+      filename, hir_result.frontend.parsed.source, mir.diagnostics,
+      hir_result.frontend.prelude_lines);
+
+  if (mir.module == nullptr || has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  auto mono_result =
+      monomorphize(*mir.module, mir_ctx, hir_result.frontend.types);
+  if (!mono_result.diagnostics.empty()) {
+    print_error_diagnostics(filename, hir_result.frontend.parsed.source,
+                            mono_result.diagnostics,
+                            hir_result.frontend.prelude_lines);
+  }
+
+  return {.hir_result = std::move(hir_result),
+          .mir_ctx = std::move(mir_ctx),
+          .mir = std::move(mir)};
+}
+
+auto lower_to_llvm(const MirResult& mir, llvm::LLVMContext& llvm_ctx,
+                   const std::filesystem::path& path) -> LlvmBackendResult {
+  LlvmBackend backend(llvm_ctx);
+  auto result = backend.lower(*mir.mir.module,
+                               mir.hir_result.frontend.prelude_bytes);
+
+  auto prelude_bytes = mir.hir_result.frontend.prelude_bytes;
+  std::vector<Diagnostic> user_diags;
+  for (const auto& diag : result.diagnostics) {
+    if (diag.severity == Severity::Warning &&
+        diag.span.offset < prelude_bytes) {
+      continue;
+    }
+    user_diags.push_back(diag);
+  }
+
+  auto filename = path.filename().string();
+  bool has_errors = print_diagnostics(filename, mir.hir_result.frontend.parsed.source,
+                                      user_diags,
+                                      mir.hir_result.frontend.prelude_lines);
+
+  if (result.module == nullptr || has_errors) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return result;
+}
+
+} // namespace dao

--- a/compiler/driver/pipeline.h
+++ b/compiler/driver/pipeline.h
@@ -1,0 +1,106 @@
+#ifndef DAO_DRIVER_PIPELINE_H
+#define DAO_DRIVER_PIPELINE_H
+
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+#include "frontend/resolve/resolve.h"
+#include "frontend/typecheck/type_checker.h"
+#include "frontend/types/type_context.h"
+#include "ir/hir/hir_builder.h"
+#include "ir/hir/hir_context.h"
+#include "ir/mir/mir_builder.h"
+#include "ir/mir/mir_context.h"
+#include "backend/llvm/llvm_backend.h"
+
+#include <llvm/IR/LLVMContext.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace dao {
+
+// ---------------------------------------------------------------------------
+// Diagnostic helpers
+// ---------------------------------------------------------------------------
+
+// Print all diagnostics as errors. Returns true if any were printed.
+auto print_error_diagnostics(std::string_view filename,
+                             const SourceBuffer& source,
+                             std::span<const Diagnostic> diags,
+                             uint32_t line_offset = 0) -> bool;
+
+// Print diagnostics with severity labels. Returns true if any errors.
+auto print_diagnostics(std::string_view filename,
+                       const SourceBuffer& source,
+                       std::span<const Diagnostic> diags,
+                       uint32_t line_offset = 0) -> bool;
+
+// ---------------------------------------------------------------------------
+// Pipeline result structs
+// ---------------------------------------------------------------------------
+
+struct LexedFile {
+  SourceBuffer source;
+  LexResult lex_result;
+};
+
+struct ParsedFile {
+  SourceBuffer source;
+  LexResult lex_result;
+  ParseResult parse_result;
+};
+
+struct PreludeParsedFile {
+  ParsedFile parsed;
+  uint32_t prelude_lines = 0;
+  uint32_t prelude_bytes = 0;
+};
+
+struct FrontendResult {
+  ParsedFile parsed;
+  ResolveResult resolve;
+  TypeContext types;
+  TypeCheckResult typecheck;
+  uint32_t prelude_lines = 0;
+  uint32_t prelude_bytes = 0;
+};
+
+struct HirResult {
+  FrontendResult frontend;
+  HirContext hir_ctx;
+  HirBuildResult hir;
+};
+
+struct MirResult {
+  HirResult hir_result;
+  MirContext mir_ctx;
+  MirBuildResult mir;
+};
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+auto read_file(const std::filesystem::path& path) -> std::string;
+
+// ---------------------------------------------------------------------------
+// Pipeline stage functions
+// ---------------------------------------------------------------------------
+
+auto lex_file(const std::filesystem::path& path) -> LexedFile;
+auto lex_and_parse(const std::filesystem::path& path) -> ParsedFile;
+auto load_prelude_source() -> std::string;
+auto lex_and_parse_with_prelude(const std::filesystem::path& path)
+    -> PreludeParsedFile;
+auto run_frontend(const std::filesystem::path& path) -> FrontendResult;
+auto run_through_hir(const std::filesystem::path& path) -> HirResult;
+auto run_through_mir(const std::filesystem::path& path) -> MirResult;
+auto lower_to_llvm(const MirResult& mir, llvm::LLVMContext& llvm_ctx,
+                   const std::filesystem::path& path) -> LlvmBackendResult;
+
+} // namespace dao
+
+#endif // DAO_DRIVER_PIPELINE_H


### PR DESCRIPTION
## Summary
- Extract pipeline result structs (`LexedFile`, `ParsedFile`, `PreludeParsedFile`, `FrontendResult`, `HirResult`, `MirResult`), pipeline functions (`lex_file`, `lex_and_parse`, `load_prelude_source`, `lex_and_parse_with_prelude`, `run_frontend`, `run_through_hir`, `run_through_mir`, `lower_to_llvm`), diagnostic helpers (`print_error_diagnostics`, `print_diagnostics`), and `read_file` from `main.cpp` into `driver/pipeline.h` / `driver/pipeline.cpp`
- Move extracted functions from anonymous namespace to `namespace dao`; `cmd_*` functions in `main.cpp` now call `dao::` qualified pipeline functions
- Remove local `read_file` duplicate from `main.cpp` in favor of the one in `pipeline.cpp` (the `support/test_utils.h` version lacks error handling so is not suitable for the driver)

## Test plan
- [x] `DAO_BUILD_JOBS=4 task test` passes 12/12 tests
- [x] No behavior change -- pure file-level decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)