### PR TITLE
feat(compiler): 🏗️ enforce generic body lowering boundary (Task 28)

### DIFF
--- a/compiler/backend/llvm/llvm_type_lowering.cpp
+++ b/compiler/backend/llvm/llvm_type_lowering.cpp
@@ -96,6 +96,20 @@ auto LlvmTypeLowering::lower(const Type* type) -> llvm::Type* {
       if (variant.payload_types.empty()) {
         continue;
       }
+      // Skip variants whose payload types contain unresolved generic
+      // parameters — these are templates (e.g. Option<T>), not concrete
+      // types.  Concrete instantiations (Option<i32>) will have real
+      // payload types that can be lowered.
+      bool has_generic_payload = false;
+      for (const auto* pt : variant.payload_types) {
+        if (pt != nullptr && pt->kind() == TypeKind::GenericParam) {
+          has_generic_payload = true;
+          break;
+        }
+      }
+      if (has_generic_payload) {
+        continue;
+      }
       std::vector<llvm::Type*> field_types;
       for (const auto* pt : variant.payload_types) {
         auto* lt = lower(pt);

--- a/compiler/driver/pipeline.cpp
+++ b/compiler/driver/pipeline.cpp
@@ -240,7 +240,8 @@ auto run_through_mir(const std::filesystem::path& path) -> MirResult {
   }
 
   auto mono_result =
-      monomorphize(*mir.module, mir_ctx, hir_result.frontend.types);
+      monomorphize(*mir.module, mir_ctx, hir_result.frontend.types,
+                   mir.generic_templates);
   if (!mono_result.diagnostics.empty()) {
     print_error_diagnostics(filename, hir_result.frontend.parsed.source,
                             mono_result.diagnostics,

--- a/compiler/ir/hir/hir.h
+++ b/compiler/ir/hir/hir.h
@@ -50,6 +50,7 @@ struct HirFunction {
   const Type* return_type;
   std::vector<HirStmt*> body;
   bool is_extern;
+  bool has_type_params = false; // true if the AST declaration has own type params
 };
 
 struct HirClassDecl {

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -123,7 +123,8 @@ auto HirBuilder::lower_function(const Decl* decl) -> HirDecl* {
   return ctx_.alloc<HirDecl>(
       decl->span,
       HirFunction{sym, std::move(hir_params), ret_type,
-                  std::move(hir_body), fn.is_extern});
+                  std::move(hir_body), fn.is_extern,
+                  /*has_type_params=*/!fn.type_params.empty()});
 }
 
 auto HirBuilder::lower_class(const Decl* decl) -> HirDecl* {

--- a/compiler/ir/hir/hir_builder.cpp
+++ b/compiler/ir/hir/hir_builder.cpp
@@ -620,17 +620,15 @@ auto HirBuilder::lower_expr(const Expr* expr) -> HirExpr* {
         }
         // Concept method on a generic type parameter: no concrete
         // symbol exists because concept methods don't have resolver
-        // symbols (only concrete extend methods do). Falls through to
-        // the normal call path, which lowers the FieldExpr callee as
-        // an HirField. The MIR builder tolerates this by suppressing
-        // "unresolved field" errors for non-struct receivers.
+        // symbols (only concrete extend methods do).  Falls through
+        // to the normal call path, which lowers the FieldExpr callee
+        // as an HirField.
         //
-        // WORKAROUND: The proper fix is to not lower uninstantiated
-        // generic function bodies to MIR at all (option 1 from the
-        // Task 27 plan). That requires a phase-boundary change where
-        // generic bodies are only lowered during monomorphization.
-        // Until then, concept method calls on generic params produce
-        // placeholder MIR that is never executed.
+        // The MIR builder lowers this into a generic template body
+        // (not the main module).  The unresolved field access is
+        // tolerated during template lowering and resolved when the
+        // monomorphizer clones and specializes the function with
+        // concrete type arguments (Task 28).
       }
     }
 

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -1,5 +1,6 @@
 #include "ir/mir/mir_builder.h"
 
+#include "frontend/types/type.h"
 #include "frontend/types/type_printer.h"
 #include "support/variant.h"
 
@@ -67,6 +68,74 @@ void MirBuilder::emit_terminator(Span span, MirPayload payload) {
 }
 
 // ---------------------------------------------------------------------------
+// Generic detection — check if an HirFunction has unresolved generic
+// parameter types in its signature (params or return type).
+// ---------------------------------------------------------------------------
+
+namespace {
+
+auto type_has_generic_param(const Type* type) -> bool {
+  if (type == nullptr) {
+    return false;
+  }
+  switch (type->kind()) {
+  case TypeKind::GenericParam:
+    return true;
+  case TypeKind::Function: {
+    const auto* fn_type = static_cast<const TypeFunction*>(type);
+    for (const auto* param : fn_type->param_types()) {
+      if (type_has_generic_param(param)) {
+        return true;
+      }
+    }
+    return type_has_generic_param(fn_type->return_type());
+  }
+  case TypeKind::Pointer:
+    return type_has_generic_param(
+        static_cast<const TypePointer*>(type)->pointee());
+  case TypeKind::Generator:
+    return type_has_generic_param(
+        static_cast<const TypeGenerator*>(type)->yield_type());
+  case TypeKind::Struct: {
+    const auto* str = static_cast<const TypeStruct*>(type);
+    for (const auto& field : str->fields()) {
+      if (type_has_generic_param(field.type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  case TypeKind::Enum: {
+    const auto* enm = static_cast<const TypeEnum*>(type);
+    for (const auto& variant : enm->variants()) {
+      for (const auto* payload : variant.payload_types) {
+        if (type_has_generic_param(payload)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+  default:
+    return false;
+  }
+}
+
+auto hir_function_is_generic(const HirFunction& fn) -> bool {
+  if (type_has_generic_param(fn.return_type)) {
+    return true;
+  }
+  for (const auto& param : fn.params) {
+    if (type_has_generic_param(param.type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
 // Top-level
 // ---------------------------------------------------------------------------
 
@@ -74,18 +143,39 @@ auto MirBuilder::build(const HirModule& module) -> MirBuildResult {
   auto* mir_mod = ctx_.alloc<MirModule>();
   mir_mod->span = module.span;
   current_module_ = mir_mod;
+  generic_templates_.clear();
 
   for (const auto* decl : module.declarations) {
     if (decl->is<HirFunction>()) {
-      auto* mir_fn = lower_function(decl->as<HirFunction>(), decl->span);
-      if (mir_fn != nullptr) {
-        mir_mod->functions.push_back(mir_fn);
+      const auto& hir_fn = decl->as<HirFunction>();
+
+      if (hir_function_is_generic(hir_fn)) {
+        // Generic function: lower body into a template for the
+        // monomorphizer to clone from, but do NOT add to the module's
+        // function list.  The lowering_generic_template_ flag gates
+        // tolerance for unresolved field accesses on generic type
+        // parameters (concept method calls like x.to_string() where
+        // x: T: Printable).
+        lowering_generic_template_ = true;
+        auto* mir_fn = lower_function(hir_fn, decl->span);
+        lowering_generic_template_ = false;
+        if (mir_fn != nullptr && mir_fn->symbol != nullptr) {
+          generic_templates_[mir_fn->symbol] = mir_fn;
+        }
+      } else {
+        // Monomorphic function: lower normally into the module.
+        auto* mir_fn = lower_function(hir_fn, decl->span);
+        if (mir_fn != nullptr) {
+          mir_mod->functions.push_back(mir_fn);
+        }
       }
     }
     // ClassDecl: no MIR function to produce; skip.
   }
 
-  return {.module = mir_mod, .diagnostics = std::move(diagnostics_)};
+  return {.module = mir_mod,
+          .diagnostics = std::move(diagnostics_),
+          .generic_templates = std::move(generic_templates_)};
 }
 
 // ---------------------------------------------------------------------------
@@ -516,14 +606,16 @@ auto MirBuilder::lower_expr_value(const HirExpr& expr) -> MirValueId {
         auto obj = lower_expr_value(*field.object);
         auto field_idx = resolve_field_index(field.object->type, field.field_name);
         if (!field_idx) {
-          // For concept method access on generic type parameters (e.g.,
-          // x.to_string() where x: T: Printable), there is no struct
-          // field to resolve — the method will be resolved during
-          // monomorphization when T is substituted with a concrete type.
-          // Emit a diagnostic only for concrete struct types where the
-          // field genuinely doesn't exist.
-          if (field.object->type != nullptr &&
-              field.object->type->kind() == TypeKind::Struct) {
+          if (lowering_generic_template_) {
+            // Template body: tolerate unresolved field accesses on
+            // generic type parameters (e.g., x.to_string() where
+            // x: T: Printable).  The monomorphizer will clone this
+            // template and substitute concrete types, at which point
+            // the field access resolves normally.
+          } else if (field.object->type != nullptr &&
+                     field.object->type->kind() == TypeKind::Struct) {
+            error(expr.span, "unresolved field '" + std::string(field.field_name) + "'");
+          } else {
             error(expr.span, "unresolved field '" + std::string(field.field_name) + "'");
           }
         }
@@ -609,8 +701,9 @@ auto MirBuilder::lower_expr_place(const HirExpr& expr) -> MirPlace {
         auto base = lower_expr_place(*field.object);
         auto field_idx = resolve_field_index(field.object->type, field.field_name);
         if (!field_idx) {
-          if (field.object->type != nullptr &&
-              field.object->type->kind() == TypeKind::Struct) {
+          if (lowering_generic_template_) {
+            // Template body: tolerate (see value-lowering counterpart).
+          } else {
             error(field.object->span, "unresolved field '" + std::string(field.field_name) + "'");
           }
         }

--- a/compiler/ir/mir/mir_builder.cpp
+++ b/compiler/ir/mir/mir_builder.cpp
@@ -68,12 +68,15 @@ void MirBuilder::emit_terminator(Span span, MirPayload payload) {
 }
 
 // ---------------------------------------------------------------------------
-// Generic detection — check if an HirFunction has unresolved generic
-// parameter types in its signature (params or return type).
+// Generic detection
 // ---------------------------------------------------------------------------
 
 namespace {
 
+/// Check if a Dao type (or any nested type) contains TypeGenericParam.
+/// Used to detect functions on generic classes (e.g. HashMap<V>.length)
+/// whose own declaration has no type params but whose signature references
+/// the enclosing class's generic parameters.
 auto type_has_generic_param(const Type* type) -> bool {
   if (type == nullptr) {
     return false;
@@ -93,9 +96,6 @@ auto type_has_generic_param(const Type* type) -> bool {
   case TypeKind::Pointer:
     return type_has_generic_param(
         static_cast<const TypePointer*>(type)->pointee());
-  case TypeKind::Generator:
-    return type_has_generic_param(
-        static_cast<const TypeGenerator*>(type)->yield_type());
   case TypeKind::Struct: {
     const auto* str = static_cast<const TypeStruct*>(type);
     for (const auto& field : str->fields()) {
@@ -116,12 +116,22 @@ auto type_has_generic_param(const Type* type) -> bool {
     }
     return false;
   }
+  case TypeKind::Generator:
+    return type_has_generic_param(
+        static_cast<const TypeGenerator*>(type)->yield_type());
   default:
     return false;
   }
 }
 
+/// A function is generic if either:
+///  (a) its AST declaration has own type parameters (e.g. fn f<T>), or
+///  (b) its lowered signature contains TypeGenericParam (e.g. methods
+///      on generic classes where self: HashMap<V>).
 auto hir_function_is_generic(const HirFunction& fn) -> bool {
+  if (fn.has_type_params) {
+    return true;
+  }
   if (type_has_generic_param(fn.return_type)) {
     return true;
   }

--- a/compiler/ir/mir/mir_builder.h
+++ b/compiler/ir/mir/mir_builder.h
@@ -20,6 +20,11 @@ namespace dao {
 struct MirBuildResult {
   MirModule* module = nullptr;
   std::vector<Diagnostic> diagnostics;
+
+  /// Generic function templates: bodies lowered to MIR but excluded from
+  /// module->functions.  The monomorphizer clones from these to produce
+  /// concrete instantiations.  Keyed by declaration symbol.
+  std::unordered_map<const Symbol*, MirFunction*> generic_templates;
 };
 
 // ---------------------------------------------------------------------------
@@ -46,6 +51,14 @@ private:
   uint32_t next_value_id_ = 0;
   uint32_t next_block_id_ = 0;
   std::unordered_map<const Symbol*, LocalId> symbol_to_local_;
+
+  // True while lowering a generic function body into a template.
+  // Gates tolerance for unresolved field accesses on non-struct types
+  // (concept method calls on generic type parameters).
+  bool lowering_generic_template_ = false;
+
+  // Generic templates accumulated during build().
+  std::unordered_map<const Symbol*, MirFunction*> generic_templates_;
 
   // Loop exit block stack for break statement lowering.
   std::vector<BlockId> loop_exit_stack_;

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -664,19 +664,16 @@ auto specialize_call_site(
 // Main pass
 // ---------------------------------------------------------------------------
 
-auto monomorphize(MirModule& module, MirContext& ctx,
-                  TypeContext& types) -> MonomorphizeResult {
+auto monomorphize(
+    MirModule& module, MirContext& ctx, TypeContext& types,
+    const std::unordered_map<const Symbol*, MirFunction*>& generic_templates)
+    -> MonomorphizeResult {
   MonomorphizeResult result;
 
-  // Phase 1: identify generic functions by symbol.
-  std::unordered_map<const Symbol*, MirFunction*> generic_fns;
-  for (auto* fn : module.functions) {
-    if (fn->symbol != nullptr && is_generic_function(fn)) {
-      generic_fns[fn->symbol] = fn;
-    }
-  }
-
-  if (generic_fns.empty()) {
+  // Phase 1: use the provided generic templates directly.
+  // The MIR builder already separated generic function bodies into
+  // templates (not in module.functions).  No scanning needed.
+  if (generic_templates.empty()) {
     return result;
   }
 
@@ -693,10 +690,6 @@ auto monomorphize(MirModule& module, MirContext& ctx,
     const size_t fn_count = module.functions.size();
     for (size_t fn_idx = 0; fn_idx < fn_count; ++fn_idx) {
       auto* fn = module.functions[fn_idx];
-      // Skip generic functions themselves — they'll be removed later.
-      if (fn->symbol != nullptr && generic_fns.count(fn->symbol) != 0) {
-        continue;
-      }
 
       // Build per-function value-type index for O(1) arg type lookups.
       auto value_types = build_value_types(fn);
@@ -711,8 +704,8 @@ auto monomorphize(MirModule& module, MirContext& ctx,
           }
 
           if (specialize_call_site(inst, fn_ref, block, inst_idx,
-                                   value_types, generic_fns, spec_cache,
-                                   module, ctx, types)) {
+                                   value_types, generic_templates,
+                                   spec_cache, module, ctx, types)) {
             changed = true;
           }
         }
@@ -720,10 +713,8 @@ auto monomorphize(MirModule& module, MirContext& ctx,
     }
   }
 
-  // Phase 5: remove generic originals.
-  std::erase_if(module.functions, [&](const MirFunction* fn) {
-    return fn->symbol != nullptr && generic_fns.count(fn->symbol) != 0;
-  });
+  // No Phase 5 needed — generic originals were never in
+  // module.functions (they live only in generic_templates).
 
   return result;
 }

--- a/compiler/ir/mir/mir_monomorphize.h
+++ b/compiler/ir/mir/mir_monomorphize.h
@@ -3,9 +3,11 @@
 
 #include "ir/mir/mir.h"
 #include "ir/mir/mir_context.h"
+#include "frontend/resolve/symbol.h"
 #include "frontend/types/type_context.h"
 #include "frontend/diagnostics/diagnostic.h"
 
+#include <unordered_map>
 #include <vector>
 
 namespace dao {
@@ -15,10 +17,14 @@ struct MonomorphizeResult {
 };
 
 /// Replace generic functions with concrete specializations based on
-/// observed call-site types. After this pass, no TypeGenericParam
-/// remains in the module and the LLVM backend can lower all types.
-auto monomorphize(MirModule& module, MirContext& ctx,
-                  TypeContext& types) -> MonomorphizeResult;
+/// observed call-site types.  Generic templates are provided separately
+/// from the module's function list (the MIR builder excludes them from
+/// module->functions).  After this pass, no TypeGenericParam remains
+/// in the module and the LLVM backend can lower all types.
+auto monomorphize(
+    MirModule& module, MirContext& ctx, TypeContext& types,
+    const std::unordered_map<const Symbol*, MirFunction*>& generic_templates)
+    -> MonomorphizeResult;
 
 } // namespace dao
 

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -244,7 +244,8 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
       goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
-    auto mono_result = monomorphize(*mir_result.module, mir_ctx, types);
+    auto mono_result = monomorphize(*mir_result.module, mir_ctx, types,
+                                    mir_result.generic_templates);
     collect_diagnostics(diagnostics, source, mono_result.diagnostics,
                         prelude_bytes, prelude_lines);
 

--- a/tools/playground/compiler_service/run.cpp
+++ b/tools/playground/compiler_service/run.cpp
@@ -192,7 +192,8 @@ void handle_run(const httplib::Request& req, httplib::Response& res,
   collect_diagnostics(diagnostics, source, mir_result.diagnostics,
                       prelude_bytes, prelude_lines);
   if (mir_result.module != nullptr) {
-    auto mono = monomorphize(*mir_result.module, mir_ctx, types);
+    auto mono = monomorphize(*mir_result.module, mir_ctx, types,
+                             mir_result.generic_templates);
     collect_diagnostics(diagnostics, source, mono.diagnostics,
                         prelude_bytes, prelude_lines);
   }


### PR DESCRIPTION
## Summary

Implement Task 28: generic function bodies are now separated from the main MIR module. The MIR builder lowers generic bodies into template storage, and the monomorphizer clones from there to produce concrete instantiations. The module's function list contains only type-concrete bodies.

## Highlights

- `MirBuilder::build()` uses `type_has_generic_param()` to detect generic functions at HIR→MIR boundary and routes them to `generic_templates` (not `module->functions`)
- `lowering_generic_template_` flag explicitly gates tolerance for unresolved field accesses (concept method calls on generic type params)
- `monomorphize()` accepts the templates map directly — no scanning of `module.functions` for generics, no Phase 5 removal needed
- All call sites updated: driver pipeline, playground analyze/run
- HIR builder workaround comment updated to reference Task 28 architecture

## Test plan

- [x] Host compiler: 12/12 tests pass
- [x] Bootstrap: lexer 105, parser 51, graph 12, resolver 34, typecheck 38, HIR 19 (259 total)
- [x] End-to-end: `hello.dao`, `structs.dao` compile and run correctly (exercises `print<T: Printable>`)
- [x] Generic function `print` correctly monomorphized for i32, string, bool receivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)