### PR TITLE
docs(roadmap): 📝 mark Task 28 complete, update Phase 7 status

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -316,7 +316,7 @@ HIR) is complete.  Tasks 25–27 (multi-file substrate) are complete —
 the `Program` value threads through resolve → typecheck → HIR with
 canonical type identity, cross-module qualified name typing, and
 program-level HIR aggregation.  Task 28 (generic body lowering boundary)
-is the next architectural cleanup before Tier B feature slices begin.
+is complete — see below.
 
 ### Task 25 — Bootstrap Multi-file Compilation + Imports (v1)
 
@@ -379,11 +379,20 @@ multi-file substrate to sit on.
 
 ### Task 28 — Proper Generic Body Lowering Boundary
 
+Status: **complete**
+
 **Objective**: Replace the current workaround for generic MIR
 lowering with the proper architectural boundary: uninstantiated
 generic function bodies must not be lowered to MIR.
 
 See `docs/task_specs/TASK_28_GENERIC_BODY_LOWERING_BOUNDARY.md`.
+
+- ✓ `HirFunction::has_type_params` propagated from AST declaration
+- ✓ `MirBuilder::build()` separates generic templates from monomorphic functions
+- ✓ Combined generic detection: declaration-based (own type params) + signature-based (enclosing class generic params)
+- ✓ `lowering_generic_template_` flag gates field-access tolerance during template lowering
+- ✓ `monomorphize()` accepts templates map directly; no Phase 5 removal needed
+- ✓ Generic enum payload sizing guard in LLVM type lowering
 
 Deliverables:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,19 +210,20 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
-Status: **Tier A pipeline + multi-file substrate complete** —
-Tasks 19–27 complete.  Six bootstrap subsystems share a consolidated
-substrate (`bootstrap/shared/base.dao`): lexer (105 tests), parser
-(51 tests), graph (12 tests), resolver (34 tests), type checker
-(37 tests), and HIR lowering (19 tests).  The Tier A pipeline
-(lex → parse → resolve → typecheck → HIR) operates at both
+Status: **Tier A pipeline + multi-file substrate + generic lowering
+boundary complete** — Tasks 19–28 complete.  Six bootstrap subsystems
+share a consolidated substrate (`bootstrap/shared/base.dao`): lexer
+(105 tests), parser (51 tests), graph (12 tests), resolver (34 tests),
+type checker (37 tests), and HIR lowering (19 tests).  The Tier A
+pipeline (lex → parse → resolve → typecheck → HIR) operates at both
 single-file and program level.  The `Program` value threads through
 all passes with canonical type identity, resolver-bound concept
 identity, module-scoped extend methods, cross-module qualified name
 typing, and program-level HIR aggregation (`HirProgram`/`HirModule`).
 On-disk multi-file test fixtures exercise the full pipeline
-end-to-end.  Next: bootstrap MIR lowering and continued self-hosting
-progression.
+end-to-end.  Task 28 (generic body lowering boundary) enforces clean
+separation of generic templates from monomorphic functions at the
+HIR → MIR boundary.  Next: Tier B bootstrap feature slices.
 
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself


### PR DESCRIPTION
## Summary

- Update Phase 7 status in ROADMAP.md to reflect Tasks 19–28 complete (including generic body lowering boundary) and set next milestone to Tier B bootstrap feature slices
- Add Status: **complete** with completion bullets to Task 28 section in IMPLEMENTATION_PLAN.md
- Update "What Comes After" paragraph to mark Task 28 as complete

## Test plan

- [ ] Verify ROADMAP.md Phase 7 status line accurately reflects Task 28 completion
- [ ] Verify IMPLEMENTATION_PLAN.md Task 28 section has correct status and completion bullets
- [ ] Confirm no unintended changes to other sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)