### PR TITLE
feat(mir): 🦺 add MIR concreteness invariant check (Task 28 §14.2)

### DIFF
--- a/compiler/driver/pipeline.cpp
+++ b/compiler/driver/pipeline.cpp
@@ -243,9 +243,17 @@ auto run_through_mir(const std::filesystem::path& path) -> MirResult {
       monomorphize(*mir.module, mir_ctx, hir_result.frontend.types,
                    mir.generic_templates);
   if (!mono_result.diagnostics.empty()) {
-    print_error_diagnostics(filename, hir_result.frontend.parsed.source,
-                            mono_result.diagnostics,
-                            hir_result.frontend.prelude_lines);
+    bool mono_errors = print_error_diagnostics(
+        filename, hir_result.frontend.parsed.source,
+        mono_result.diagnostics, hir_result.frontend.prelude_lines);
+    // Monomorphization emits errors for MIR concreteness invariant
+    // violations (Task 28 §14.2).  These must halt the pipeline
+    // before LLVM lowering — allowing generic residue through would
+    // surface as an opaque LLVM DataLayout assertion on unsized
+    // types, obscuring the root cause.
+    if (mono_errors) {
+      std::exit(EXIT_FAILURE);
+    }
   }
 
   return {.hir_result = std::move(hir_result),

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -673,9 +673,11 @@ auto monomorphize(
   // Phase 1: use the provided generic templates directly.
   // The MIR builder already separated generic function bodies into
   // templates (not in module.functions).  No scanning needed.
-  if (generic_templates.empty()) {
-    return result;
-  }
+  //
+  // When generic_templates is empty, skip specialization but still
+  // run the concreteness invariant check below — the check must fire
+  // even for programs with no generics, to catch synthetic residue.
+  const bool has_templates = !generic_templates.empty();
 
   // Specialization cache: (generic fn, type args) → specialized fn.
   std::unordered_map<SpecKey, MirFunction*, SpecKeyHash> spec_cache;
@@ -683,7 +685,7 @@ auto monomorphize(
   // Phase 2+3+4: iterate until no new specializations are produced.
   // Use index-based iteration because specialize_call_site() may
   // push_back new functions, invalidating range-for iterators.
-  bool changed = true;
+  bool changed = has_templates;
   while (changed) {
     changed = false;
 
@@ -715,6 +717,55 @@ auto monomorphize(
 
   // No Phase 5 needed — generic originals were never in
   // module.functions (they live only in generic_templates).
+
+  // MIR concreteness invariant (Task 28 §8.1, §14.2):
+  //
+  // After monomorphization, every function in module.functions must
+  // be type-concrete.  No TypeGenericParam residue may remain in:
+  //   - function return types
+  //   - local variable types (including parameters)
+  //   - per-instruction result types
+  //
+  // If this invariant is violated, the LLVM backend will abort on
+  // unsized types later (`getTypeInfo() on unsized type`) with a
+  // backtrace deep inside LLVM, making regressions hard to diagnose.
+  // Emit an explicit internal-error diagnostic at the MIR boundary
+  // instead so the regression is localized to the offending function.
+  for (const auto* fn : module.functions) {
+    if (is_generic_function(fn)) {
+      std::string fn_name = fn->symbol != nullptr
+                                ? std::string(fn->symbol->name)
+                                : std::string("<anonymous>");
+      result.diagnostics.push_back(Diagnostic::error(
+          fn->span,
+          "internal: MIR concreteness invariant violated — function '" +
+              fn_name +
+              "' contains unresolved generic parameter types after "
+              "monomorphization"));
+      continue;
+    }
+    // Also scan instruction types: is_generic_function() checks the
+    // signature and locals, but an instruction may produce a value of
+    // generic type even when locals are concrete (e.g. a call to a
+    // generic function not yet monomorphized).
+    for (const auto* block : fn->blocks) {
+      for (const auto* inst : block->insts) {
+        if (type_has_generic(inst->type)) {
+          std::string fn_name = fn->symbol != nullptr
+                                    ? std::string(fn->symbol->name)
+                                    : std::string("<anonymous>");
+          result.diagnostics.push_back(Diagnostic::error(
+              inst->span,
+              "internal: MIR concreteness invariant violated — "
+              "instruction in '" +
+                  fn_name +
+                  "' produces a value with unresolved generic "
+                  "parameter type after monomorphization"));
+          break;
+        }
+      }
+    }
+  }
 
   return result;
 }

--- a/compiler/ir/mir/mir_monomorphize.cpp
+++ b/compiler/ir/mir/mir_monomorphize.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace dao {
@@ -129,9 +130,18 @@ auto substitute_type(const Type* type, const TypeSubst& subst,
 // or instruction types contain TypeGenericParam.
 // ---------------------------------------------------------------------------
 
-auto type_has_generic(const Type* type) -> bool {
+// Recursive walk with a visited set to tolerate cyclic types such as
+// `class Node { next: *Node }` where following Struct fields through
+// a Pointer pointee returns to the same Struct.  Without the visited
+// set this would stack-overflow.
+auto type_has_generic_impl(const Type* type,
+                           std::unordered_set<const Type*>& visited)
+    -> bool {
   if (type == nullptr) {
     return false;
+  }
+  if (!visited.insert(type).second) {
+    return false; // already walked this node; cycle — assume no generic here
   }
   switch (type->kind()) {
   case TypeKind::GenericParam:
@@ -139,22 +149,22 @@ auto type_has_generic(const Type* type) -> bool {
   case TypeKind::Function: {
     const auto* fn = static_cast<const TypeFunction*>(type);
     for (const auto* param : fn->param_types()) {
-      if (type_has_generic(param)) {
+      if (type_has_generic_impl(param, visited)) {
         return true;
       }
     }
-    return type_has_generic(fn->return_type());
+    return type_has_generic_impl(fn->return_type(), visited);
   }
   case TypeKind::Pointer:
-    return type_has_generic(
-        static_cast<const TypePointer*>(type)->pointee());
+    return type_has_generic_impl(
+        static_cast<const TypePointer*>(type)->pointee(), visited);
   case TypeKind::Generator:
-    return type_has_generic(
-        static_cast<const TypeGenerator*>(type)->yield_type());
+    return type_has_generic_impl(
+        static_cast<const TypeGenerator*>(type)->yield_type(), visited);
   case TypeKind::Struct: {
     const auto* st = static_cast<const TypeStruct*>(type);
     for (const auto& field : st->fields()) {
-      if (type_has_generic(field.type)) {
+      if (type_has_generic_impl(field.type, visited)) {
         return true;
       }
     }
@@ -164,7 +174,7 @@ auto type_has_generic(const Type* type) -> bool {
     const auto* en = static_cast<const TypeEnum*>(type);
     for (const auto& variant : en->variants()) {
       for (const auto* pt : variant.payload_types) {
-        if (type_has_generic(pt)) {
+        if (type_has_generic_impl(pt, visited)) {
           return true;
         }
       }
@@ -174,6 +184,11 @@ auto type_has_generic(const Type* type) -> bool {
   default:
     return false;
   }
+}
+
+auto type_has_generic(const Type* type) -> bool {
+  std::unordered_set<const Type*> visited;
+  return type_has_generic_impl(type, visited);
 }
 
 auto is_generic_function(const MirFunction* fn) -> bool {

--- a/compiler/ir/mir/mir_test.cpp
+++ b/compiler/ir/mir/mir_test.cpp
@@ -602,6 +602,25 @@ suite<"mir_concreteness"> mir_concreteness = [] {
     expect(pipe.mir_result.generic_templates.empty());
   };
 
+  // Regression: the invariant scan must not stack-overflow on
+  // recursive types like `class Node { next: *Node }` where
+  // following Struct fields through a Pointer pointee returns to
+  // the same Struct.
+  "concreteness check handles recursive types"_test = [] {
+    MirTestPipeline pipe(
+        "class Node:\n"
+        "    next: *Node\n"
+        "    value: i32\n"
+        "fn main(): i32\n"
+        "    return 0\n");
+    // Should complete without stack overflow and without emitting
+    // spurious concreteness diagnostics.
+    auto mono = monomorphize(*pipe.module(), pipe.mir_ctx, pipe.types,
+                             pipe.mir_result.generic_templates);
+    expect(mono.diagnostics.empty())
+        << "unexpected concreteness diagnostics on recursive type";
+  };
+
   // Concreteness check catches synthetic residue: manually inject a
   // generic function into module.functions and verify monomorphize
   // emits the internal-error diagnostic.

--- a/compiler/ir/mir/mir_test.cpp
+++ b/compiler/ir/mir/mir_test.cpp
@@ -8,6 +8,7 @@
 #include "ir/hir/hir_context.h"
 #include "ir/mir/mir_builder.h"
 #include "ir/mir/mir_context.h"
+#include "ir/mir/mir_monomorphize.h"
 #include "ir/mir/mir_printer.h"
 #include "support/test_utils.h"
 
@@ -551,6 +552,85 @@ suite<"mir_generator"> mir_generator = [] {
     // iter_next should produce i32, not Generator<i32>
     expect(contains(dump, "iter_next")) << dump;
     expect(contains(dump, ": i32")) << dump;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Task 28: MIR concreteness invariant
+// ---------------------------------------------------------------------------
+
+suite<"mir_concreteness"> mir_concreteness = [] {
+  // After monomorphization, module.functions must contain only
+  // type-concrete bodies.  Generic declarations live in
+  // generic_templates and are cloned+specialized on demand.
+  "monomorphization produces no concreteness diagnostics"_test = [] {
+    MirTestPipeline pipe(
+        "fn id<T>(x: T): T -> x\n"
+        "fn main(): i32\n"
+        "    let a: i32 = id<i32>(42)\n"
+        "    return a\n");
+    // Generic id<T> should be in generic_templates, not
+    // module.functions.  Only main and id$i32 (the specialization)
+    // should end up in module.functions after monomorphize.
+    auto mono = monomorphize(*pipe.module(), pipe.mir_ctx, pipe.types,
+                             pipe.mir_result.generic_templates);
+    expect(mono.diagnostics.empty())
+        << "unexpected concreteness diagnostics: "
+        << (mono.diagnostics.empty() ? ""
+                                     : mono.diagnostics[0].message);
+    // Verify no generic residue in final module.
+    for (const auto* fn : pipe.module()->functions) {
+      const bool has_generic_return =
+          fn->return_type != nullptr &&
+          fn->return_type->kind() == TypeKind::GenericParam;
+      expect(!has_generic_return)
+          << "function " << (fn->symbol != nullptr ? fn->symbol->name : "")
+          << " has generic return type";
+    }
+  };
+
+  // A program with no generics should monomorphize as a no-op
+  // with no diagnostics.
+  "no-op monomorphization"_test = [] {
+    MirTestPipeline pipe(
+        "fn add(a: i32, b: i32): i32 -> a + b\n"
+        "fn main(): i32\n"
+        "    return add(1, 2)\n");
+    auto mono = monomorphize(*pipe.module(), pipe.mir_ctx, pipe.types,
+                             pipe.mir_result.generic_templates);
+    expect(mono.diagnostics.empty());
+    expect(pipe.mir_result.generic_templates.empty());
+  };
+
+  // Concreteness check catches synthetic residue: manually inject a
+  // generic function into module.functions and verify monomorphize
+  // emits the internal-error diagnostic.
+  "concreteness check fires on synthetic residue"_test = [] {
+    MirTestPipeline pipe(
+        "fn main(): i32\n"
+        "    return 0\n");
+    // Manually craft a MirFunction whose return type is a generic
+    // parameter (simulating a regression where a generic body slipped
+    // into module.functions).
+    auto* bad_fn = pipe.mir_ctx.alloc<MirFunction>();
+    bad_fn->return_type =
+        pipe.types.generic_param(/*binder=*/nullptr, "T", 0);
+    bad_fn->span = {};
+    bad_fn->is_extern = false;
+    pipe.module()->functions.push_back(bad_fn);
+    auto mono = monomorphize(*pipe.module(), pipe.mir_ctx, pipe.types,
+                             pipe.mir_result.generic_templates);
+    // Expect at least one error diagnostic about the invariant.
+    bool found = false;
+    for (const auto& diag : mono.diagnostics) {
+      if (diag.severity == Severity::Error &&
+          diag.message.find("MIR concreteness invariant violated") !=
+              std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    expect(found) << "expected concreteness invariant diagnostic";
   };
 };
 

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -253,6 +253,22 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
     print_mir(mir_out, *mir_result.module);
     mir_text = mir_out.str();
 
+    // Stop before LLVM lowering on mono errors (e.g. MIR concreteness
+    // invariant violations — Task 28 §14.2).  MIR dump is still
+    // produced for inspection, but LLVM IR would fail on unsized
+    // types with an opaque assertion.
+    bool mono_has_user_error = false;
+    for (const auto& diag : mono_result.diagnostics) {
+      if (diag.severity == Severity::Error &&
+          diag.span.offset >= prelude_bytes) {
+        mono_has_user_error = true;
+        break;
+      }
+    }
+    if (mono_has_user_error) {
+      goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
     // --- LLVM IR ---
     llvm::LLVMContext llvm_ctx;
     LlvmBackend llvm_backend(llvm_ctx);

--- a/tools/playground/compiler_service/analyze.cpp
+++ b/tools/playground/compiler_service/analyze.cpp
@@ -253,19 +253,22 @@ void handle_analyze(const httplib::Request& req, httplib::Response& res,
     print_mir(mir_out, *mir_result.module);
     mir_text = mir_out.str();
 
-    // Stop before LLVM lowering on mono errors (e.g. MIR concreteness
-    // invariant violations — Task 28 §14.2).  MIR dump is still
-    // produced for inspection, but LLVM IR would fail on unsized
-    // types with an opaque assertion.
-    bool mono_has_user_error = false;
+    // Stop before LLVM lowering on any mono error, including those
+    // originating in the prelude.  MIR concreteness invariant
+    // violations (Task 28 §14.2) are internal errors that must halt
+    // unconditionally — their span reflects the offending function's
+    // source location, which may legitimately fall inside the prelude
+    // if the regression is in prelude lowering, but the LLVM
+    // DataLayout assertion would fire all the same.  MIR dump is
+    // still produced above for inspection.
+    bool mono_has_error = false;
     for (const auto& diag : mono_result.diagnostics) {
-      if (diag.severity == Severity::Error &&
-          diag.span.offset >= prelude_bytes) {
-        mono_has_user_error = true;
+      if (diag.severity == Severity::Error) {
+        mono_has_error = true;
         break;
       }
     }
-    if (mono_has_user_error) {
+    if (mono_has_error) {
       goto respond; // NOLINT(cppcoreguidelines-avoid-goto)
     }
 

--- a/tools/playground/compiler_service/run.cpp
+++ b/tools/playground/compiler_service/run.cpp
@@ -191,13 +191,24 @@ void handle_run(const httplib::Request& req, httplib::Response& res,
       build_mir(*hir_result.module, mir_ctx, types);
   collect_diagnostics(diagnostics, source, mir_result.diagnostics,
                       prelude_bytes, prelude_lines);
+  bool mono_has_errors = false;
   if (mir_result.module != nullptr) {
     auto mono = monomorphize(*mir_result.module, mir_ctx, types,
                              mir_result.generic_templates);
     collect_diagnostics(diagnostics, source, mono.diagnostics,
                         prelude_bytes, prelude_lines);
+    // Halt before LLVM lowering on mono errors (e.g. MIR
+    // concreteness invariant violations — Task 28 §14.2).
+    // Allowing generic residue through surfaces as an opaque LLVM
+    // DataLayout assertion.
+    for (const auto& diag : mono.diagnostics) {
+      if (diag.severity == Severity::Error) {
+        mono_has_errors = true;
+        break;
+      }
+    }
   }
-  if (mir_result.module == nullptr) {
+  if (mir_result.module == nullptr || mono_has_errors) {
     if (diagnostics.empty()) {
       diagnostics.push_back(
           make_internal_error("MIR lowering failed (possible prelude error)"));


### PR DESCRIPTION
## Summary

Close Task 28 acceptance criterion #8: \"At least one invariant/assertion guards against regression at the MIR boundary.\"

After monomorphization, every function in \`module.functions\` must be type-concrete — no \`TypeGenericParam\` residue in return types, local types, or per-instruction result types. Without this check, a regression would surface as an opaque LLVM assertion deep inside DataLayout, making the root cause hard to diagnose.

## Highlights

- \`monomorphize()\` now runs the concreteness check unconditionally (even when \`generic_templates\` is empty), so synthetic residue from a future regression is still caught
- Emits an internal-error diagnostic pointing at the offending function with a clear \"MIR concreteness invariant violated\" message
- Three new \`mir_concreteness\` tests:
  1. Positive: real generic function (\`fn id<T>\`) monomorphizes cleanly, no diagnostics
  2. No-op: program with no generics, no diagnostics, empty templates map
  3. Synthetic residue: manually inject a \`MirFunction\` with \`TypeGenericParam\` return into \`module.functions\`, verify the diagnostic fires

## Test plan

- [x] Host compiler: 12/12 (including new \`mir_concreteness\` suite)
- [x] End-to-end: \`hello.dao\` (uses generic \`print<T: Printable>\`) compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)