### PR TITLE
fix(runtime): 🐛 heap-allocate scalar-to-string conversion results

### DIFF
--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -283,12 +283,14 @@ For the current supported hook slice:
    reside in static storage and are valid for the lifetime of the
    process.
 
-3. **Conversion results use transient storage.** Scalar-to-string
+3. **Conversion results are heap-owned.** Scalar-to-string
    conversion hooks (`__dao_conv_*_to_string`) return a `dao_string`
-   whose `ptr` points to thread-local transient storage. The result
-   is valid until the next call to the same conversion hook on the
-   same thread. Callers must consume or copy the result before the
-   next conversion call.
+   whose `ptr` points to a freshly `malloc`-allocated buffer owned
+   by the caller.  The result is valid until the caller explicitly
+   frees it (or indefinitely, under the current leak-on-exit runtime
+   posture).  Callers may store the result in long-lived data
+   structures (e.g. as a HashMap key) without copying — see rule 6
+   below for details.
 
 4. **Generator frames are caller-managed.** Generator frames are
    allocated by `__dao_gen_alloc` and must be freed by

--- a/docs/contracts/CONTRACT_RUNTIME_ABI.md
+++ b/docs/contracts/CONTRACT_RUNTIME_ABI.md
@@ -300,14 +300,19 @@ For the current supported hook slice:
    one `__dao_mem_resource_exit` call. The compiler inserts exit
    calls on both normal and early-return paths.
 
-6. **String concat results are heap-allocated.**
-   `__dao_str_concat` returns a `dao_string` whose `ptr` points to
-   a freshly `malloc`-allocated buffer owned by the caller. Unlike
-   scalar-to-string conversion hooks, concat cannot use transient
-   storage because concat composes with itself (e.g.
-   `concat("a", concat("b", "c"))`). In the current runtime these
-   allocations are not automatically freed — they leak until process
-   exit. Future arena or GC integration will reclaim them.
+6. **String-producing runtime hooks return heap-allocated buffers.**
+   Both `__dao_str_concat` and all `__dao_conv_*_to_string` hooks
+   return a `dao_string` whose `ptr` points to a freshly
+   `malloc`-allocated buffer owned by the caller.  Earlier versions
+   of the scalar-to-string hooks returned pointers to thread-local
+   static buffers, which silently corrupted any data structure that
+   stored the returned string: the next conversion call overwrote
+   the previous contents in place (observable via
+   `HashMap<V>.set(i64_to_string(i), v)` in a loop, where keys
+   collided because every returned string pointed at the same
+   buffer).  In the current runtime these allocations are not
+   automatically freed — they leak until process exit.  Future arena
+   or GC integration will reclaim them.
 
 ## Stability
 

--- a/runtime/core/CMakeLists.txt
+++ b/runtime/core/CMakeLists.txt
@@ -41,5 +41,24 @@ target_include_directories(overflow_test PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_executable(convert_test
+  convert_test.cpp
+)
+
+set_target_properties(convert_test PROPERTIES
+  LINKER_LANGUAGE CXX
+)
+
+target_link_libraries(convert_test
+  PRIVATE
+    dao_runtime
+    Boost::ut
+)
+
+target_include_directories(convert_test PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 include(CTest)
 add_test(NAME overflow_test COMMAND overflow_test)
+add_test(NAME convert_test COMMAND convert_test)

--- a/runtime/core/convert.c
+++ b/runtime/core/convert.c
@@ -3,7 +3,17 @@
 // Implements: scalar-to-string, numeric type conversions
 // Authority:  docs/contracts/CONTRACT_RUNTIME_ABI.md
 //
-// String conversion results use thread-local transient buffers.
+// String conversion results are heap-allocated via malloc.  The caller
+// owns the memory; in the current runtime there is no automatic
+// deallocation — these allocations leak until process exit.  Future
+// arena/GC integration will reclaim them.  Matches the convention used
+// by __dao_str_concat in string.c.
+//
+// Earlier versions returned pointers to thread-local static buffers,
+// which silently corrupted any data structure (e.g. HashMap keys) that
+// stored the returned string: the next conversion call overwrote the
+// previous contents in place.
+//
 // Numeric conversions trap (abort) on out-of-range or invalid inputs.
 
 #include "dao_abi.h"
@@ -11,65 +21,82 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+// Helper: format into a stack buffer of known size, then duplicate
+// into a fresh heap allocation sized to the actual length.  Returns
+// an empty string on OOM rather than crashing (same posture as
+// __dao_str_concat).
+static struct dao_string conv_str_dup(const char *buf, int len) {
+  if (len <= 0) {
+    return (struct dao_string){.ptr = NULL, .len = 0};
+  }
+  char *heap = (char *)malloc((size_t)len);
+  if (heap == NULL) {
+    return (struct dao_string){.ptr = NULL, .len = 0};
+  }
+  memcpy(heap, buf, (size_t)len);
+  return (struct dao_string){.ptr = heap, .len = len};
+}
 
 struct dao_string __dao_conv_i8_to_string(int8_t x) {
-  static _Thread_local char buf[8];
+  char buf[8];
   int len = snprintf(buf, sizeof(buf), "%d", (int)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_i16_to_string(int16_t x) {
-  static _Thread_local char buf[8];
+  char buf[8];
   int len = snprintf(buf, sizeof(buf), "%d", (int)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_i32_to_string(int32_t x) {
-  static _Thread_local char buf[32];
+  char buf[32];
   int len = snprintf(buf, sizeof(buf), "%d", x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_i64_to_string(int64_t x) {
-  static _Thread_local char buf[32];
+  char buf[32];
   int len = snprintf(buf, sizeof(buf), "%lld", (long long)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_u8_to_string(uint8_t x) {
-  static _Thread_local char buf[8];
+  char buf[8];
   int len = snprintf(buf, sizeof(buf), "%u", (unsigned)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_u16_to_string(uint16_t x) {
-  static _Thread_local char buf[8];
+  char buf[8];
   int len = snprintf(buf, sizeof(buf), "%u", (unsigned)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_u32_to_string(uint32_t x) {
-  static _Thread_local char buf[16];
+  char buf[16];
   int len = snprintf(buf, sizeof(buf), "%u", x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_u64_to_string(uint64_t x) {
-  static _Thread_local char buf[32];
+  char buf[32];
   int len = snprintf(buf, sizeof(buf), "%llu", (unsigned long long)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_f32_to_string(float x) {
-  static _Thread_local char buf[64];
+  char buf[64];
   int len = snprintf(buf, sizeof(buf), "%g", (double)x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_f64_to_string(double x) {
-  static _Thread_local char buf[64];
+  char buf[64];
   int len = snprintf(buf, sizeof(buf), "%g", x);
-  return (struct dao_string){.ptr = buf, .len = len};
+  return conv_str_dup(buf, len);
 }
 
 struct dao_string __dao_conv_bool_to_string(bool x) {

--- a/runtime/core/convert_test.cpp
+++ b/runtime/core/convert_test.cpp
@@ -1,0 +1,84 @@
+// convert_test.cpp — Runtime-level tests for scalar-to-string conversion hooks.
+//
+// These tests verify that each conversion hook returns a freshly
+// heap-allocated buffer rather than a pointer to a shared static
+// buffer.  Returning a static buffer silently corrupted any data
+// structure (e.g. HashMap keys) that stored the returned string:
+// the next conversion call overwrote the previous contents in place.
+//
+// Authority: docs/contracts/CONTRACT_RUNTIME_ABI.md §6
+
+#include "dao_abi.h"
+
+#include <boost/ut.hpp>
+#include <cstdint>
+#include <cstring>
+
+using namespace boost::ut;
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+suite<"conv_to_string_fresh"> conv_to_string_fresh = [] {
+  // Core regression: two successive conversions must return distinct
+  // pointers, so the caller can keep the first string alive while
+  // computing the second.
+  "i64_to_string returns distinct buffers"_test = [] {
+    auto s1 = __dao_conv_i64_to_string(0);
+    auto s2 = __dao_conv_i64_to_string(1);
+    expect(s1.ptr != s2.ptr) << "i64_to_string reused buffer";
+    expect(eq(s1.len, int64_t{1}));
+    expect(eq(s2.len, int64_t{1}));
+    expect(s1.ptr[0] == '0');
+    expect(s2.ptr[0] == '1');
+  };
+
+  // After two successive conversions, the first result must still
+  // read as its original value.  The old thread-local-buffer design
+  // would have silently overwritten s1 with s2's contents.
+  "i64_to_string prior result survives later call"_test = [] {
+    auto s1 = __dao_conv_i64_to_string(42);
+    auto s2 = __dao_conv_i64_to_string(1337);
+    (void)s2;
+    expect(eq(s1.len, int64_t{2}));
+    expect(s1.ptr[0] == '4' && s1.ptr[1] == '2');
+  };
+
+  // All the sibling hooks follow the same convention.
+  "i32_to_string returns distinct buffers"_test = [] {
+    auto s1 = __dao_conv_i32_to_string(10);
+    auto s2 = __dao_conv_i32_to_string(20);
+    expect(s1.ptr != s2.ptr);
+    expect(s1.ptr[0] == '1' && s1.ptr[1] == '0');
+    expect(s2.ptr[0] == '2' && s2.ptr[1] == '0');
+  };
+
+  "u64_to_string returns distinct buffers"_test = [] {
+    auto s1 = __dao_conv_u64_to_string(UINT64_C(7));
+    auto s2 = __dao_conv_u64_to_string(UINT64_C(8));
+    expect(s1.ptr != s2.ptr);
+    expect(s1.ptr[0] == '7');
+    expect(s2.ptr[0] == '8');
+  };
+
+  "f64_to_string returns distinct buffers"_test = [] {
+    auto s1 = __dao_conv_f64_to_string(1.5);
+    auto s2 = __dao_conv_f64_to_string(2.5);
+    expect(s1.ptr != s2.ptr);
+  };
+
+  // bool_to_string returns string literals ("true" / "false") which
+  // are deliberately shared globals — this is safe because bool only
+  // has two values.  Verify the two distinct strings.
+  "bool_to_string literals"_test = [] {
+    auto st = __dao_conv_bool_to_string(true);
+    auto sf = __dao_conv_bool_to_string(false);
+    expect(eq(st.len, int64_t{4}));
+    expect(eq(sf.len, int64_t{5}));
+    expect(std::memcmp(st.ptr, "true", 4) == 0);
+    expect(std::memcmp(sf.ptr, "false", 5) == 0);
+  };
+};
+
+// NOLINTEND(readability-magic-numbers)
+
+auto main() -> int {} // NOLINT(readability-named-parameter)

--- a/runtime/core/dao_abi.h
+++ b/runtime/core/dao_abi.h
@@ -77,10 +77,16 @@ bool __dao_eq_string(const struct dao_string *a, const struct dao_string *b);
 // ---------------------------------------------------------------------------
 
 // Scalar-to-string conversions return a dao_string by value.
-// The returned ptr points to thread-local transient storage that is
-// valid until the next call to the same conversion hook on the same
-// thread. Callers must consume or copy the result before the next
-// conversion call.
+// The returned ptr points to a freshly malloc-allocated buffer owned
+// by the caller; successive calls return distinct buffers, so the
+// result may be stored in long-lived data structures (e.g. HashMap
+// keys) without copying.  Matches the convention used by
+// __dao_str_concat.  In the current runtime these allocations are
+// not automatically freed — they leak until process exit.
+//
+// __dao_conv_bool_to_string is a documented exception: it returns a
+// pointer to a static string literal ("true" or "false"), which is
+// safe because the value set has exactly two entries.
 struct dao_string __dao_conv_i8_to_string(int8_t x);
 struct dao_string __dao_conv_i16_to_string(int16_t x);
 struct dao_string __dao_conv_i32_to_string(int32_t x);


### PR DESCRIPTION
## Summary

**Root-cause fix for the "HashMap-in-while bug"** that has forced triple-scan workarounds throughout the bootstrap compiler.

The bug was not in HashMap codegen and not in while-loop handling. It was in the scalar-to-string conversion hooks: every `__dao_conv_<T>_to_string` returned a `dao_string` pointing at a static `_Thread_local` buffer, so every call overwrote the previous contents in place.

## Reproducer

```dao
let m: HashMap<i64> = HashMap<i64>::new()
let i: i64 = to_i64(0)
while i < to_i64(3):
  m = m.set(i64_to_string(i), i * to_i64(10))
  i = i + to_i64(1)
// m.length() before fix: 1.  After fix: 3.
```

## Root cause

Each `i64_to_string(i)` call returned a pointer to the same thread-local buffer. HashMap stored the pointer. On the next iteration, the previous key's contents were overwritten in-place by the new conversion, so HashMap now had two entries with the same key — the update path fired and count was never incremented past 1.

## Fix

- Every `__dao_conv_<T>_to_string` hook (i8/i16/i32/i64/u8/u16/u32/u64/f32/f64) now mallocs a fresh buffer via a new `conv_str_dup` helper, matching the existing convention used by `__dao_str_concat`.
- `bool_to_string` unchanged — it returns string literals (`"true"`/`"false"`) which are safe shared globals.
- `CONTRACT_RUNTIME_ABI.md` §6 updated to document that all string-producing hooks return heap-allocated buffers.
- New `runtime/core/convert_test.cpp` with 6 regressions verifying distinct pointers across successive calls.

## Follow-up

This unblocks removing the triple-scan workarounds throughout `bootstrap/resolver/`, `bootstrap/typecheck/`, and `bootstrap/hir/` — `uses_triples`, `expr_type_triples`, `extend_concept_bindings` triples, and the `extract_extend_decl_indices` / `find_extend_concept_use` / `extend_triple_maybe_add` scaffolding. Separate cleanup PR will follow once this lands.

## Test plan

- [x] Host compiler: 13/13 (including new `convert_test` suite)
- [x] Bootstrap: lexer 105, parser 51, graph 12, resolver 34, typecheck 39, HIR 21 (262 total)
- [x] End-to-end: `hello.dao` and the original reproducer both work correctly
- [x] Reproducer now prints `length = 3` and `count = 3` instead of `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
