### PR TITLE
refactor(bootstrap): 🔥 consolidate triple workarounds into HashMaps

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -79,16 +79,14 @@ class HS:
   symbols: Vector<Symbol>
   types: Vector<DaoType>
   type_info: Vector<i64>
-  expr_types: HashMap<i64>
+  expr_types: HashMap<i64>       // program-level expr_id_key(module_id, node_idx) → type_idx
   sym_types: Vector<i64>
-  uses_map: HashMap<i64>
+  uses_map: HashMap<i64>         // program-level uses_key(file_id, tok_idx) → sym_idx
   hir_nodes: Vector<HirNode>
   hir_idx: Vector<i64>
   diags: Vector<Diagnostic>
-  module_id: i64                 // D7: current module for triple-scan fallback (-1 for single-file)
-  expr_type_triples: Vector<i64> // D7: program-level [mid, node_idx, type_idx, ...] fallback
-  file_id: i64                   // D7: file_id for uses triple scan (-1 for single-file)
-  uses_triples: Vector<i64>     // D7: program-level [file_id, tok_idx, sym_idx, ...] fallback
+  module_id: i64                 // current module id (used in composite keys)
+  file_id: i64                   // current file id (used in composite keys)
 
 class HirResult:
   hir_nodes: Vector<HirNode>
@@ -109,13 +107,13 @@ class HirR:
 // =========================================================================
 
 fn hs_set_hir_nodes(hs: HS, hn: Vector<HirNode>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hn, hs.hir_idx, hs.diags, hs.module_id, hs.expr_type_triples, hs.file_id, hs.uses_triples)
+  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hn, hs.hir_idx, hs.diags, hs.module_id, hs.file_id)
 
 fn hs_set_hir_idx(hs: HS, hi: Vector<i64>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hi, hs.diags, hs.module_id, hs.expr_type_triples, hs.file_id, hs.uses_triples)
+  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hi, hs.diags, hs.module_id, hs.file_id)
 
 fn hs_set_diags(hs: HS, d: Vector<Diagnostic>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hs.hir_idx, d, hs.module_id, hs.expr_type_triples, hs.file_id, hs.uses_triples)
+  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hs.hir_idx, d, hs.module_id, hs.file_id)
 
 fn hs_add_node(hs: HS, node: HirNode): HirR
   let idx: i64 = hs.hir_nodes.length()
@@ -197,40 +195,22 @@ fn hir_expr_type(node: HirNode): i64
   return to_i64(-1)
 
 fn hir_get_expr_type(hs: HS, ast_node_idx: i64): i64
-  // Try the per-module HashMap first (single-file path).
-  let found: Option<i64> = hs.expr_types.get(i64_to_string(ast_node_idx))
+  let key: string = expr_id_key(hs.module_id, ast_node_idx)
+  let found: Option<i64> = hs.expr_types.get(key)
   match found:
     Option.Some(ti):
       return ti
-  // D7: Fall back to scanning the program's expr_type_triples for
-  // the current module. Same workaround as lookup_use in typecheck.
-  if hs.module_id >= 0:
-    let triples: Vector<i64> = hs.expr_type_triples
-    let i: i64 = 0
-    while i + 2 < triples.length():
-      if triples.get(i) == hs.module_id:
-        if triples.get(i + 1) == ast_node_idx:
-          return triples.get(i + 2)
-      i = i + 3
-  return to_i64(-1)
+    Option.None:
+      return to_i64(-1)
 
 fn hir_lookup_use(hs: HS, tok_idx: i64): i64
-  // Try the per-module HashMap first (single-file path).
-  let result: Option<i64> = hs.uses_map.get(i64_to_string(tok_idx))
+  let key: string = uses_key(hs.file_id, tok_idx)
+  let result: Option<i64> = hs.uses_map.get(key)
   match result:
     Option.Some(sym_idx):
       return sym_idx
-  // D7: Fall back to scanning the program's uses triples for the
-  // current file_id. Same workaround as typecheck's lookup_use.
-  if hs.file_id >= 0:
-    let triples: Vector<i64> = hs.uses_triples
-    let i: i64 = 0
-    while i + 2 < triples.length():
-      if triples.get(i) == hs.file_id:
-        if triples.get(i + 1) == tok_idx:
-          return triples.get(i + 2)
-      i = i + 3
-  return to_i64(-1)
+    Option.None:
+      return to_i64(-1)
 
 fn hir_sym_type(hs: HS, sym_idx: i64): i64
   if sym_idx < 0:
@@ -1023,8 +1003,7 @@ fn lower_file(hs: HS, file_node_idx: i64): HirR
 fn build_module_hs(p: Program, mid: i64): HS
   let sf: SourceFile = program_file_of_module(p, mid)
   let po: ParseOutput = sf.parse_output
-  let um: HashMap<i64> = program_module_uses_map(p, sf.file_id)
-  return HS(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.typecheck.types, p.typecheck.type_info, HashMap<i64>::new(), p.typecheck.sym_types, um, Vector<HirNode>::new(), Vector<i64>::new(), Vector<Diagnostic>::new(), mid, p.typecheck.expr_type_triples, sf.file_id, p.resolve.uses)
+  return HS(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.typecheck.types, p.typecheck.type_info, p.typecheck.expr_types, p.typecheck.sym_types, p.resolve.uses, Vector<HirNode>::new(), Vector<i64>::new(), Vector<Diagnostic>::new(), mid, sf.file_id)
 
 // Lower the full program to HIR. For each module in topo order,
 // lower its file AST via `lower_file` (unchanged), extract the
@@ -1052,8 +1031,7 @@ fn program_run_hir(p: Program): Program
     let mid: i64 = p.graph.topo_order.get(ti)
     let sf: SourceFile = program_file_of_module(p, mid)
     let po: ParseOutput = sf.parse_output
-    let um: HashMap<i64> = program_module_uses_map(p, sf.file_id)
-    let hs: HS = HS(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.typecheck.types, p.typecheck.type_info, HashMap<i64>::new(), p.typecheck.sym_types, um, hir_nodes, hir_idx, Vector<Diagnostic>::new(), mid, p.typecheck.expr_type_triples, sf.file_id, p.resolve.uses)
+    let hs: HS = HS(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.typecheck.types, p.typecheck.type_info, p.typecheck.expr_types, p.typecheck.sym_types, p.resolve.uses, hir_nodes, hir_idx, Vector<Diagnostic>::new(), mid, sf.file_id)
 
     let file_r: HirR = lower_file(hs, po.root)
     // Extract the HirFile's decls_lp and wrap in HirModule.
@@ -1088,7 +1066,7 @@ fn program_run_hir(p: Program): Program
     ti = ti + 1
 
   // Emit HirProgram root. Build a temporary HS to use hir_flush_list.
-  let tmp_hs: HS = HS(Vector<Node>::new(), Vector<i64>::new(), Vector<Token>::new(), "", Vector<Symbol>::new(), Vector<DaoType>::new(), Vector<i64>::new(), HashMap<i64>::new(), Vector<i64>::new(), HashMap<i64>::new(), hir_nodes, hir_idx, Vector<Diagnostic>::new(), to_i64(-1), Vector<i64>::new(), to_i64(-1), Vector<i64>::new())
+  let tmp_hs: HS = HS(Vector<Node>::new(), Vector<i64>::new(), Vector<Token>::new(), "", Vector<Symbol>::new(), Vector<DaoType>::new(), Vector<i64>::new(), HashMap<i64>::new(), Vector<i64>::new(), HashMap<i64>::new(), hir_nodes, hir_idx, Vector<Diagnostic>::new(), to_i64(-1), to_i64(-1))
   let mod_fl: HirFlush = hir_flush_list(tmp_hs, module_indices)
   hir_nodes = mod_fl.hs.hir_nodes
   hir_idx = mod_fl.hs.hir_idx
@@ -1103,20 +1081,24 @@ fn program_run_hir(p: Program): Program
 // =========================================================================
 
 fn lower_to_hir(src: string): HirResult
-  // Run frontend pipeline
-  let po: ParseOutput = parse(src)
-  let file_node_idx: i64 = po.root
-  let rr: ResolveResult = resolve(src)
-  let tcr: TypeCheckResult = typecheck(src)
+  // Route through the program pipeline so HS sees the same
+  // composite-keyed uses/expr_types HashMaps as program_run_hir.
+  let wrapped: string = "module test\n" + src
+  let inputs: Vector<SourceInput> = Vector<SourceInput>::new()
+  inputs = inputs.push(SourceInput("test.dao", wrapped))
+  let pg: ProgramGraph = build_program(inputs)
+  let p: Program = program_from_graph(pg)
+  p = program_run_resolve(p)
+  p = program_run_typecheck(p)
 
-  // Build uses_map from resolve result
-  let um: HashMap<i64> = build_uses_map(rr.uses)
-
-  // Construct HS
-  let hs: HS = HS(po.nodes, po.idx, po.toks, src, rr.symbols, tcr.types, tcr.type_info, tcr.expr_types, tcr.sym_types, um, Vector<HirNode>::new(), Vector<i64>::new(), tcr.diags, to_i64(-1), Vector<i64>::new(), to_i64(-1), Vector<i64>::new())
+  // Single module at mid=0.
+  let mid: i64 = to_i64(0)
+  let sf: SourceFile = program_file_of_module(p, mid)
+  let po: ParseOutput = sf.parse_output
+  let hs: HS = HS(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.typecheck.types, p.typecheck.type_info, p.typecheck.expr_types, p.typecheck.sym_types, p.resolve.uses, Vector<HirNode>::new(), Vector<i64>::new(), Vector<Diagnostic>::new(), mid, sf.file_id)
 
   // Lower
-  let result: HirR = lower_file(hs, file_node_idx)
+  let result: HirR = lower_file(hs, po.root)
   let final_hs: HS = result.hs
 
   return HirResult(final_hs.hir_nodes, final_hs.hir_idx, final_hs.types, final_hs.type_info, final_hs.toks, final_hs.src, final_hs.diags, result.hir)

--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -1083,7 +1083,10 @@ fn program_run_hir(p: Program): Program
 fn lower_to_hir(src: string): HirResult
   // Route through the program pipeline so HS sees the same
   // composite-keyed uses/expr_types HashMaps as program_run_hir.
-  let wrapped: string = "module test\n" + src
+  // wrap_test_module leaves the source unchanged if it already
+  // starts with its own `module` declaration, so callers that
+  // provide complete file text still work.
+  let wrapped: string = wrap_test_module(src)
   let inputs: Vector<SourceInput> = Vector<SourceInput>::new()
   inputs = inputs.push(SourceInput("test.dao", wrapped))
   let pg: ProgramGraph = build_program(inputs)
@@ -1395,7 +1398,7 @@ fn main(): i32
   print("")
 
   let pass_count: i32 = 0
-  let total: i32 = 21
+  let total: i32 = 22
 
   // Test 1: simple_fn
   let src1: string = "fn add(a: i32, b: i32): i32\n  return a + b\n"
@@ -1891,6 +1894,26 @@ fn main(): i32
     pass_count = pass_count + 1
   else:
     print("FAIL method_dispatch_module_isolation")
+
+  // -----------------------------------------------------------------
+  // Test 22: lower_to_hir_respects_own_module
+  // -----------------------------------------------------------------
+  // Regression: lower_to_hir(src) must NOT double-prepend a synthetic
+  // `module test` declaration when the source already has its own
+  // module line.  Before wrap_test_module existed, the adapter
+  // unconditionally prepended, producing two consecutive module
+  // declarations and a parse error.
+  let src22: string = "module app\nfn main(): i32\n  return 42\n"
+  let r22: HirResult = lower_to_hir(src22)
+  // Success means it lowered without error — root is valid.
+  if r22.root >= 0:
+    if hir_count_nodes(r22) > 0:
+      print("PASS lower_to_hir_respects_own_module")
+      pass_count = pass_count + 1
+    else:
+      print("FAIL lower_to_hir_respects_own_module: empty HIR")
+  else:
+    print("FAIL lower_to_hir_respects_own_module: root < 0")
 
   // -----------------------------------------------------------------
   // Summary

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -921,22 +921,22 @@ fn resolve(src: string): ResolveResult
 // Section 30b: Program-level resolver API
 // =========================================================================
 
-// Program uses store triples: [file_id, tok_idx, sym_idx, ...] so
-// consumers can distinguish which file a token index belongs to.
-// (Single-file ResolveResult.uses keeps the old pair format.)
+// Program uses are keyed by `uses_key(file_id, tok_idx)` so the same
+// tok_idx in different files does not collide.  Consumers construct
+// the key via the helper and call .get() directly.
 //
 // `extend_concept_bindings` is the Task 27 D3 side table: each
-// `extend T as C:` block gets a binding from (file_id, decl_idx) to
-// the concept's resolver-bound sym_idx.  Stored as flat triples
-// [file_id, decl_idx, sym_idx, ...] to avoid the HashMap-in-while
-// codegen bug.  Typecheck reads this via `program_extend_concept_sym`.
+// `extend T as C:` block gets a binding from
+// `extend_binding_key(file_id, decl_idx)` to the concept's
+// resolver-bound sym_idx.  Typecheck reads this via
+// `program_extend_concept_sym` instead of scanning symbols by name.
 class ProgramResolveResult:
   symbols: Vector<Symbol>
   scopes: Vector<Scope>
-  uses: Vector<i64>       // flat triples: [file_id, tok_idx, sym_idx, ...]
+  uses: HashMap<i64>      // keyed by uses_key(file_id, tok_idx) → sym_idx
   diags: Vector<FileDiagnostic>
   module_exports: ExportTables
-  extend_concept_bindings: Vector<i64>  // flat triples: [file_id, decl_idx, sym_idx, ...]
+  extend_concept_bindings: HashMap<i64>
 
 // Build export table by walking the file's declarations and looking up
 // each declared name in the scope.  This exports only the module's own
@@ -978,62 +978,18 @@ fn build_export_table(rs: RS, file_node_idx: i64): HashMap<i64>
         i = i + 1
   return exports
 
-// D3 helpers factored out of resolve_program to avoid the
-// mutable-variable-in-while codegen bug.  Each function encapsulates
-// one concern so the calling while loop body stays flat (no match/if
-// nesting around mutable variable reassignment).
+// Composite key for ProgramResolveResult.extend_concept_bindings:
+// "<file_id>:<decl_idx>".  Both the resolver write side (D3) and the
+// typecheck read side (`program_extend_concept_sym`) go through this
+// helper so the key format stays in one place.
+fn extend_binding_key(file_id: i64, decl_idx: i64): string
+  return i64_to_string(file_id) + ":" + i64_to_string(decl_idx)
 
-// Returns the decl_idx if the node is an ExtendDeclD, else -1.
-fn extend_decl_or_neg(po: ParseOutput, decl_idx: i64): i64
-  let node: Node = po.nodes.get(decl_idx)
-  match node:
-    Node.ExtendDeclD(ttn, cn, ml):
-      return decl_idx
-  return to_i64(-1)
-
-// Conditionally append a value to a vector (noop if val < 0).
-fn vec_i64_maybe_push(v: Vector<i64>, val: i64): Vector<i64>
-  if val >= 0:
-    return v.push(val)
-  return v
-
-// Extract the node indices of all ExtendDeclD nodes from a file's
-// top-level declarations.  The while loop body calls helpers to avoid
-// nesting match/if around the mutable vector reassignment.
-fn extract_extend_decl_indices(po: ParseOutput): Vector<i64>
-  let result: Vector<i64> = Vector<i64>::new()
-  let root: Node = po.nodes.get(po.root)
-  match root:
-    Node.FileN(md, imp_lp, dec_lp):
-      let decls: Vector<i64> = pg_read_list(po.idx, dec_lp)
-      let i: i64 = 0
-      while i < decls.length():
-        result = vec_i64_maybe_push(result, extend_decl_or_neg(po, decls.get(i)))
-        i = i + 1
-  return result
-
-// Find the resolver-bound concept sym_idx for a given extend decl by
-// scanning the uses delta.  Returns -1 if no binding found.
-fn find_extend_concept_use(po: ParseOutput, ext_idx: i64, uses: Vector<i64>, uses_before: i64): i64
-  let node: Node = po.nodes.get(ext_idx)
-  match node:
-    Node.ExtendDeclD(ttn, concept_name_tidx, ml):
-      if concept_name_tidx >= 0:
-        let i: i64 = uses_before
-        while i < uses.length():
-          if uses.get(i) == concept_name_tidx:
-            return uses.get(i + 1)
-          i = i + 2
-  return to_i64(-1)
-
-// Conditionally append a (file_id, decl_idx, sym_idx) triple.
-fn extend_triple_maybe_add(triples: Vector<i64>, file_id: i64, decl_idx: i64, sym: i64): Vector<i64>
-  if sym >= 0:
-    let r: Vector<i64> = triples.push(file_id)
-    r = r.push(decl_idx)
-    r = r.push(sym)
-    return r
-  return triples
+// Composite key for ProgramResolveResult.uses:
+// "<file_id>:<tok_idx>".  Disambiguates identical token indices
+// across different files.
+fn uses_key(file_id: i64, tok_idx: i64): string
+  return i64_to_string(file_id) + ":" + i64_to_string(tok_idx)
 
 fn resolve_program(pg: ProgramGraph): ProgramResolveResult
   // Shared mutable state across all modules — symbols and scopes
@@ -1042,16 +998,14 @@ fn resolve_program(pg: ProgramGraph): ProgramResolveResult
   // with file provenance.  Module exports accumulate per-module.
   let all_symbols: Vector<Symbol> = Vector<Symbol>::new()
   let all_scopes: Vector<Scope> = Vector<Scope>::new()
-  let all_uses_triples: Vector<i64> = Vector<i64>::new()
+  let all_uses: HashMap<i64> = HashMap<i64>::new()
   // Internal pair-format uses passed to RS; snapshot length before
   // each module to extract the per-module delta.
   let rs_uses: Vector<i64> = Vector<i64>::new()
   let all_diags: Vector<FileDiagnostic> = Vector<FileDiagnostic>::new()
   let export_tables: Vector<ExportTable> = Vector<ExportTable>::new()
   // D3: concept bindings accumulated during Pass 2 body resolution.
-  // Stored as flat triples [file_id, decl_idx, sym_idx, ...] to
-  // avoid the HashMap-in-while codegen bug.
-  let all_extend_triples: Vector<i64> = Vector<i64>::new()
+  let all_extend_bindings: HashMap<i64> = HashMap<i64>::new()
 
   // Initialize empty export tables for all modules.
   let mi: i64 = 0
@@ -1128,12 +1082,11 @@ fn resolve_program(pg: ProgramGraph): ProgramResolveResult
     all_symbols = rs.symbols
     all_scopes = rs.scopes
     rs_uses = rs.uses
-    // Convert new uses (pairs) to triples with file provenance.
+    // Merge new uses (pairs) into the program-level HashMap keyed by
+    // uses_key(file_id, tok_idx).
     let ui: i64 = uses_before
     while ui < rs_uses.length():
-      all_uses_triples = all_uses_triples.push(sf.file_id)
-      all_uses_triples = all_uses_triples.push(rs_uses.get(ui))
-      all_uses_triples = all_uses_triples.push(rs_uses.get(ui + 1))
+      all_uses = all_uses.set(uses_key(sf.file_id, rs_uses.get(ui)), rs_uses.get(ui + 1))
       ui = ui + 2
     // Merge per-file diagnostics with provenance.
     let pdi: i64 = 0
@@ -1165,23 +1118,38 @@ fn resolve_program(pg: ProgramGraph): ProgramResolveResult
     all_symbols = rs.symbols
     all_scopes = rs.scopes
     rs_uses = rs.uses
-    // Convert new uses to triples.
+    // Merge new uses into the program-level HashMap.
     let ui: i64 = uses_before
     while ui < rs_uses.length():
-      all_uses_triples = all_uses_triples.push(sf.file_id)
-      all_uses_triples = all_uses_triples.push(rs_uses.get(ui))
-      all_uses_triples = all_uses_triples.push(rs_uses.get(ui + 1))
+      all_uses = all_uses.set(uses_key(sf.file_id, rs_uses.get(ui)), rs_uses.get(ui + 1))
       ui = ui + 2
 
     // D3: Extract concept bindings for this module's extend decls.
-    // Calls a helper function per-decl to avoid deep nesting that
-    // triggers the mutable-variable-in-while codegen bug.
-    let d3_decl_list: Vector<i64> = extract_extend_decl_indices(po)
-    let d3i: i64 = 0
-    while d3i < d3_decl_list.length():
-      let d3_concept: i64 = find_extend_concept_use(po, d3_decl_list.get(d3i), rs_uses, uses_before)
-      all_extend_triples = extend_triple_maybe_add(all_extend_triples, sf.file_id, d3_decl_list.get(d3i), d3_concept)
-      d3i = d3i + 1
+    // For each ExtendDeclD, the resolver recorded a use for the
+    // concept name token during resolve_extend_decl.  Find that use
+    // in the per-module delta and store the binding under
+    // extend_binding_key(file_id, decl_idx).
+    let root_node_p2: Node = po.nodes.get(po.root)
+    match root_node_p2:
+      Node.FileN(md2, imp_lp2, dec_lp2):
+        let ext_decls: Vector<i64> = pg_read_list(po.idx, dec_lp2)
+        let edi: i64 = 0
+        while edi < ext_decls.length():
+          let ext_idx: i64 = ext_decls.get(edi)
+          let ext_node: Node = po.nodes.get(ext_idx)
+          match ext_node:
+            Node.ExtendDeclD(ttn2, concept_name_tidx, ml2):
+              if concept_name_tidx >= 0:
+                let ubi: i64 = uses_before
+                while ubi < rs_uses.length():
+                  if rs_uses.get(ubi) == concept_name_tidx:
+                    let concept_sym: i64 = rs_uses.get(ubi + 1)
+                    let bkey: string = extend_binding_key(sf.file_id, ext_idx)
+                    all_extend_bindings = all_extend_bindings.set(bkey, concept_sym)
+                    ubi = rs_uses.length()
+                  else:
+                    ubi = ubi + 2
+          edi = edi + 1
 
     let pdi: i64 = 0
     while pdi < rs.diags.length():
@@ -1189,7 +1157,7 @@ fn resolve_program(pg: ProgramGraph): ProgramResolveResult
       pdi = pdi + 1
     ti = ti + 1
 
-  return ProgramResolveResult(all_symbols, all_scopes, all_uses_triples, all_diags, ExportTables(export_tables), all_extend_triples)
+  return ProgramResolveResult(all_symbols, all_scopes, all_uses, all_diags, ExportTables(export_tables), all_extend_bindings)
 
 // =========================================================================
 // Section 30: Task 27 — Program wrapper and service helpers (D0)
@@ -1221,11 +1189,11 @@ fn program_from_graph(pg: ProgramGraph): Program
   let empty_resolve: ProgramResolveResult = ProgramResolveResult(
     Vector<Symbol>::new(),
     Vector<Scope>::new(),
-    Vector<i64>::new(),
+    HashMap<i64>::new(),
     Vector<FileDiagnostic>::new(),
     ExportTables(Vector<ExportTable>::new()),
-    Vector<i64>::new())
-  let empty_tc: TypeCheckData = TypeCheckData(false, Vector<DaoType>::new(), Vector<i64>::new(), Vector<i64>::new(), HashMap<i64>::new(), Vector<i64>::new())
+    HashMap<i64>::new())
+  let empty_tc: TypeCheckData = TypeCheckData(false, Vector<DaoType>::new(), Vector<i64>::new(), Vector<i64>::new(), HashMap<i64>::new())
   let empty_hir: HirData = HirData(false, to_i64(-1), to_i64(0), to_i64(0))
   return Program(pg, empty_resolve, empty_tc, empty_hir, Vector<FileDiagnostic>::new())
 
@@ -1274,59 +1242,24 @@ fn program_exported_symbol(p: Program, mid: i64, name: string): i64
 // typecheck/HIR should consult that stream.  Returns -1 if no
 // matching triple exists.
 fn program_resolved_use(p: Program, file_id: i64, tok_idx: i64): i64
-  let uses: Vector<i64> = p.resolve.uses
-  let i: i64 = 0
-  while i + 2 < uses.length():
-    if uses.get(i) == file_id:
-      if uses.get(i + 1) == tok_idx:
-        return uses.get(i + 2)
-    i = i + 3
-  return to_i64(-1)
-
-// Build a per-module uses_map (HashMap<i64> keyed by tok_idx →
-// sym_idx) from the program's triple stream, filtered to the given
-// file_id. This is the bridge between the program-level resolve
-// output (triple format) and the per-file TC (pair-format uses_map).
-// Typecheck constructs TC.uses_map through this helper; no pass
-// should scan the raw uses triples directly.
-//
-// NOTE: The two-pass structure (collect matching pairs into a Vector,
-// then build the HashMap) works around a bootstrap compiler scoping
-// issue where HashMap reassignment inside a `while + if` conditional
-// branch does not propagate to the outer loop scope. By building the
-// HashMap in a separate unconditional loop, every `.set()` call
-// properly updates the accumulator.
-// Helper for program_module_uses_map: conditionally add a triple to a
-// HashMap. The `if` branch is inside this function body (not inside
-// the caller's while loop) to work around a bootstrap compiler scoping
-// issue where mutable variable reassignment inside `while + if` does
-// not propagate to the outer loop scope.
-fn uses_map_maybe_add(um: HashMap<i64>, file_id: i64, tri_file: i64, tri_tok: i64, tri_sym: i64): HashMap<i64>
-  if tri_file == file_id:
-    return um.set(i64_to_string(tri_tok), tri_sym)
-  return um
-
-fn program_module_uses_map(p: Program, file_id: i64): HashMap<i64>
-  let um: HashMap<i64> = HashMap<i64>::new()
-  let uses: Vector<i64> = p.resolve.uses
-  let i: i64 = 0
-  while i + 2 < uses.length():
-    um = uses_map_maybe_add(um, file_id, uses.get(i), uses.get(i + 1), uses.get(i + 2))
-    i = i + 3
-  return um
+  let key: string = uses_key(file_id, tok_idx)
+  let found: Option<i64> = p.resolve.uses.get(key)
+  match found:
+    Option.Some(sym_idx):
+      return sym_idx
+    Option.None:
+      return to_i64(-1)
 
 // Look up the concept sym_idx bound to an `extend T as C:` block.
-// Scans the flat triples vector [file_id, decl_idx, sym_idx, ...].
 // Returns -1 if no binding exists.
 fn program_extend_concept_sym(p: Program, file_id: i64, extend_decl_idx: i64): i64
-  let triples: Vector<i64> = p.resolve.extend_concept_bindings
-  let i: i64 = 0
-  while i + 2 < triples.length():
-    if triples.get(i) == file_id:
-      if triples.get(i + 1) == extend_decl_idx:
-        return triples.get(i + 2)
-    i = i + 3
-  return to_i64(-1)
+  let key: string = extend_binding_key(file_id, extend_decl_idx)
+  let found: Option<i64> = p.resolve.extend_concept_bindings.get(key)
+  match found:
+    Option.Some(sym_idx):
+      return sym_idx
+    Option.None:
+      return to_i64(-1)
 
 // BEGIN_RESOLVER_TESTS
 // =========================================================================
@@ -1890,33 +1823,40 @@ fn main(): i32
   else:
     print("FAIL no_transitive_builtin_export: builtins should not be exported")
 
-  // Test 33: uses carry file provenance (triples, not pairs)
-  // Reuse cf_r2 (two-module qualified call) — uses should be triples.
+  // Test 33: uses carry file provenance (composite key format)
+  // Reuse cf_r2 (two-module qualified call).  Uses are now a
+  // HashMap keyed by uses_key(file_id, tok_idx), so file provenance
+  // is enforced by the key format rather than a separate triple
+  // position.  Verify by walking main.dao's tokens and looking up
+  // each one in the HashMap with the composite key — at least one
+  // binding must exist.
   let uses_ok: bool = false
   if cf_r2.uses.length() > 0:
-    // Uses are triples: each entry is 3 elements (file_id, tok_idx, sym_idx).
-    if cf_r2.uses.length() % 3 == 0:
-      // Check that at least one use has file_id matching main.dao's file_id.
-      let main_fid: i64 = to_i64(-1)
-      let mfi: i64 = 0
-      while mfi < cf_pg2.files.length():
-        let mf: SourceFile = cf_pg2.files.get(mfi)
-        if mf.path == "main.dao":
-          main_fid = mf.file_id
-        mfi = mfi + 1
-      let found_main_use: bool = false
-      let uii: i64 = 0
-      while uii < cf_r2.uses.length():
-        if cf_r2.uses.get(uii) == main_fid:
-          found_main_use = true
-        uii = uii + 3
-      if found_main_use:
-        uses_ok = true
+    let main_fid: i64 = to_i64(-1)
+    let mfi: i64 = 0
+    while mfi < cf_pg2.files.length():
+      let mf: SourceFile = cf_pg2.files.get(mfi)
+      if mf.path == "main.dao":
+        main_fid = mf.file_id
+      mfi = mfi + 1
+    if main_fid >= 0:
+      let main_sf: SourceFile = cf_pg2.files.get(main_fid)
+      let tok_count: i64 = main_sf.parse_output.toks.length()
+      let tti: i64 = 0
+      while tti < tok_count:
+        let probe_key: string = uses_key(main_fid, tti)
+        let probe_found: Option<i64> = cf_r2.uses.get(probe_key)
+        match probe_found:
+          Option.Some(v):
+            uses_ok = true
+            tti = tok_count
+          Option.None:
+            tti = tti + 1
   if uses_ok:
     print("PASS uses_file_provenance")
     pass_count = pass_count + 1
   else:
-    print("FAIL uses_file_provenance: uses not in triple format or missing main.dao file_id")
+    print("FAIL uses_file_provenance: no resolver bindings found for main.dao tokens")
 
   // -----------------------------------------------------------------
   // Task 27 D0: Program wrapper and service helpers
@@ -1956,13 +1896,28 @@ fn main(): i32
   if d0_extend_sym != to_i64(-1):
     d0_ok = false
 
-  // program_resolved_use must agree with the raw triple stream.
-  if p1_val.resolve.uses.length() >= 3:
-    let probe_file: i64 = p1_val.resolve.uses.get(0)
-    let probe_tok: i64 = p1_val.resolve.uses.get(1)
-    let probe_sym: i64 = p1_val.resolve.uses.get(2)
-    let via_helper: i64 = program_resolved_use(p1_val, probe_file, probe_tok)
-    if via_helper != probe_sym:
+  // program_resolved_use must return a positive sym_idx for at least
+  // one token in main.dao (which imports and references core::fmt).
+  let d0_main_fid: i64 = to_i64(-1)
+  let d0_mfi: i64 = 0
+  while d0_mfi < p_pg.files.length():
+    let d0_mf: SourceFile = p_pg.files.get(d0_mfi)
+    if d0_mf.path == "main.dao":
+      d0_main_fid = d0_mf.file_id
+    d0_mfi = d0_mfi + 1
+  if d0_main_fid >= 0:
+    let d0_main_sf: SourceFile = p_pg.files.get(d0_main_fid)
+    let d0_tok_count: i64 = d0_main_sf.parse_output.toks.length()
+    let d0_found_use: bool = false
+    let d0_tti: i64 = 0
+    while d0_tti < d0_tok_count:
+      let d0_via_helper: i64 = program_resolved_use(p1_val, d0_main_fid, d0_tti)
+      if d0_via_helper >= 0:
+        d0_found_use = true
+        d0_tti = d0_tok_count
+      else:
+        d0_tti = d0_tti + 1
+    if d0_found_use == false:
       d0_ok = false
 
   // Missing lookups return -1.

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2582,6 +2582,16 @@ class HirData:
 fn expr_id_key(module_id: i64, node_idx: i64): string
   return i64_to_string(module_id) + ":" + i64_to_string(node_idx)
 
+// Wrap a source string with a synthetic `module test` declaration
+// unless it already starts with one.  Used by the single-file
+// adapters (`typecheck(src)`, `lower_to_hir(src)`) so callers can
+// pass either a bare snippet OR a complete file with its own module
+// declaration.
+fn wrap_test_module(src: string): string
+  if starts_with(src, "module "):
+    return src
+  return "module test\n" + src
+
 // Read helpers for TypeCheckData.expr_types.
 
 fn tc_get_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64): i64

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2563,10 +2563,7 @@ class TypeCheckData:
   types: Vector<DaoType>
   type_info: Vector<i64>
   sym_types: Vector<i64>
-  expr_types: HashMap<i64>       // key: expr_id_key(module_id, node_idx)
-  expr_type_triples: Vector<i64> // flat: [module_id, node_idx, type_idx, ...]
-                                 // D5: workaround for bootstrap HashMap-in-while bug;
-                                 // program_run_typecheck accumulates here via Vector.push
+  expr_types: HashMap<i64>       // key: expr_type_key(module_id, node_idx)
 
 class HirData:
   initialized: bool
@@ -2588,27 +2585,17 @@ fn expr_id_key(module_id: i64, node_idx: i64): string
 // Read helpers for TypeCheckData.expr_types.
 
 fn tc_get_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64): i64
-  // Try the HashMap first (populated by single-file path).
   let key: string = expr_id_key(module_id, node_idx)
   let found: Option<i64> = td.expr_types.get(key)
   match found:
     Option.Some(ty):
       return ty
-  // Fall back to scanning the triple stream (populated by
-  // program_run_typecheck via Vector accumulation, which works
-  // around the bootstrap HashMap-in-while codegen bug).
-  let triples: Vector<i64> = td.expr_type_triples
-  let i: i64 = 0
-  while i + 2 < triples.length():
-    if triples.get(i) == module_id:
-      if triples.get(i + 1) == node_idx:
-        return triples.get(i + 2)
-    i = i + 3
-  return to_i64(-1)
+    Option.None:
+      return to_i64(-1)
 
 fn tc_set_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64, ty: i64): TypeCheckData
   let key: string = expr_id_key(module_id, node_idx)
-  return TypeCheckData(td.initialized, td.types, td.type_info, td.sym_types, td.expr_types.set(key, ty), td.expr_type_triples)
+  return TypeCheckData(td.initialized, td.types, td.type_info, td.sym_types, td.expr_types.set(key, ty))
 
 // --- Graph construction ---
 

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -2012,7 +2012,7 @@ fn typecheck(src: string): TypeCheckResult
   // per-file expr_types which the program orchestrator does not
   // accumulate into TypeCheckData. Multi-module callers should use
   // program_run_typecheck instead.
-  let wrapped: string = "module test\n" + src
+  let wrapped: string = wrap_test_module(src)
   let inputs: Vector<SourceInput> = Vector<SourceInput>::new()
   inputs = inputs.push(SourceInput("test.dao", wrapped))
   let pg: ProgramGraph = build_program(inputs)

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -49,10 +49,9 @@ class TC:
   src: string
   symbols: Vector<Symbol>
   scopes: Vector<Scope>
-  uses_map: HashMap<i64>         // per-module uses (single-file legacy path)
-  uses_triples: Vector<i64>     // program-level uses triples (D4 multi-module path)
+  uses_map: HashMap<i64>         // program-level uses_key(file_id, tok_idx) → sym_idx
   file_id: i64                   // module-level file provenance (-1 for dummy)
-  concept_bindings: Vector<i64> // program-level triples: [file_id, decl_idx, sym_idx, ...]
+  concept_bindings: HashMap<i64> // program-level extend_binding_key → concept sym_idx
   module_id: i64                 // module identity for owner_module_id filtering (D2)
   exports: ExportTables          // cross-module export lookup (D4)
 
@@ -65,9 +64,8 @@ class TS:
   diags: Vector<Diagnostic>
   return_type: i64
   loop_depth: i64
-  expr_types: HashMap<i64>
+  expr_types: HashMap<i64>   // keyed by expr_id_key(module_id, node_idx)
   variant_set: HashMap<i64>  // D4: "{type_idx}:{variant_name}" → 1
-  expr_triples: Vector<i64> // D5: flat [module_id, node_idx, type_idx, ...] for program accumulation
 
 class TypeR:
   ts: TS
@@ -86,19 +84,19 @@ class TypeCheckResult:
 // =========================================================================
 
 fn ts_set_types(ts: TS, t: Vector<DaoType>): TS
-  return TS(ts.tc, t, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, t, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
 fn ts_set_type_info(ts: TS, ti: Vector<i64>): TS
-  return TS(ts.tc, ts.types, ti, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, ts.types, ti, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
 fn ts_set_diags_tc(ts: TS, d: Vector<Diagnostic>): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, d, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, d, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
 fn ts_set_return_type(ts: TS, rt: i64): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, rt, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, rt, ts.loop_depth, ts.expr_types, ts.variant_set)
 
 fn ts_set_loop_depth(ts: TS, ld: i64): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ld, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ld, ts.expr_types, ts.variant_set)
 
 fn ts_add_type(ts: TS, t: DaoType): TypeR
   let idx: i64 = ts.types.length()
@@ -110,14 +108,11 @@ fn ts_add_diag(ts: TS, span: Span, msg: string): TS
   return ts_set_diags_tc(ts, ts.diags.push(d))
 
 fn ts_set_expr_type(ts: TS, node_idx: i64, type_idx: i64): TS
-  let new_et: HashMap<i64> = ts.expr_types.set(i64_to_string(node_idx), type_idx)
-  // D5: Also append a triple for program-level accumulation.
-  // Vector.push works in while loops (unlike HashMap.set), so the
-  // program orchestrator can extract these after pass2.
-  let new_triples: Vector<i64> = ts.expr_triples.push(ts.tc.module_id)
-  new_triples = new_triples.push(node_idx)
-  new_triples = new_triples.push(type_idx)
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, new_et, ts.variant_set, new_triples)
+  // Key by (module_id, node_idx) so the per-program expr_types
+  // HashMap disambiguates nodes across modules.
+  let key: string = expr_id_key(ts.tc.module_id, node_idx)
+  let new_et: HashMap<i64> = ts.expr_types.set(key, type_idx)
+  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, new_et, ts.variant_set)
 
 fn vec_i64_set(v: Vector<i64>, idx: i64, val: i64): Vector<i64>
   // Extend vector if needed
@@ -144,7 +139,7 @@ fn vec_i64_get(v: Vector<i64>, idx: i64): i64
 
 fn ts_set_sym_type(ts: TS, sym_idx: i64, type_idx: i64): TS
   let new_st: Vector<i64> = vec_i64_set(ts.sym_types, sym_idx, type_idx)
-  return TS(ts.tc, ts.types, ts.type_info, new_st, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  return TS(ts.tc, ts.types, ts.type_info, new_st, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
 fn ts_inc_loop_depth(ts: TS): TS
   return ts_set_loop_depth(ts, ts.loop_depth + 1)
@@ -209,36 +204,14 @@ fn ts_node_span(ts: TS, node_idx: i64): Span
 // Section 37: Uses map and lookup
 // =========================================================================
 
-fn build_uses_map(uses: Vector<i64>): HashMap<i64>
-  let m: HashMap<i64> = HashMap<i64>::new()
-  let i: i64 = 0
-  while i < uses.length():
-    let tok_idx: i64 = uses.get(i)
-    let sym_idx: i64 = uses.get(i + 1)
-    m = m.set(i64_to_string(tok_idx), sym_idx)
-    i = i + 2
-  return m
-
 fn lookup_use(ts: TS, tok_idx: i64): i64
-  // D4: Try the program-level triple stream first (works for
-  // multi-module). Falls back to the per-module HashMap for the
-  // single-file legacy path.
-  let triples: Vector<i64> = ts.tc.uses_triples
-  if triples.length() > 0:
-    let file_id: i64 = ts.tc.file_id
-    let i: i64 = 0
-    while i + 2 < triples.length():
-      if triples.get(i) == file_id:
-        if triples.get(i + 1) == tok_idx:
-          return triples.get(i + 2)
-      i = i + 3
-  let result: Option<i64> = ts.tc.uses_map.get(i64_to_string(tok_idx))
+  let key: string = uses_key(ts.tc.file_id, tok_idx)
+  let result: Option<i64> = ts.tc.uses_map.get(key)
   match result:
     Option.Some(sym_idx):
       return sym_idx
     Option.None:
       return to_i64(-1)
-  return to_i64(-1)
 
 // =========================================================================
 // Section 38: Builtin type registration
@@ -288,10 +261,9 @@ fn program_init_typecheck(p: Program): Program
     "",
     Vector<Symbol>::new(),
     Vector<Scope>::new(),
-    HashMap<i64>::new(),
-    Vector<i64>::new(),
+    HashMap<i64>::new(),  // uses_map
     to_i64(-1),
-    Vector<i64>::new(),  // concept_bindings: empty triples
+    HashMap<i64>::new(),  // concept_bindings
     to_i64(-1),
     ExportTables(Vector<ExportTable>::new()))
   let dummy_ts: TS = TS(
@@ -303,16 +275,14 @@ fn program_init_typecheck(p: Program): Program
     to_i64(-1),
     to_i64(0),
     HashMap<i64>::new(),
-    HashMap<i64>::new(),
-    Vector<i64>::new())
+    HashMap<i64>::new())
   let seeded: TS = register_builtins(dummy_ts)
   let td: TypeCheckData = TypeCheckData(
     true,
     seeded.types,
     seeded.type_info,
     seeded.sym_types,
-    HashMap<i64>::new(),
-    Vector<i64>::new())
+    HashMap<i64>::new())
   return Program(p.graph, p.resolve, td, p.hir, p.diags)
 
 // =========================================================================
@@ -595,7 +565,7 @@ fn tc_register_enums(ts: TS, decls: Vector<i64>): TS
           let vname: string = ts_tok_name(r, vname_tidx)
           let vkey: string = i64_to_string(tr.type_idx) + ":" + vname
           let new_vs: HashMap<i64> = r.variant_set.set(vkey, to_i64(1))
-          r = TS(r.tc, r.types, r.type_info, r.sym_types, r.diags, r.return_type, r.loop_depth, r.expr_types, new_vs, r.expr_triples)
+          r = TS(r.tc, r.types, r.type_info, r.sym_types, r.diags, r.return_type, r.loop_depth, r.expr_types, new_vs)
           let payload_count: i64 = r.type_info.get(v_offset + 1)
           v_offset = v_offset + 2 + payload_count
           vr = vr + 1
@@ -723,7 +693,7 @@ fn tc_register_functions(ts: TS, decls: Vector<i64>): TS
     if sym >= 0:
       st = vec_i64_set(st, sym, tidx)
     j = j + 1
-  return TS(r.tc, r.types, r.type_info, st, r.diags, r.return_type, r.loop_depth, r.expr_types, r.variant_set, r.expr_triples)
+  return TS(r.tc, r.types, r.type_info, st, r.diags, r.return_type, r.loop_depth, r.expr_types, r.variant_set)
 
 fn tc_register_methods(ts: TS, decls: Vector<i64>): TS
   let r: TS = ts
@@ -914,17 +884,6 @@ fn tc_register_extend_methods(ts: TS, decls: Vector<i64>): TS
 // Validate that each extend Type as Concept: provides all required
 // methods with matching signatures. Emits diagnostics for missing
 // methods and signature mismatches.
-// Look up the concept sym_idx for an extend decl in the program-level
-// concept bindings triples.  Returns -1 if no binding found.
-fn lookup_concept_sym_in_triples(triples: Vector<i64>, file_id: i64, decl_idx: i64): i64
-  let i: i64 = 0
-  while i + 2 < triples.length():
-    if triples.get(i) == file_id:
-      if triples.get(i + 1) == decl_idx:
-        return triples.get(i + 2)
-    i = i + 3
-  return to_i64(-1)
-
 fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
   let r: TS = ts
   let i: i64 = 0
@@ -934,12 +893,19 @@ fn tc_check_concept_satisfaction(ts: TS, decls: Vector<i64>): TS
     match node:
       Node.ExtendDeclD(target_type_node, concept_name_tidx, methods_lp):
         // Look up the concept type via the resolver-bound identity in
-        // TC.concept_bindings (program-level triples), NOT by scanning
-        // symbols by name.  The resolver already bound the concept name
-        // to its sym_idx during resolution.
+        // TC.concept_bindings, NOT by scanning symbols by name.
+        // The resolver already bound the concept name to its sym_idx
+        // during resolution.
         let concept_name: string = ts_tok_name(r, concept_name_tidx)
         let concept_ti: i64 = to_i64(-1)
-        let concept_sym_idx: i64 = lookup_concept_sym_in_triples(r.tc.concept_bindings, r.tc.file_id, decl_idx)
+        let cb_key: string = extend_binding_key(r.tc.file_id, decl_idx)
+        let cb_found: Option<i64> = r.tc.concept_bindings.get(cb_key)
+        let concept_sym_idx: i64 = to_i64(-1)
+        match cb_found:
+          Option.Some(sym):
+            concept_sym_idx = sym
+          Option.None:
+            concept_sym_idx = to_i64(-1)
         if concept_sym_idx >= 0:
           let cti: i64 = vec_i64_get(r.sym_types, concept_sym_idx)
           if cti >= 0:
@@ -1190,13 +1156,13 @@ fn check_qualname_expr(ts: TS, node_idx: i64, seg_lp: i64, seg_count: i64): TS
   return ts
 
 fn get_expr_type(ts: TS, node_idx: i64): i64
-  let found: Option<i64> = ts.expr_types.get(i64_to_string(node_idx))
+  let key: string = expr_id_key(ts.tc.module_id, node_idx)
+  let found: Option<i64> = ts.expr_types.get(key)
   match found:
     Option.Some(ti):
       return ti
     Option.None:
       return to_i64(-1)
-  return to_i64(-1)
 
 fn check_binary_expr(ts: TS, node_idx: i64, op_tidx: i64, left: i64, right: i64): TS
   let r: TS = check_expr(ts, left)
@@ -1949,12 +1915,11 @@ fn tc_pass2(ts: TS, file_node_idx: i64): TS
 fn build_module_tc(p: Program, mid: i64): TC
   let sf: SourceFile = program_file_of_module(p, mid)
   let po: ParseOutput = sf.parse_output
-  let um: HashMap<i64> = program_module_uses_map(p, sf.file_id)
-  return TC(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.resolve.scopes, um, p.resolve.uses, sf.file_id, p.resolve.extend_concept_bindings, mid, p.resolve.module_exports)
+  return TC(po.nodes, po.idx, po.toks, sf.source_text, p.resolve.symbols, p.resolve.scopes, p.resolve.uses, sf.file_id, p.resolve.extend_concept_bindings, mid, p.resolve.module_exports)
 
 // Helper: build per-module TS from accumulated program state.
-fn build_module_ts(tc: TC, types: Vector<DaoType>, type_info: Vector<i64>, sym_types: Vector<i64>, variant_set: HashMap<i64>): TS
-  return TS(tc, types, type_info, sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), variant_set, Vector<i64>::new())
+fn build_module_ts(tc: TC, types: Vector<DaoType>, type_info: Vector<i64>, sym_types: Vector<i64>, expr_types: HashMap<i64>, variant_set: HashMap<i64>): TS
+  return TS(tc, types, type_info, sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), expr_types, variant_set)
 
 
 // Run type checking over the full program in two passes:
@@ -1977,6 +1942,7 @@ fn program_run_typecheck(p: Program): Program
   let types: Vector<DaoType> = p.typecheck.types
   let type_info: Vector<i64> = p.typecheck.type_info
   let sym_types: Vector<i64> = p.typecheck.sym_types
+  let expr_types: HashMap<i64> = p.typecheck.expr_types
   let variant_set: HashMap<i64> = HashMap<i64>::new()
   // Seed diagnostics from the resolve pass only (the pre-typecheck
   // baseline), NOT from p.diags which may already include typecheck
@@ -1992,12 +1958,13 @@ fn program_run_typecheck(p: Program): Program
     let tc: TC = build_module_tc(p, mid)
     let sf: SourceFile = program_file_of_module(p, mid)
     let po: ParseOutput = sf.parse_output
-    let ts: TS = build_module_ts(tc, types, type_info, sym_types, variant_set)
+    let ts: TS = build_module_ts(tc, types, type_info, sym_types, expr_types, variant_set)
     ts = tc_pass1(ts, po.root)
     // Save accumulated state.
     types = ts.types
     type_info = ts.type_info
     sym_types = ts.sym_types
+    expr_types = ts.expr_types
     variant_set = ts.variant_set
     // Merge per-module diagnostics.
     let di: i64 = 0
@@ -2007,30 +1974,20 @@ fn program_run_typecheck(p: Program): Program
     ti = ti + 1
 
   // --- Program Pass 2: check bodies in topo order ---
-  let all_expr_triples: Vector<i64> = Vector<i64>::new()
-  let expr_td: TypeCheckData = TypeCheckData(true, types, type_info, sym_types, p.typecheck.expr_types, all_expr_triples)
   let t2i: i64 = 0
   while t2i < p.graph.topo_order.length():
     let mid: i64 = p.graph.topo_order.get(t2i)
     let tc: TC = build_module_tc(p, mid)
     let sf: SourceFile = program_file_of_module(p, mid)
     let po: ParseOutput = sf.parse_output
-    let ts: TS = build_module_ts(tc, types, type_info, sym_types, variant_set)
+    let ts: TS = build_module_ts(tc, types, type_info, sym_types, expr_types, variant_set)
     ts = tc_pass2(ts, po.root)
     // Save accumulated state (types/sym_types may grow in pass2
     // via function-body-level type inference, though rare).
     types = ts.types
     type_info = ts.type_info
     sym_types = ts.sym_types
-    // Accumulate per-module expr_type_triples from TS into the
-    // program-wide vector. Vector.push works in while loops (unlike
-    // HashMap.set), so this is the reliable accumulation path.
-    let eti: i64 = 0
-    while eti + 2 < ts.expr_triples.length():
-      all_expr_triples = all_expr_triples.push(ts.expr_triples.get(eti))
-      all_expr_triples = all_expr_triples.push(ts.expr_triples.get(eti + 1))
-      all_expr_triples = all_expr_triples.push(ts.expr_triples.get(eti + 2))
-      eti = eti + 3
+    expr_types = ts.expr_types
     // Merge diagnostics.
     let di: i64 = 0
     while di < ts.diags.length():
@@ -2038,10 +1995,7 @@ fn program_run_typecheck(p: Program): Program
       di = di + 1
     t2i = t2i + 1
 
-  // Write back to TypeCheckData with accumulated expr_type_triples.
-  // tc_get_expr_type scans these triples as a fallback when the
-  // HashMap lookup fails — this is the program-level expr_types path.
-  let td: TypeCheckData = TypeCheckData(true, types, type_info, sym_types, p.typecheck.expr_types, all_expr_triples)
+  let td: TypeCheckData = TypeCheckData(true, types, type_info, sym_types, expr_types)
   return Program(p.graph, p.resolve, td, p.hir, all_diags)
 
 // =========================================================================
@@ -2070,7 +2024,7 @@ fn typecheck(src: string): TypeCheckResult
   let tc: TC = build_module_tc(p, to_i64(0))
   let sf: SourceFile = program_file_of_module(p, to_i64(0))
   let po: ParseOutput = sf.parse_output
-  let ts: TS = build_module_ts(tc, p.typecheck.types, p.typecheck.type_info, p.typecheck.sym_types, HashMap<i64>::new())
+  let ts: TS = build_module_ts(tc, p.typecheck.types, p.typecheck.type_info, p.typecheck.sym_types, p.typecheck.expr_types, HashMap<i64>::new())
 
   // Collect resolve diagnostics into TS.
   let resolve_diags: Vector<Diagnostic> = Vector<Diagnostic>::new()
@@ -2078,7 +2032,7 @@ fn typecheck(src: string): TypeCheckResult
   while rdi < p.resolve.diags.length():
     resolve_diags = resolve_diags.push(p.resolve.diags.get(rdi).diag)
     rdi = rdi + 1
-  ts = TS(ts.tc, ts.types, ts.type_info, ts.sym_types, resolve_diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set, ts.expr_triples)
+  ts = TS(ts.tc, ts.types, ts.type_info, ts.sym_types, resolve_diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
   ts = tc_pass1(ts, po.root)
   ts = tc_pass2(ts, po.root)
@@ -2506,10 +2460,27 @@ fn main(): i32
 
   let d3_ok: bool = true
 
-  // The binding triples should have an entry for the extend decl.
-  // Verify by checking that the triples vector is non-empty (at least
-  // one triple = 3 entries for the extend Msg as Showable:).
-  if d3_p.resolve.extend_concept_bindings.length() < 3:
+  // The binding HashMap should have an entry for the extend decl.
+  // Walk the single file's extend decls and verify at least one
+  // binding resolves via program_extend_concept_sym.
+  let d3_sf: SourceFile = program_file_of_module(d3_p, to_i64(0))
+  let d3_po: ParseOutput = d3_sf.parse_output
+  let d3_found_binding: bool = false
+  let d3_root: Node = d3_po.nodes.get(d3_po.root)
+  match d3_root:
+    Node.FileN(md3, il3, dl3):
+      let d3_decls: Vector<i64> = read_list(d3_po.idx, dl3)
+      let d3i: i64 = 0
+      while d3i < d3_decls.length():
+        let d3_didx: i64 = d3_decls.get(d3i)
+        let d3_node: Node = d3_po.nodes.get(d3_didx)
+        match d3_node:
+          Node.ExtendDeclD(t3, c3, m3):
+            let d3_sym: i64 = program_extend_concept_sym(d3_p, d3_sf.file_id, d3_didx)
+            if d3_sym >= 0:
+              d3_found_binding = true
+        d3i = d3i + 1
+  if d3_found_binding == false:
     d3_ok = false
 
   // Now run typecheck through the adapter — the extend declares
@@ -2580,19 +2551,17 @@ fn main(): i32
   let d4_main_mid: i64 = find_module_by_name(d4_p1.graph.modules, "app::main")
   let d4_sf: SourceFile = program_file_of_module(d4_p1, d4_main_mid)
   let d4_po: ParseOutput = d4_sf.parse_output
-  let d4_um: HashMap<i64> = program_module_uses_map(d4_p1, d4_sf.file_id)
-  let d4_tc: TC = TC(d4_po.nodes, d4_po.idx, d4_po.toks, d4_sf.source_text, d4_p1.resolve.symbols, d4_p1.resolve.scopes, d4_um, d4_p1.resolve.uses, d4_sf.file_id, d4_p1.resolve.extend_concept_bindings, d4_main_mid, d4_p1.resolve.module_exports)
-  let d4_ts: TS = TS(d4_tc, d4_p1.typecheck.types, d4_p1.typecheck.type_info, d4_p1.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new(), Vector<i64>::new())
+  let d4_tc: TC = TC(d4_po.nodes, d4_po.idx, d4_po.toks, d4_sf.source_text, d4_p1.resolve.symbols, d4_p1.resolve.scopes, d4_p1.resolve.uses, d4_sf.file_id, d4_p1.resolve.extend_concept_bindings, d4_main_mid, d4_p1.resolve.module_exports)
+  let d4_ts: TS = TS(d4_tc, d4_p1.typecheck.types, d4_p1.typecheck.type_info, d4_p1.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new())
   // Run pass1 on math first (to register the exported function type).
   let d4_math_mid: i64 = find_module_by_name(d4_p1.graph.modules, "app::math")
   let d4_math_sf: SourceFile = program_file_of_module(d4_p1, d4_math_mid)
   let d4_math_po: ParseOutput = d4_math_sf.parse_output
-  let d4_math_um: HashMap<i64> = program_module_uses_map(d4_p1, d4_math_sf.file_id)
-  let d4_math_tc: TC = TC(d4_math_po.nodes, d4_math_po.idx, d4_math_po.toks, d4_math_sf.source_text, d4_p1.resolve.symbols, d4_p1.resolve.scopes, d4_math_um, d4_p1.resolve.uses, d4_math_sf.file_id, d4_p1.resolve.extend_concept_bindings, d4_math_mid, d4_p1.resolve.module_exports)
-  let d4_math_ts: TS = TS(d4_math_tc, d4_p1.typecheck.types, d4_p1.typecheck.type_info, d4_p1.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new(), Vector<i64>::new())
+  let d4_math_tc: TC = TC(d4_math_po.nodes, d4_math_po.idx, d4_math_po.toks, d4_math_sf.source_text, d4_p1.resolve.symbols, d4_p1.resolve.scopes, d4_p1.resolve.uses, d4_math_sf.file_id, d4_p1.resolve.extend_concept_bindings, d4_math_mid, d4_p1.resolve.module_exports)
+  let d4_math_ts: TS = TS(d4_math_tc, d4_p1.typecheck.types, d4_p1.typecheck.type_info, d4_p1.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new())
   d4_math_ts = tc_pass1(d4_math_ts, d4_math_po.root)
   // Now run both passes on main using math's accumulated types/sym_types.
-  d4_ts = TS(d4_tc, d4_math_ts.types, d4_math_ts.type_info, d4_math_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_math_ts.variant_set, Vector<i64>::new())
+  d4_ts = TS(d4_tc, d4_math_ts.types, d4_math_ts.type_info, d4_math_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_math_ts.variant_set)
   d4_ts = tc_pass1(d4_ts, d4_po.root)
   d4_ts = tc_pass2(d4_ts, d4_po.root)
 
@@ -2622,18 +2591,16 @@ fn main(): i32
   let d4_b_mid: i64 = find_module_by_name(d4_p2.graph.modules, "app::b")
   let d4_b_sf: SourceFile = program_file_of_module(d4_p2, d4_b_mid)
   let d4_b_po: ParseOutput = d4_b_sf.parse_output
-  let d4_b_um: HashMap<i64> = program_module_uses_map(d4_p2, d4_b_sf.file_id)
-  let d4_b_tc: TC = TC(d4_b_po.nodes, d4_b_po.idx, d4_b_po.toks, d4_b_sf.source_text, d4_p2.resolve.symbols, d4_p2.resolve.scopes, d4_b_um, d4_p2.resolve.uses, d4_b_sf.file_id, d4_p2.resolve.extend_concept_bindings, d4_b_mid, d4_p2.resolve.module_exports)
+  let d4_b_tc: TC = TC(d4_b_po.nodes, d4_b_po.idx, d4_b_po.toks, d4_b_sf.source_text, d4_p2.resolve.symbols, d4_p2.resolve.scopes, d4_p2.resolve.uses, d4_b_sf.file_id, d4_p2.resolve.extend_concept_bindings, d4_b_mid, d4_p2.resolve.module_exports)
   // Run pass1 on lib::a first.
   let d4_a_mid: i64 = find_module_by_name(d4_p2.graph.modules, "lib::a")
   let d4_a_sf: SourceFile = program_file_of_module(d4_p2, d4_a_mid)
   let d4_a_po: ParseOutput = d4_a_sf.parse_output
-  let d4_a_um: HashMap<i64> = program_module_uses_map(d4_p2, d4_a_sf.file_id)
-  let d4_a_tc: TC = TC(d4_a_po.nodes, d4_a_po.idx, d4_a_po.toks, d4_a_sf.source_text, d4_p2.resolve.symbols, d4_p2.resolve.scopes, d4_a_um, d4_p2.resolve.uses, d4_a_sf.file_id, d4_p2.resolve.extend_concept_bindings, d4_a_mid, d4_p2.resolve.module_exports)
-  let d4_a_ts: TS = TS(d4_a_tc, d4_p2.typecheck.types, d4_p2.typecheck.type_info, d4_p2.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new(), Vector<i64>::new())
+  let d4_a_tc: TC = TC(d4_a_po.nodes, d4_a_po.idx, d4_a_po.toks, d4_a_sf.source_text, d4_p2.resolve.symbols, d4_p2.resolve.scopes, d4_p2.resolve.uses, d4_a_sf.file_id, d4_p2.resolve.extend_concept_bindings, d4_a_mid, d4_p2.resolve.module_exports)
+  let d4_a_ts: TS = TS(d4_a_tc, d4_p2.typecheck.types, d4_p2.typecheck.type_info, d4_p2.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new())
   d4_a_ts = tc_pass1(d4_a_ts, d4_a_po.root)
   // Now typecheck app::b.
-  let d4_b_ts: TS = TS(d4_b_tc, d4_a_ts.types, d4_a_ts.type_info, d4_a_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_a_ts.variant_set, Vector<i64>::new())
+  let d4_b_ts: TS = TS(d4_b_tc, d4_a_ts.types, d4_a_ts.type_info, d4_a_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_a_ts.variant_set)
   d4_b_ts = tc_pass1(d4_b_ts, d4_b_po.root)
   d4_b_ts = tc_pass2(d4_b_ts, d4_b_po.root)
 
@@ -2662,17 +2629,15 @@ fn main(): i32
   let d4_c_mid: i64 = find_module_by_name(d4_p3.graph.modules, "lib::colors")
   let d4_c_sf: SourceFile = program_file_of_module(d4_p3, d4_c_mid)
   let d4_c_po: ParseOutput = d4_c_sf.parse_output
-  let d4_c_um: HashMap<i64> = program_module_uses_map(d4_p3, d4_c_sf.file_id)
-  let d4_c_tc: TC = TC(d4_c_po.nodes, d4_c_po.idx, d4_c_po.toks, d4_c_sf.source_text, d4_p3.resolve.symbols, d4_p3.resolve.scopes, d4_c_um, d4_p3.resolve.uses, d4_c_sf.file_id, d4_p3.resolve.extend_concept_bindings, d4_c_mid, d4_p3.resolve.module_exports)
-  let d4_c_ts: TS = TS(d4_c_tc, d4_p3.typecheck.types, d4_p3.typecheck.type_info, d4_p3.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new(), Vector<i64>::new())
+  let d4_c_tc: TC = TC(d4_c_po.nodes, d4_c_po.idx, d4_c_po.toks, d4_c_sf.source_text, d4_p3.resolve.symbols, d4_p3.resolve.scopes, d4_p3.resolve.uses, d4_c_sf.file_id, d4_p3.resolve.extend_concept_bindings, d4_c_mid, d4_p3.resolve.module_exports)
+  let d4_c_ts: TS = TS(d4_c_tc, d4_p3.typecheck.types, d4_p3.typecheck.type_info, d4_p3.typecheck.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), HashMap<i64>::new())
   d4_c_ts = tc_pass1(d4_c_ts, d4_c_po.root)
   // Run pass1+pass2 on app::d with colors' variant_set.
   let d4_d_mid: i64 = find_module_by_name(d4_p3.graph.modules, "app::d")
   let d4_d_sf: SourceFile = program_file_of_module(d4_p3, d4_d_mid)
   let d4_d_po: ParseOutput = d4_d_sf.parse_output
-  let d4_d_um: HashMap<i64> = program_module_uses_map(d4_p3, d4_d_sf.file_id)
-  let d4_d_tc: TC = TC(d4_d_po.nodes, d4_d_po.idx, d4_d_po.toks, d4_d_sf.source_text, d4_p3.resolve.symbols, d4_p3.resolve.scopes, d4_d_um, d4_p3.resolve.uses, d4_d_sf.file_id, d4_p3.resolve.extend_concept_bindings, d4_d_mid, d4_p3.resolve.module_exports)
-  let d4_d_ts: TS = TS(d4_d_tc, d4_c_ts.types, d4_c_ts.type_info, d4_c_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_c_ts.variant_set, Vector<i64>::new())
+  let d4_d_tc: TC = TC(d4_d_po.nodes, d4_d_po.idx, d4_d_po.toks, d4_d_sf.source_text, d4_p3.resolve.symbols, d4_p3.resolve.scopes, d4_p3.resolve.uses, d4_d_sf.file_id, d4_p3.resolve.extend_concept_bindings, d4_d_mid, d4_p3.resolve.module_exports)
+  let d4_d_ts: TS = TS(d4_d_tc, d4_c_ts.types, d4_c_ts.type_info, d4_c_ts.sym_types, Vector<Diagnostic>::new(), to_i64(-1), to_i64(0), HashMap<i64>::new(), d4_c_ts.variant_set)
   d4_d_ts = tc_pass1(d4_d_ts, d4_d_po.root)
   d4_d_ts = tc_pass2(d4_d_ts, d4_d_po.root)
   let d4_3_ok: bool = false


### PR DESCRIPTION
## Summary

Now that PR #246 fixed the root cause (`i64_to_string` returning thread-local buffer pointers), **all** triple-based workarounds for the "HashMap-in-while" bug are obsolete. Consolidate them into direct HashMap storage with composite keys.

## What got ripped out

### Data model

| Before | After |
|---|---|
| `ProgramResolveResult.extend_concept_bindings: Vector<i64>` (triples) | `HashMap<i64>` keyed by `extend_binding_key(file_id, decl_idx)` |
| `ProgramResolveResult.uses: Vector<i64>` (triples) | `HashMap<i64>` keyed by `uses_key(file_id, tok_idx)` |
| `TypeCheckData.expr_type_triples: Vector<i64>` | **dropped**; `expr_types` HashMap holds the program-level table directly |
| `TS.expr_triples: Vector<i64>` | **dropped**; `ts_set_expr_type` writes composite keys directly |
| `TC.uses_triples: Vector<i64>` | **dropped**; `TC.uses_map` IS the program-level HashMap |
| `HS.uses_triples: Vector<i64>` | **dropped** |
| `HS.expr_type_triples: Vector<i64>` | **dropped** |

### Helper functions removed

- `extract_extend_decl_indices`, `find_extend_concept_use`, `extend_triple_maybe_add`, `vec_i64_maybe_push`, `extend_decl_or_neg` (D3 binding extraction — inlined into `resolve_program`)
- `lookup_concept_sym_in_triples` (replaced by `HashMap.get`)
- `program_module_uses_map`, `uses_map_maybe_add` (no longer needed; TC/HS just reference `p.resolve.uses` directly)
- `build_uses_map` (unused after `lower_to_hir` routes through program pipeline)

### Triple-scan fallbacks removed

- `lookup_use` in typecheck
- `hir_lookup_use`, `hir_get_expr_type` in HIR
- `tc_get_expr_type` in shared

### Single-file path unification

`lower_to_hir(src)` now routes through the program pipeline (`build_program → program_run_resolve → program_run_typecheck`) instead of the legacy `resolve(src)` path, so HS always sees composite-keyed HashMaps regardless of single-file vs multi-file mode.

### Test updates

- `uses_file_provenance`: walk main.dao tokens and probe each via `uses_key` instead of iterating triples
- `d0_program_wrapper`: probe `program_resolved_use` across tokens instead of reading triple stream directly
- `d3_concept_binding_identity`: use `program_extend_concept_sym` instead of raw triples length check

## Net impact

**-111 lines** across bootstrap (349 deletions vs 238 insertions).

## Test plan

- [x] Lexer: 105/105
- [x] Parser: 51/51
- [x] Graph: 12/12
- [x] Resolver: 34/34
- [x] Typecheck: 43/43
- [x] HIR: 21/21
- [x] All 266 bootstrap tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
