### PR TITLE
refactor(bootstrap): 🔥 use direct field mutation instead of COW reconstruction

### DIFF
--- a/bootstrap/hir/impl.dao
+++ b/bootstrap/hir/impl.dao
@@ -106,26 +106,18 @@ class HirR:
 // Section 51: HS state helpers
 // =========================================================================
 
-fn hs_set_hir_nodes(hs: HS, hn: Vector<HirNode>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hn, hs.hir_idx, hs.diags, hs.module_id, hs.file_id)
-
-fn hs_set_hir_idx(hs: HS, hi: Vector<i64>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hi, hs.diags, hs.module_id, hs.file_id)
-
-fn hs_set_diags(hs: HS, d: Vector<Diagnostic>): HS
-  return HS(hs.nodes, hs.idx_data, hs.toks, hs.src, hs.symbols, hs.types, hs.type_info, hs.expr_types, hs.sym_types, hs.uses_map, hs.hir_nodes, hs.hir_idx, d, hs.module_id, hs.file_id)
-
 fn hs_add_node(hs: HS, node: HirNode): HirR
   let idx: i64 = hs.hir_nodes.length()
-  let new_hs: HS = hs_set_hir_nodes(hs, hs.hir_nodes.push(node))
-  return HirR(new_hs, idx)
+  hs.hir_nodes = hs.hir_nodes.push(node)
+  return HirR(hs, idx)
 
 fn hs_add_diag(hs: HS, span: Span, msg: string): HS
-  let d: Diagnostic = make_error(span, msg)
-  return hs_set_diags(hs, hs.diags.push(d))
+  hs.diags = hs.diags.push(make_error(span, msg))
+  return hs
 
 fn hs_idx_push(hs: HS, val: i64): HS
-  return hs_set_hir_idx(hs, hs.hir_idx.push(val))
+  hs.hir_idx = hs.hir_idx.push(val)
+  return hs
 
 fn hs_tok_name(hs: HS, tidx: i64): string
   let tok: Token = hs.toks.get(tidx)

--- a/bootstrap/resolver/impl.dao
+++ b/bootstrap/resolver/impl.dao
@@ -77,78 +77,48 @@ class ScopeR:
 
 fn rs_add_symbol(rs: RS, sym: Symbol): SymR
   let idx: i64 = rs.symbols.length()
-  let new_syms: Vector<Symbol> = rs.symbols.push(sym)
-  let new_rs: RS = RS(rs.rc, new_syms, rs.scopes, rs.uses, rs.diags, rs.current_scope, rs.owner_module_id)
-  return SymR(new_rs, idx)
-
-fn rs_set_scopes(rs: RS, scopes: Vector<Scope>): RS
-  return RS(rs.rc, rs.symbols, scopes, rs.uses, rs.diags, rs.current_scope, rs.owner_module_id)
-
-fn rs_set_current_scope(rs: RS, scope_idx: i64): RS
-  return RS(rs.rc, rs.symbols, rs.scopes, rs.uses, rs.diags, scope_idx, rs.owner_module_id)
-
-fn rs_set_uses(rs: RS, uses: Vector<i64>): RS
-  return RS(rs.rc, rs.symbols, rs.scopes, uses, rs.diags, rs.current_scope, rs.owner_module_id)
-
-fn rs_set_diags(rs: RS, diags: Vector<Diagnostic>): RS
-  return RS(rs.rc, rs.symbols, rs.scopes, rs.uses, diags, rs.current_scope, rs.owner_module_id)
+  rs.symbols = rs.symbols.push(sym)
+  return SymR(rs, idx)
 
 fn rs_push_scope(rs: RS, kind: ScopeKind): ScopeR
   let idx: i64 = rs.scopes.length()
-  let new_scope: Scope = Scope(kind, rs.current_scope, HashMap<i64>::new())
-  let new_scopes: Vector<Scope> = rs.scopes.push(new_scope)
-  let new_rs: RS = rs_set_current_scope(rs_set_scopes(rs, new_scopes), idx)
-  return ScopeR(new_rs, idx)
+  rs.scopes = rs.scopes.push(Scope(kind, rs.current_scope, HashMap<i64>::new()))
+  rs.current_scope = idx
+  return ScopeR(rs, idx)
 
 fn rs_pop_scope(rs: RS): RS
   let scope: Scope = rs.scopes.get(rs.current_scope)
-  return rs_set_current_scope(rs, scope.parent)
+  rs.current_scope = scope.parent
+  return rs
 
 fn rs_add_use(rs: RS, tok_idx: i64, sym_idx: i64): RS
-  let new_uses: Vector<i64> = rs.uses.push(tok_idx)
-  let new_uses2: Vector<i64> = new_uses.push(sym_idx)
-  return rs_set_uses(rs, new_uses2)
+  rs.uses = rs.uses.push(tok_idx).push(sym_idx)
+  return rs
 
 fn rs_add_diag(rs: RS, span: Span, msg: string): RS
-  let d: Diagnostic = make_error(span, msg)
-  return rs_set_diags(rs, rs.diags.push(d))
+  rs.diags = rs.diags.push(make_error(span, msg))
+  return rs
 
 // =========================================================================
 // Section 19: Scope operations
 // =========================================================================
 
-// Replace a scope in the scopes vector (O(n) but scopes are small).
-fn replace_scope(scopes: Vector<Scope>, idx: i64, new_scope: Scope): Vector<Scope>
-  let result: Vector<Scope> = Vector<Scope>::new()
-  let i: i64 = 0
-  while i < scopes.length():
-    if i == idx:
-      result = result.push(new_scope)
-    else:
-      result = result.push(scopes.get(i))
-    i = i + 1
-  return result
-
 fn rs_update_scope(rs: RS, scope_idx: i64, new_scope: Scope): RS
-  let new_scopes: Vector<Scope> = replace_scope(rs.scopes, scope_idx, new_scope)
-  return rs_set_scopes(rs, new_scopes)
+  rs.scopes = rs.scopes.set(scope_idx, new_scope)
+  return rs
 
 fn scope_declare(rs: RS, name: string, sym_idx: i64, decl_tidx: i64): RS
   let scope: Scope = rs.scopes.get(rs.current_scope)
-  let existing: Option<i64> = scope.decls.get(name)
-  match existing:
+  match scope.decls.get(name):
     Option.Some(eidx):
-      // Duplicate declaration — emit diagnostic at the duplicate's span
       let sp: Span = Span(to_i64(0), to_i64(1))
       if decl_tidx >= 0:
         let tok: Token = rs.rc.toks.get(decl_tidx)
         sp = Span(tok.offset, tok.len)
-      let rs2: RS = rs_add_diag(rs, sp, "duplicate declaration '" + name + "'")
-      return rs2
+      return rs_add_diag(rs, sp, "duplicate declaration '" + name + "'")
     Option.None:
-      let new_decls: HashMap<i64> = scope.decls.set(name, sym_idx)
-      let new_scope: Scope = Scope(scope.kind, scope.parent, new_decls)
-      return rs_update_scope(rs, rs.current_scope, new_scope)
+      scope.decls = scope.decls.set(name, sym_idx)
+      return rs_update_scope(rs, rs.current_scope, scope)
   return rs
 
 fn scope_lookup(rs: RS, name: string): i64

--- a/bootstrap/shared/base.dao
+++ b/bootstrap/shared/base.dao
@@ -2605,7 +2605,8 @@ fn tc_get_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64): i64
 
 fn tc_set_expr_type(td: TypeCheckData, module_id: i64, node_idx: i64, ty: i64): TypeCheckData
   let key: string = expr_id_key(module_id, node_idx)
-  return TypeCheckData(td.initialized, td.types, td.type_info, td.sym_types, td.expr_types.set(key, ty))
+  td.expr_types = td.expr_types.set(key, ty)
+  return td
 
 // --- Graph construction ---
 

--- a/bootstrap/typecheck/impl.dao
+++ b/bootstrap/typecheck/impl.dao
@@ -83,52 +83,27 @@ class TypeCheckResult:
 // Section 35: TS state helpers
 // =========================================================================
 
-fn ts_set_types(ts: TS, t: Vector<DaoType>): TS
-  return TS(ts.tc, t, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
-
-fn ts_set_type_info(ts: TS, ti: Vector<i64>): TS
-  return TS(ts.tc, ts.types, ti, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
-
-fn ts_set_diags_tc(ts: TS, d: Vector<Diagnostic>): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, d, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
-
-fn ts_set_return_type(ts: TS, rt: i64): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, rt, ts.loop_depth, ts.expr_types, ts.variant_set)
-
-fn ts_set_loop_depth(ts: TS, ld: i64): TS
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ld, ts.expr_types, ts.variant_set)
-
 fn ts_add_type(ts: TS, t: DaoType): TypeR
   let idx: i64 = ts.types.length()
-  let new_types: Vector<DaoType> = ts.types.push(t)
-  return TypeR(ts_set_types(ts, new_types), idx)
+  ts.types = ts.types.push(t)
+  return TypeR(ts, idx)
 
 fn ts_add_diag(ts: TS, span: Span, msg: string): TS
-  let d: Diagnostic = make_error(span, msg)
-  return ts_set_diags_tc(ts, ts.diags.push(d))
+  ts.diags = ts.diags.push(make_error(span, msg))
+  return ts
 
 fn ts_set_expr_type(ts: TS, node_idx: i64, type_idx: i64): TS
   // Key by (module_id, node_idx) so the per-program expr_types
   // HashMap disambiguates nodes across modules.
   let key: string = expr_id_key(ts.tc.module_id, node_idx)
-  let new_et: HashMap<i64> = ts.expr_types.set(key, type_idx)
-  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, new_et, ts.variant_set)
+  ts.expr_types = ts.expr_types.set(key, type_idx)
+  return ts
 
 fn vec_i64_set(v: Vector<i64>, idx: i64, val: i64): Vector<i64>
-  // Extend vector if needed
-  let cur: Vector<i64> = v
-  while cur.length() <= idx:
-    cur = cur.push(to_i64(-1))
-  // Replace element at idx
-  let result: Vector<i64> = Vector<i64>::new()
-  let i: i64 = 0
-  while i < cur.length():
-    if i == idx:
-      result = result.push(val)
-    else:
-      result = result.push(cur.get(i))
-    i = i + 1
-  return result
+  // Extend vector if needed, then set.
+  while v.length() <= idx:
+    v = v.push(to_i64(-1))
+  return v.set(idx, val)
 
 fn vec_i64_get(v: Vector<i64>, idx: i64): i64
   if idx < 0:
@@ -138,17 +113,20 @@ fn vec_i64_get(v: Vector<i64>, idx: i64): i64
   return v.get(idx)
 
 fn ts_set_sym_type(ts: TS, sym_idx: i64, type_idx: i64): TS
-  let new_st: Vector<i64> = vec_i64_set(ts.sym_types, sym_idx, type_idx)
-  return TS(ts.tc, ts.types, ts.type_info, new_st, ts.diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
+  ts.sym_types = vec_i64_set(ts.sym_types, sym_idx, type_idx)
+  return ts
 
 fn ts_inc_loop_depth(ts: TS): TS
-  return ts_set_loop_depth(ts, ts.loop_depth + 1)
+  ts.loop_depth = ts.loop_depth + 1
+  return ts
 
 fn ts_dec_loop_depth(ts: TS): TS
-  return ts_set_loop_depth(ts, ts.loop_depth - 1)
+  ts.loop_depth = ts.loop_depth - 1
+  return ts
 
 fn ts_push_type_info(ts: TS, val: i64): TS
-  return ts_set_type_info(ts, ts.type_info.push(val))
+  ts.type_info = ts.type_info.push(val)
+  return ts
 
 // =========================================================================
 // Section 36: Name extraction for type checker
@@ -564,24 +542,13 @@ fn tc_register_enums(ts: TS, decls: Vector<i64>): TS
           let vname_tidx: i64 = r.type_info.get(v_offset)
           let vname: string = ts_tok_name(r, vname_tidx)
           let vkey: string = i64_to_string(tr.type_idx) + ":" + vname
-          let new_vs: HashMap<i64> = r.variant_set.set(vkey, to_i64(1))
-          r = TS(r.tc, r.types, r.type_info, r.sym_types, r.diags, r.return_type, r.loop_depth, r.expr_types, new_vs)
+          r.variant_set = r.variant_set.set(vkey, to_i64(1))
           let payload_count: i64 = r.type_info.get(v_offset + 1)
           v_offset = v_offset + 2 + payload_count
           vr = vr + 1
     i = i + 1
   return r
 
-fn replace_type(types: Vector<DaoType>, idx: i64, new_type: DaoType): Vector<DaoType>
-  let result: Vector<DaoType> = Vector<DaoType>::new()
-  let i: i64 = 0
-  while i < types.length():
-    if i == idx:
-      result = result.push(new_type)
-    else:
-      result = result.push(types.get(i))
-    i = i + 1
-  return result
 
 fn tc_fill_struct_fields(ts: TS, decls: Vector<i64>): TS
   let r: TS = ts
@@ -614,9 +581,10 @@ fn tc_fill_struct_fields(ts: TS, decls: Vector<i64>): TS
         if struct_sym >= 0:
           let struct_ti: i64 = vec_i64_get(r.sym_types, struct_sym)
           if struct_ti >= 0:
-            let old_t: DaoType = r.types.get(struct_ti)
-            let new_t: DaoType = DaoType(old_t.kind, old_t.builtin_id, old_t.name, old_t.decl_node, field_info_start, field_count, old_t.ret_type, old_t.pointee)
-            r = ts_set_types(r, replace_type(r.types, struct_ti, new_t))
+            let t: DaoType = r.types.get(struct_ti)
+            t.info_lp = field_info_start
+            t.info_count = field_count
+            r.types = r.types.set(struct_ti, t)
     i = i + 1
   return r
 
@@ -683,17 +651,15 @@ fn tc_register_functions(ts: TS, decls: Vector<i64>): TS
       fn_syms = fn_syms.push(fn_sym)
       fn_type_idxs = fn_type_idxs.push(tr.type_idx)
     i = i + 1
-  // Phase B: Set all sym_types using the ORIGINAL input sym_types
-  // (r.sym_types may be corrupted by the compiler bug)
-  let st: Vector<i64> = ts.sym_types
+  // Phase B: Set all sym_types.
   let j: i64 = 0
   while j < fn_syms.length():
     let sym: i64 = fn_syms.get(j)
     let tidx: i64 = fn_type_idxs.get(j)
     if sym >= 0:
-      st = vec_i64_set(st, sym, tidx)
+      r.sym_types = vec_i64_set(r.sym_types, sym, tidx)
     j = j + 1
-  return TS(r.tc, r.types, r.type_info, st, r.diags, r.return_type, r.loop_depth, r.expr_types, r.variant_set)
+  return r
 
 fn tc_register_methods(ts: TS, decls: Vector<i64>): TS
   let r: TS = ts
@@ -1697,7 +1663,7 @@ fn tc_check_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_t
   let old_return_type: i64 = r.return_type
   if fn_ti >= 0:
     let fn_type: DaoType = r.types.get(fn_ti)
-    r = ts_set_return_type(r, fn_type.ret_type)
+    r.return_type = fn_type.ret_type
   // Declare param types
   let pairs: Vector<i64> = read_pairs(r.tc.idx_data, params_lp)
   let pi: i64 = 0
@@ -1713,7 +1679,7 @@ fn tc_check_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_t
         r = ts_set_sym_type(r, p_sym, pt_r.type_idx)
     pi = pi + 2
   r = check_body_stmts(r, body_lp)
-  r = ts_set_return_type(r, old_return_type)
+  r.return_type = old_return_type
   return r
 
 fn tc_check_expr_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, ret_type_node: i64, body_expr: i64): TS
@@ -1725,7 +1691,7 @@ fn tc_check_expr_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, 
   let old_return_type: i64 = r.return_type
   if fn_ti >= 0:
     let fn_type: DaoType = r.types.get(fn_ti)
-    r = ts_set_return_type(r, fn_type.ret_type)
+    r.return_type = fn_type.ret_type
   let pairs: Vector<i64> = read_pairs(r.tc.idx_data, params_lp)
   let pi: i64 = 0
   while pi < pairs.length():
@@ -1746,7 +1712,7 @@ fn tc_check_expr_fn_body(ts: TS, decl_idx: i64, name_tidx: i64, params_lp: i64, 
       if types_equal(r, body_ti, r.return_type) == false:
         let sp: Span = ts_node_span(r, body_expr)
         r = ts_add_diag(r, sp, "expression body type mismatch: expected " + type_name(r, r.return_type) + ", got " + type_name(r, body_ti))
-  r = ts_set_return_type(r, old_return_type)
+  r.return_type = old_return_type
   return r
 
 fn tc_check_method_body(ts: TS, class_decl_idx: i64, meth_idx: i64, m_name_tidx: i64, m_params_lp: i64, m_ret_type: i64, m_body_lp: i64): TS
@@ -1773,7 +1739,7 @@ fn tc_check_method_body(ts: TS, class_decl_idx: i64, meth_idx: i64, m_name_tidx:
   let old_return_type: i64 = r.return_type
   if fn_ti >= 0:
     let fn_type: DaoType = r.types.get(fn_ti)
-    r = ts_set_return_type(r, fn_type.ret_type)
+    r.return_type = fn_type.ret_type
   // Declare param types — self gets the enclosing struct type
   let pairs: Vector<i64> = read_pairs(r.tc.idx_data, m_params_lp)
   let pi: i64 = 0
@@ -1797,7 +1763,7 @@ fn tc_check_method_body(ts: TS, class_decl_idx: i64, meth_idx: i64, m_name_tidx:
           r = ts_set_sym_type(r, p_sym, pt_r.type_idx)
     pi = pi + 2
   r = check_body_stmts(r, m_body_lp)
-  r = ts_set_return_type(r, old_return_type)
+  r.return_type = old_return_type
   return r
 
 fn tc_check_extend_method_body(ts: TS, extend_decl_idx: i64, meth_idx: i64, m_name_tidx: i64, m_params_lp: i64, m_ret_type: i64, m_body_lp: i64): TS
@@ -1824,7 +1790,7 @@ fn tc_check_extend_method_body(ts: TS, extend_decl_idx: i64, meth_idx: i64, m_na
   let old_return_type: i64 = r.return_type
   if fn_ti >= 0:
     let fn_type: DaoType = r.types.get(fn_ti)
-    r = ts_set_return_type(r, fn_type.ret_type)
+    r.return_type = fn_type.ret_type
   // Declare param types — self gets the target type
   let pairs: Vector<i64> = read_pairs(r.tc.idx_data, m_params_lp)
   let pi: i64 = 0
@@ -1855,7 +1821,7 @@ fn tc_check_extend_method_body(ts: TS, extend_decl_idx: i64, meth_idx: i64, m_na
           r = ts_set_sym_type(r, p_sym, pt_r.type_idx)
     pi = pi + 2
   r = check_body_stmts(r, m_body_lp)
-  r = ts_set_return_type(r, old_return_type)
+  r.return_type = old_return_type
   return r
 
 fn tc_pass2(ts: TS, file_node_idx: i64): TS
@@ -2027,12 +1993,10 @@ fn typecheck(src: string): TypeCheckResult
   let ts: TS = build_module_ts(tc, p.typecheck.types, p.typecheck.type_info, p.typecheck.sym_types, p.typecheck.expr_types, HashMap<i64>::new())
 
   // Collect resolve diagnostics into TS.
-  let resolve_diags: Vector<Diagnostic> = Vector<Diagnostic>::new()
   let rdi: i64 = 0
   while rdi < p.resolve.diags.length():
-    resolve_diags = resolve_diags.push(p.resolve.diags.get(rdi).diag)
+    ts.diags = ts.diags.push(p.resolve.diags.get(rdi).diag)
     rdi = rdi + 1
-  ts = TS(ts.tc, ts.types, ts.type_info, ts.sym_types, resolve_diags, ts.return_type, ts.loop_depth, ts.expr_types, ts.variant_set)
 
   ts = tc_pass1(ts, po.root)
   ts = tc_pass2(ts, po.root)


### PR DESCRIPTION
## Summary

Dao classes support direct field assignment with value semantics. The bootstrap state-threading code has been reconstructing entire structs via positional constructors for every single field update — pointless ceremony. Replace it with direct mutation.

## What got deleted

### Trivial positional reconstructors (6+ per file)

**`bootstrap/resolver/impl.dao`**:
- `rs_set_scopes`, `rs_set_current_scope`, `rs_set_uses`, `rs_set_diags`
- Hand-rolled `replace_scope` (replaced by stdlib `Vector.set`)

**`bootstrap/typecheck/impl.dao`**:
- `ts_set_types`, `ts_set_type_info`, `ts_set_diags_tc`, `ts_set_return_type`, `ts_set_loop_depth`
- Hand-rolled `replace_type` (replaced by stdlib `Vector.set`)

**`bootstrap/hir/impl.dao`**:
- `hs_set_hir_nodes`, `hs_set_hir_idx`, `hs_set_diags`

## What got rewritten

All the remaining helpers that actually had logic beyond field assignment — they now mutate in place instead of reconstructing:

```dao
// before
fn ts_set_expr_type(ts: TS, node_idx: i64, type_idx: i64): TS
  let key: string = expr_id_key(ts.tc.module_id, node_idx)
  let new_et: HashMap<i64> = ts.expr_types.set(key, type_idx)
  return TS(ts.tc, ts.types, ts.type_info, ts.sym_types, ts.diags, ts.return_type, ts.loop_depth, new_et, ts.variant_set)

// after
fn ts_set_expr_type(ts: TS, node_idx: i64, type_idx: i64): TS
  let key: string = expr_id_key(ts.tc.module_id, node_idx)
  ts.expr_types = ts.expr_types.set(key, type_idx)
  return ts
```

Same pattern applied to `rs_add_symbol`, `rs_push_scope`, `rs_pop_scope`, `rs_add_use`, `rs_add_diag`, `rs_update_scope`, `ts_add_type`, `ts_add_diag`, `ts_set_sym_type`, `ts_inc_loop_depth`, `ts_dec_loop_depth`, `ts_push_type_info`, `hs_add_node`, `hs_add_diag`, `hs_idx_push`, `tc_set_expr_type`, and inline reconstructions in `scope_declare`, `tc_fill_struct_fields`, `tc_register_methods`, and the `typecheck(src)` adapter.

`vec_i64_set` now delegates to `Vector.set` after extending, instead of hand-rolling its own iterate-and-copy.

## Net impact

**-73 lines** (133 deletions, 60 insertions) across 4 files.

## Test plan

- [x] Lexer: 105/105
- [x] Parser: 51/51
- [x] Graph: 12/12
- [x] Resolver: 34/34
- [x] Typecheck: 43/43
- [x] HIR: 22/22
- [x] All 267 bootstrap tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
