### PR TITLE
docs(bootstrap): 📝 mark Task 29 complete, refresh Phase 7 status

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -304,19 +304,22 @@ Task 22 (bootstrap resolver) is complete — two-pass name resolution
 with scope chains, symbol tables, uses map, 34 tests (including
 cross-file resolution and program wrapper tests).
 Task 23 (bootstrap type checker) is complete — expression/statement
-type checking with 37 tests (including cross-module calls, concept
+type checking with 43 tests (including cross-module calls, concept
 binding identity, variant validation, and on-disk multi-file fixtures).
 Task 24 (bootstrap HIR) is complete — typed AST lowered to
-compiler-owned HIR with 19 tests (including program-level lowering
+compiler-owned HIR with 22 tests (including program-level lowering
 and on-disk multi-file smoke test).  Shared substrate consolidated
 in `bootstrap/shared/base.dao`; assembly via `bootstrap/assemble.sh`.
+Task 29 (bootstrap MIR) is complete — HIR lowered to basic-block MIR
+with 8 tests.
 
-The Tier A bootstrap pipeline (lex → parse → resolve → typecheck →
-HIR) is complete.  Tasks 25–27 (multi-file substrate) are complete —
-the `Program` value threads through resolve → typecheck → HIR with
-canonical type identity, cross-module qualified name typing, and
-program-level HIR aggregation.  Task 28 (generic body lowering boundary)
-is complete — see below.
+The Tier A bootstrap frontend-to-IR pipeline (lex → parse → resolve
+→ typecheck → HIR → MIR) is complete.  Tasks 25–27 (multi-file
+substrate) are complete — the `Program` value threads through
+resolve → typecheck → HIR → MIR with canonical type identity,
+cross-module qualified name typing, and program-level HIR aggregation.
+Task 28 (generic body lowering boundary) is complete — see below.
+Task 29 (bootstrap MIR Tier A) is complete — see below.
 
 ### Task 25 — Bootstrap Multi-file Compilation + Imports (v1)
 
@@ -414,6 +417,64 @@ This is architectural cleanup of the host compiler, not a bootstrap
 task.  It lands before Tier B bootstrap slices because those slices
 (methods, concept dispatch, generic semantics) depend on a clean
 generic compilation pipeline.
+
+### Task 29 — Bootstrap MIR (Tier A)
+
+Status: **complete** (#249)
+
+First iteration of the bootstrap compiler's MIR layer.  HIR lowers
+to a basic-block MIR mirroring the host compiler structure
+(`compiler/ir/mir/mir.h`).  Closes the Tier A self-hosting arc for
+the frontend-to-IR pipeline: `lex → parse → resolve → typecheck →
+HIR → MIR`.
+
+- ✓ `MirNode` arena-indexed flat node graph
+- ✓ `MirModule` / `MirFunction` / `MirLocal` / `MirBlock` structural
+  nodes
+- ✓ instruction set: `MirConstInt`/`Float`/`Bool`/`String`,
+  `MirLoad`/`Store`, `MirBinary`/`Unary`, `MirFieldAccess`,
+  `MirFnRef`/`Call`, `MirReturn`/`Br`/`CondBr`, `MirErrorExpr`
+- ✓ basic-block CFG: `MS.fn_blocks` accumulates per-function blocks,
+  `BlockR.sealed` tracks terminator emission, `block_seal` rewrites
+  each `MirBlock` with its instruction list offset and count
+- ✓ `ExprR { br, value }` threading for expression lowering — Dao
+  classes are value-copied across function boundaries, so explicit
+  state threading is required
+- ✓ if/else lowering: `cond_br → then/else → br → merge` with
+  early-return detection
+- ✓ while lowering: `br → header (cond_br) → body (br header) / exit`
+- ✓ program pipeline routing: `lower_to_mir` threads through
+  `build_program → program_run_resolve → program_run_typecheck →
+  program_run_hir`, walking both `HirFile` and `HirProgram` roots
+- ✓ unsupported statement kinds emit diagnostics via `ms_add_diag`
+  instead of silently dropping control flow
+- ✓ 8 Tier A regression tests: `minimal_program`,
+  `let_binary_return`, `function_call`, `multi_function`,
+  `param_locals`, `extern_function`, `if_stmt`, `while_stmt`
+
+HIR schema improvements landed alongside:
+
+- ✓ `HirLet.sym` stores resolver symbol index (not declaration
+  token); `lower_let_stmt` resolves and stores up-front
+- ✓ `HirFunction.sym` renamed from `name`, actually populated with
+  `fn_sym` from `hir_find_sym_by_decl` (was storing a token index)
+- ✓ `HirFunction` params list stores `(sym, type_idx)` pairs
+- ✓ `BEGIN_HIR_TESTS` marker added so MIR assembly can include the
+  HIR library without pulling in test helpers
+
+Deferred to Tier B (same deferrals as the bootstrap HIR, plus):
+
+- Generators (iter init/has_next/next/destroy/yield)
+- Monomorphization / generic template separation
+- Mode/resource region enter/exit
+- Enum construction / discriminant / payload
+- Lambda / closures
+- Try operator
+- For-over-iterable
+- Index expressions
+- Break/continue
+
+See `bootstrap/mir/impl.dao` and `bootstrap/README.md`.
 
 ### Task 14 — Numeric Type Expansion
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,20 +210,26 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
-Status: **Tier A pipeline + multi-file substrate + generic lowering
-boundary complete** — Tasks 19–28 complete.  Six bootstrap subsystems
-share a consolidated substrate (`bootstrap/shared/base.dao`): lexer
-(105 tests), parser (51 tests), graph (12 tests), resolver (34 tests),
-type checker (37 tests), and HIR lowering (19 tests).  The Tier A
-pipeline (lex → parse → resolve → typecheck → HIR) operates at both
-single-file and program level.  The `Program` value threads through
-all passes with canonical type identity, resolver-bound concept
-identity, module-scoped extend methods, cross-module qualified name
-typing, and program-level HIR aggregation (`HirProgram`/`HirModule`).
-On-disk multi-file test fixtures exercise the full pipeline
-end-to-end.  Task 28 (generic body lowering boundary) enforces clean
-separation of generic templates from monomorphic functions at the
-HIR → MIR boundary.  Next: Tier B bootstrap feature slices.
+Status: **Tier A frontend-to-IR pipeline complete** — Tasks 19–29
+complete.  Seven bootstrap subsystems share a consolidated substrate
+(`bootstrap/shared/base.dao`): lexer (105 tests), parser (51 tests),
+graph (12 tests), resolver (34 tests), type checker (43 tests),
+HIR lowering (22 tests), and MIR lowering (8 tests) — 275 bootstrap
+tests total.  The Tier A pipeline (lex → parse → resolve → typecheck
+→ HIR → MIR) operates at both single-file and program level.  The
+`Program` value threads through all passes with canonical type
+identity, resolver-bound concept identity, module-scoped extend
+methods, cross-module qualified name typing, and program-level HIR
+aggregation (`HirProgram`/`HirModule`).  On-disk multi-file test
+fixtures exercise the full pipeline end-to-end.  Task 28 (generic
+body lowering boundary) enforces clean separation of generic
+templates from monomorphic functions at the HIR → MIR boundary in
+the host compiler.  Task 29 (bootstrap MIR) lowers HIR to a
+basic-block MIR mirroring the host compiler structure with full
+control flow (if/else, while) and diagnostic-emitting unsupported-
+kind handling.  Next: bootstrap LLVM backend (Task 30) to close the
+self-hosting loop at the native object emission level, followed by
+Tier B bootstrap feature slices.
 
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself


### PR DESCRIPTION
## Summary

Roll the merged bootstrap MIR subsystem (#249) into the top-level planning docs. Docs-only sync — no source changes.

## Highlights

- **\`docs/ROADMAP.md\` Phase 7 block**:
  - Header: \"Tasks 19–28 complete\" → \"Tasks 19–29 complete\"
  - Subsystem inventory: six → seven (adds mir)
  - Test counts refreshed: typecheck 37→43, hir 19→22, +mir 8, total 275
  - Pipeline description extended to include MIR (\`lex → parse → resolve → typecheck → HIR → MIR\`)
  - Next slice sequenced: bootstrap LLVM backend (Task 30), then Tier B feature slices
- **\`docs/IMPLEMENTATION_PLAN.md\` \"What Comes After\"**: refresh completion paragraph with current test counts and add Task 29 to the Tier A pipeline summary
- **\`docs/IMPLEMENTATION_PLAN.md\`**: new Task 29 section between Task 28 and Task 14, covering scope, deliverables, HIR schema improvements landed alongside, and Tier B deferrals

## Test plan

- [x] Docs-only — no code changes, no build impact
- [x] Test counts cross-checked against \`bootstrap/*/impl.dao\` and post-#249 \`./bootstrap/*/*.gen\` runs (275/275)

🤖 Generated with [Claude Code](https://claude.com/claude-code)