### PR TITLE
docs(bootstrap): 📝 mark Task 30 complete, refresh Phase 7 status

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -312,14 +312,18 @@ and on-disk multi-file smoke test).  Shared substrate consolidated
 in `bootstrap/shared/base.dao`; assembly via `bootstrap/assemble.sh`.
 Task 29 (bootstrap MIR) is complete — HIR lowered to basic-block MIR
 with 8 tests.
+Task 30 (bootstrap LLVM backend) is complete — MIR lowered to
+deterministic textual LLVM IR with 12 tests.
 
-The Tier A bootstrap frontend-to-IR pipeline (lex → parse → resolve
-→ typecheck → HIR → MIR) is complete.  Tasks 25–27 (multi-file
-substrate) are complete — the `Program` value threads through
-resolve → typecheck → HIR → MIR with canonical type identity,
-cross-module qualified name typing, and program-level HIR aggregation.
-Task 28 (generic body lowering boundary) is complete — see below.
-Task 29 (bootstrap MIR Tier A) is complete — see below.
+The Tier A bootstrap frontend-to-IR-to-text pipeline (lex → parse →
+resolve → typecheck → HIR → MIR → LLVM text) is complete.
+Tasks 25–27 (multi-file substrate) are complete — the `Program`
+value threads through resolve → typecheck → HIR → MIR with
+canonical type identity, cross-module qualified name typing, and
+program-level HIR aggregation.  Task 28 (generic body lowering
+boundary) is complete — see below.  Task 29 (bootstrap MIR Tier A)
+is complete — see below.  Task 30 (bootstrap LLVM backend Tier A)
+is complete — see below.
 
 ### Task 25 — Bootstrap Multi-file Compilation + Imports (v1)
 
@@ -475,6 +479,43 @@ Deferred to Tier B (same deferrals as the bootstrap HIR, plus):
 - Break/continue
 
 See `bootstrap/mir/impl.dao` and `bootstrap/README.md`.
+
+### Task 30 — Bootstrap LLVM Backend (Tier A)
+
+Status: **complete** (#252)
+
+First iteration of the bootstrap LLVM backend.  Lowers Task 29
+bootstrap MIR to deterministic textual LLVM IR via a backend-private
+Dao-side mini-IR and text serializer.  Closes the Tier A
+frontend-to-IR-to-text pipeline: `lex → parse → resolve → typecheck
+→ HIR → MIR → LLVM text`.
+
+- ✓ Backend-private mini-IR: `LlModule` / `LlFunction` / `LlBlock` /
+  `LlInst` / `LlInstKind` / `LlType` / `LlGlobal` / `LlParam`
+- ✓ `MirBackendInput` bundles `MirResult` + symbols + types + tokens
+  + source, preserving Task 29's `MirResult` contract
+- ✓ Type lowering centralized in `ll_type_from_mir` for Tier A
+  primitives (i32, i64, f32, f64, bool→i1, void, string→ptr)
+- ✓ Alloca-everything SSA with mandatory param seeding (§5.4/§10.3)
+- ✓ Type-dispatched arithmetic (add/sub/mul/sdiv/srem, fadd/fsub/
+  fmul/fdiv), comparisons (icmp/fcmp), calls, terminators
+- ✓ String literals → private module-global `[N x i8]` + GEP with
+  correct escape decoding/re-encoding
+- ✓ Fail-closed: `MirFieldAccess`, `MirErrorExpr`, anonymous syms,
+  unsupported types, unterminated blocks all produce diagnostics
+- ✓ Deterministic output (byte-identical across runs)
+- ✓ MirModule root contract honored (`MirResult.root` → fn_list walk)
+- ✓ `write_llvm_text` wired to stdlib `write_file`
+- ✓ 12 Tier A regression tests
+
+Narrow upstream fix landed alongside:
+
+- ✓ `tc_register_fn_sig_core` writes `sym_types` for each param
+  during function-signature registration (fixes extern fn param
+  types being -1)
+
+See `docs/task_specs/TASK_30_BOOTSTRAP_LLVM_BACKEND.md` and
+`bootstrap/llvm/impl.dao`.
 
 ### Task 14 — Numeric Type Expansion
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -216,9 +216,10 @@ substrate (`bootstrap/shared/base.dao`): lexer (105 tests), parser
 (51 tests), graph (12 tests), resolver (34 tests), type checker
 (43 tests), HIR lowering (22 tests), MIR lowering (8 tests), and
 LLVM backend (12 tests) — 287 bootstrap tests total.  The Tier A
-pipeline (lex → parse → resolve → typecheck → HIR → MIR → LLVM
-text) operates at both single-file and program level.  The
-`Program` value threads through all passes with canonical type
+pipeline covers lex → parse → resolve → typecheck → HIR → MIR →
+LLVM text.  The `Program` value threads through resolve →
+typecheck → HIR at both single-file and program level with canonical
+type
 identity, resolver-bound concept identity, module-scoped extend
 methods, cross-module qualified name typing, and program-level HIR
 aggregation (`HirProgram`/`HirModule`).  On-disk multi-file test

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,13 +210,14 @@ Exit criteria:
 
 ## Phase 7 — Bootstrap Compiler
 
-Status: **Tier A frontend-to-IR pipeline complete** — Tasks 19–29
-complete.  Seven bootstrap subsystems share a consolidated substrate
-(`bootstrap/shared/base.dao`): lexer (105 tests), parser (51 tests),
-graph (12 tests), resolver (34 tests), type checker (43 tests),
-HIR lowering (22 tests), and MIR lowering (8 tests) — 275 bootstrap
-tests total.  The Tier A pipeline (lex → parse → resolve → typecheck
-→ HIR → MIR) operates at both single-file and program level.  The
+Status: **Tier A frontend-to-IR-to-text pipeline complete** — Tasks
+19–30 complete.  Eight bootstrap subsystems share a consolidated
+substrate (`bootstrap/shared/base.dao`): lexer (105 tests), parser
+(51 tests), graph (12 tests), resolver (34 tests), type checker
+(43 tests), HIR lowering (22 tests), MIR lowering (8 tests), and
+LLVM backend (12 tests) — 287 bootstrap tests total.  The Tier A
+pipeline (lex → parse → resolve → typecheck → HIR → MIR → LLVM
+text) operates at both single-file and program level.  The
 `Program` value threads through all passes with canonical type
 identity, resolver-bound concept identity, module-scoped extend
 methods, cross-module qualified name typing, and program-level HIR
@@ -227,9 +228,12 @@ templates from monomorphic functions at the HIR → MIR boundary in
 the host compiler.  Task 29 (bootstrap MIR) lowers HIR to a
 basic-block MIR mirroring the host compiler structure with full
 control flow (if/else, while) and diagnostic-emitting unsupported-
-kind handling.  Next: bootstrap LLVM backend (Task 30) to close the
-self-hosting loop at the native object emission level, followed by
-Tier B bootstrap feature slices.
+kind handling.  Task 30 (bootstrap LLVM backend) lowers MIR to
+deterministic textual LLVM IR via a backend-private mini-IR and
+text serializer, with alloca-everything SSA, param seeding, fail-
+closed type/terminator validation, and correct string-literal
+escape handling.  Next: `llc`/`clang` validation of emitted IR
+(Task 30.5), then Tier B bootstrap feature slices.
 
 Goals:
 - begin implementing non-trivial compiler subsystems in Dao itself


### PR DESCRIPTION
## Summary

Roll the merged bootstrap LLVM backend (#252) into the top-level planning docs. Docs-only sync — no source changes.

## Highlights

- **`docs/ROADMAP.md` Phase 7 block**: "Tasks 19–29 complete" → "Tasks 19–30 complete", eight subsystems (adds llvm), 287 bootstrap tests total, pipeline extended to `lex → parse → resolve → typecheck → HIR → MIR → LLVM text`, next slice: `llc`/`clang` validation (Task 30.5)
- **`docs/IMPLEMENTATION_PLAN.md`**: Task 30 completion note in the pipeline summary + new Task 30 section covering deliverables, mini-IR shape, fail-closed validation, string escape handling, upstream typecheck fix, and test count

## Test plan

- [x] Docs-only — no code changes, no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)